### PR TITLE
Move general config out of capture and refactor configuration code

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ pip install capsula
 At the root of your project, create a `capsula.toml` file. The following is an example of a `capsula.toml` file. Note that the root directory is the directory where `capsula.toml` is located.
 
 ```toml
-[capture]
 # The directory where the captured context is stored.
 vault-directory = 'vault'
 
@@ -35,6 +34,7 @@ vault-directory = 'vault'
 # It will be formatted by `datetime.now(UTC).astimezone().strftime(capsule_template)`.
 capsule-template = '%Y%m%d_%H%M%S'
 
+[capture]
 # Whether to include CPU information in the captured context.
 # Note that this may take a relatively long time to capture.
 include-cpu = true

--- a/capsula.toml
+++ b/capsula.toml
@@ -38,6 +38,9 @@ environment-variables = [
 capsula = '.'
 
 [monitor]
+# Whether to capture the context before running the command using the `capture` configuration.
+# capture = true
+
 # You can configure the monitoring behavior for each "item" (e.g., Python function, CLI command).
 [monitor.item.calculate-pi-cli.files]
 # List of files (relative to the root directory) to include after the execution of the command.

--- a/capsula.toml
+++ b/capsula.toml
@@ -1,4 +1,3 @@
-[capture]
 # The directory where the captured context is stored.
 vault-directory = 'vault'
 
@@ -6,6 +5,7 @@ vault-directory = 'vault'
 # It will be formatted by `datetime.now(UTC).astimezone().strftime(capsule_template)`.
 capsule-template = '%Y%m%d_%H%M%S'
 
+[capture]
 # Whether to include CPU information in the captured context.
 # Note that this may take a relatively long time to capture.
 include-cpu = true

--- a/capsula/__main__.py
+++ b/capsula/__main__.py
@@ -56,7 +56,7 @@ def main(
     logging.basicConfig(level=logging.getLevelNamesMapping()[log_level])
 
     click.echo(f"Root directory: {directory}")
-    capsula_config_path: Path = ctx.obj["directory"] / "capsula.toml"
+    capsula_config_path: Path = directory / "capsula.toml"
     with capsula_config_path.open("rb") as capsula_config_file:
         capsula_config = CapsulaConfig(**tomllib.load(capsula_config_file))
     capsula_config.root_directory = directory

--- a/capsula/__main__.py
+++ b/capsula/__main__.py
@@ -12,9 +12,9 @@ from typing import TYPE_CHECKING
 
 import click
 
-from capsula._monitor import MonitorConfig, MonitoringHandlerCli
-from capsula.capture import CaptureConfig
+from capsula._monitor import MonitoringHandlerCli
 from capsula.capture import capture as capture_core
+from capsula.config import CapsulaConfig
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -55,11 +55,11 @@ def main(
     ctx.ensure_object(dict)
     logging.basicConfig(level=logging.getLevelNamesMapping()[log_level])
 
-    ctx.obj["directory"] = directory
-    click.echo(f"directory: {ctx.obj['directory']}")
+    click.echo(f"Root directory: {directory}")
     capsula_config_path: Path = ctx.obj["directory"] / "capsula.toml"
     with capsula_config_path.open("rb") as capsula_config_file:
-        capsula_config = tomllib.load(capsula_config_file)
+        capsula_config = CapsulaConfig(**tomllib.load(capsula_config_file))
+    capsula_config.root_directory = directory
 
     ctx.obj["capsula_config"] = capsula_config
 
@@ -68,9 +68,7 @@ def main(
 @click.pass_context
 def capture(ctx: click.Context) -> None:
     """Capture the context."""
-    capsula_capture_config = CaptureConfig(**ctx.obj["capsula_config"]["capture"])
-    capsula_capture_config.root_directory = ctx.obj["directory"]
-    capture_core(config=capsula_capture_config)
+    capture_core(config=ctx.obj["capsula_config"])
 
 
 @main.command()
@@ -86,11 +84,9 @@ def capture(ctx: click.Context) -> None:
 @click.pass_context
 def monitor(ctx: click.Context, items: Iterable[str], args: tuple[str]) -> None:
     """Monitor execution."""
-    capture_config = CaptureConfig(**ctx.obj["capsula_config"]["capture"])
-    capture_config.root_directory = ctx.obj["directory"]
-    capture_core(config=capture_config)
+    config: CapsulaConfig = ctx.obj["capsula_config"]
+    capture_core(config=config)
 
-    monitor_config = MonitorConfig(**ctx.obj["capsula_config"]["monitor"])
-    handler = MonitoringHandlerCli(capture_config=capture_config, monitor_config=monitor_config)
+    handler = MonitoringHandlerCli(config=config)
     pre_run_info = handler.setup(args)
     handler.run_and_teardown(pre_run_info=pre_run_info, items=items)

--- a/capsula/config.py
+++ b/capsula/config.py
@@ -1,0 +1,90 @@
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from capsula.file import CaptureFileConfig
+
+if sys.version_info < (3, 11):
+    from datetime import timezone as _timezone
+
+    UTC = _timezone.utc
+
+else:
+    from datetime import UTC
+
+
+class GitConfig(BaseModel):
+    repositories: dict[str, Path] = Field(default_factory=dict)
+
+
+def to_hyphen_case(string: str) -> str:
+    return string.replace("_", "-")
+
+
+class CaptureConfig(BaseModel):
+    """Configuration for the capture command."""
+
+    model_config = ConfigDict(
+        alias_generator=to_hyphen_case,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
+    # Whether to include the Capsula version in the output file.
+    # include_capsula_version: bool = True
+
+    include_cpu: bool = True
+
+    pre_capture_commands: list[str] = Field(default_factory=list)
+
+    environment_variables: list[str] = Field(default_factory=list)
+
+    files: dict[Path, CaptureFileConfig] = Field(default_factory=dict)
+
+    git: GitConfig = Field(default_factory=GitConfig)
+
+
+class MonitorItemConfig(BaseModel):
+    files: dict[Path, CaptureFileConfig] = Field(default_factory=dict)
+
+
+class MonitorConfig(BaseModel):
+    items: dict[str, MonitorItemConfig] = Field(default_factory=dict, alias="item")
+
+
+class CapsulaConfig(BaseModel):
+    vault_directory: Path
+    capsule_template: str
+
+    capture: CaptureConfig
+    monitor: MonitorConfig
+
+    _capsule_directory: Path | None = None
+    _root_directory: Path | None = None
+
+    @property
+    def capsule(self) -> Path:
+        if self._capsule_directory is None:
+            self._capsule_directory = (
+                self.root_directory
+                / self.vault_directory
+                / datetime.now(UTC)
+                .astimezone()
+                .strftime(
+                    self.capsule_template,
+                )
+            )
+        return self._capsule_directory
+
+    @property
+    def root_directory(self) -> Path:
+        if self._root_directory is None:
+            msg = "Project root is not set"
+            raise ValueError(msg)
+        return self._root_directory
+
+    @root_directory.setter
+    def root_directory(self, value: Path) -> None:
+        self._root_directory = value

--- a/capsula/config.py
+++ b/capsula/config.py
@@ -15,19 +15,19 @@ else:
     from datetime import UTC
 
 
+def _to_hyphen_case(string: str) -> str:
+    return string.replace("_", "-")
+
+
 class GitConfig(BaseModel):
     repositories: dict[str, Path] = Field(default_factory=dict)
-
-
-def to_hyphen_case(string: str) -> str:
-    return string.replace("_", "-")
 
 
 class CaptureConfig(BaseModel):
     """Configuration for the capture command."""
 
     model_config = ConfigDict(
-        alias_generator=to_hyphen_case,
+        alias_generator=_to_hyphen_case,
         populate_by_name=True,
         extra="forbid",
     )
@@ -55,6 +55,12 @@ class MonitorConfig(BaseModel):
 
 
 class CapsulaConfig(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=_to_hyphen_case,
+        populate_by_name=True,
+        extra="forbid",
+    )
+
     vault_directory: Path
     capsule_template: str
 

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -1,18 +1,21 @@
 import tempfile
 from pathlib import Path
 
-from capsula.capture import CaptureConfig, capture
+from capsula.capture import capture
+from capsula.config import CapsulaConfig, CaptureConfig, MonitorConfig
 
 
 def test_capture() -> None:
     with tempfile.TemporaryDirectory() as root_directory:
-        capture_config = CaptureConfig(
+        capsula_config = CapsulaConfig(
             vault_directory=Path(root_directory) / "vault",
             capsule_template=r"%Y%m%d_%H%M%S",
+            capture=CaptureConfig(),
+            monitor=MonitorConfig(),
         )
-        capture_config.root_directory = Path(root_directory)
+        capsula_config.root_directory = Path(root_directory)
 
-        ctx = capture(config=capture_config)
+        ctx = capture(config=capsula_config)
 
         assert ctx.platform is not None
         assert ctx.cpu is not None


### PR DESCRIPTION
- Rearrange [capture] block in README.md and capsula.toml
- Refactor code to use CapsulaConfig for CaptureConfig and MonitorConfig
- fix click context key error
- Use _to_hyphen_case as alias generator of capsula config model config
