### PR TITLE
Support Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.11", "3.10"] # , "3.9", "3.8", "3.7", "3.6"]
+        python-version: ["3.11", "3.10", "3.9"] #, "3.8", "3.7", "3.6"]
 
     steps:
     - uses: actions/checkout@v3

--- a/capsula/__main__.py
+++ b/capsula/__main__.py
@@ -1,12 +1,12 @@
 import logging
 import sys
+from collections.abc import Iterable
+from pathlib import Path
 
 if sys.version_info < (3, 11):
     import tomli as tomllib
 else:
     import tomllib
-from collections.abc import Iterable
-from pathlib import Path
 
 import click
 

--- a/capsula/__main__.py
+++ b/capsula/__main__.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import sys
 
@@ -7,17 +5,14 @@ if sys.version_info < (3, 11):
     import tomli as tomllib
 else:
     import tomllib
+from collections.abc import Iterable
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import click
 
 from capsula._monitor import MonitoringHandlerCli
 from capsula.capture import capture as capture_core
 from capsula.config import CapsulaConfig
-
-if TYPE_CHECKING:
-    from collections.abc import Iterable
 
 
 @click.group()

--- a/capsula/_monitor.py
+++ b/capsula/_monitor.py
@@ -3,34 +3,32 @@ import logging
 import subprocess
 import sys
 import time
-from typing import Optional
+import traceback
+import warnings
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Iterable, Sequence
+from functools import wraps
+from pathlib import Path
+from shutil import copyfile, move
+from typing import Any, Generic, Literal, Optional, TypeVar
 
 if sys.version_info < (3, 11):
     import tomli as tomllib
 else:
     import tomllib
-import traceback
-import warnings
-from abc import ABC, abstractmethod
 
 if sys.version_info < (3, 11):
+    from datetime import datetime, timedelta
     from datetime import timezone as _timezone
 
     UTC = _timezone.utc
 else:
-    from datetime import UTC
-from datetime import datetime, timedelta
-from functools import wraps
-from pathlib import Path
-from shutil import copyfile, move
-from typing import Any, Generic, Literal, TypeVar
+    from datetime import UTC, datetime, timedelta
 
 if sys.version_info < (3, 10):
     from typing_extensions import ParamSpec
 else:
     from typing import ParamSpec
-
-from collections.abc import Callable, Iterable, Sequence
 
 from pydantic import BaseModel, Field
 

--- a/capsula/_monitor.py
+++ b/capsula/_monitor.py
@@ -1,10 +1,9 @@
-from __future__ import annotations
-
 import inspect
 import logging
 import subprocess
 import sys
 import time
+from typing import Optional
 
 if sys.version_info < (3, 11):
     import tomli as tomllib
@@ -24,22 +23,20 @@ from datetime import datetime, timedelta
 from functools import wraps
 from pathlib import Path
 from shutil import copyfile, move
-from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
+from typing import Any, Generic, Literal, TypeVar
 
 if sys.version_info < (3, 10):
     from typing_extensions import ParamSpec
 else:
     from typing import ParamSpec
 
+from collections.abc import Callable, Iterable, Sequence
+
 from pydantic import BaseModel, Field
 
 from capsula.capture import capture as capture_core
 from capsula.config import CapsulaConfig
 from capsula.hash import compute_hash
-
-if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Sequence
-
 
 logger = logging.getLogger(__name__)
 
@@ -55,23 +52,23 @@ class PreRunInfoCli(PreRunInfoBase):
 
 
 class PreRunInfoFunc(PreRunInfoBase):
-    source_file: Path | None
-    source_line: int | None
+    source_file: Optional[Path]
+    source_line: Optional[int]
     function_name: str
     args: tuple[Any, ...]
     kwargs: dict[str, Any]
 
 
 class OutputFileInfo(BaseModel):
-    hash_algorithm: Literal["md5", "sha1", "sha256", "sha3"] | None
-    file_hash: str | None = Field(..., alias="hash")
+    hash_algorithm: Optional[Literal["md5", "sha1", "sha256", "sha3"]]
+    file_hash: Optional[str] = Field(..., alias="hash")
 
 
 class PostRunInfoBase(BaseModel):
     root_directory: Path
     timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC).astimezone())
     run_time: timedelta
-    files: dict[Path, OutputFileInfo | None] = Field(default_factory=dict)
+    files: dict[Path, Optional[OutputFileInfo]] = Field(default_factory=dict)
 
 
 class PostRunInfoCli(PostRunInfoBase):
@@ -86,7 +83,7 @@ class ExceptionInfo(BaseModel):
     error_details: str
 
     @classmethod
-    def from_exception(cls, exc: BaseException) -> ExceptionInfo:
+    def from_exception(cls, exc: BaseException) -> "ExceptionInfo":
         return cls(
             error_type=type(exc).__name__,
             error_message=str(exc),
@@ -95,8 +92,8 @@ class ExceptionInfo(BaseModel):
 
 
 class PostRunInfoFunc(PostRunInfoBase):
-    return_value: Any | None = None
-    exception_info: ExceptionInfo | None = None
+    return_value: Optional[Any] = None
+    exception_info: Optional[ExceptionInfo] = None
 
 
 _TPreRunInfo = TypeVar("_TPreRunInfo", bound=PreRunInfoBase)
@@ -128,7 +125,7 @@ class MonitoringHandlerBase(ABC, Generic[_TPreRunInfo, _TPostRunInfo]):
         *,
         items: Iterable[str],
         **kwargs: Any,
-    ) -> tuple[_TPostRunInfo, BaseException | None]:
+    ) -> tuple[_TPostRunInfo, Optional[BaseException]]:
         ...
 
     def run_and_teardown(
@@ -137,7 +134,7 @@ class MonitoringHandlerBase(ABC, Generic[_TPreRunInfo, _TPostRunInfo]):
         *,
         items: Iterable[str],
         **kwargs: Any,
-    ) -> tuple[_TPostRunInfo, BaseException | None]:
+    ) -> tuple[_TPostRunInfo, Optional[BaseException]]:
         post_run_info, exc = self.run(pre_run_info, items=items, **kwargs)
         return self.teardown(post_run_info=post_run_info, items=items), exc
 
@@ -210,7 +207,7 @@ class MonitoringHandlerFunc(MonitoringHandlerBase[PreRunInfoFunc, PostRunInfoFun
             _file_path_str = inspect.getsourcefile(func)
         except TypeError:
             _file_path_str = None
-        file_path: Path | None = Path(_file_path_str) if _file_path_str is not None else None
+        file_path = Path(_file_path_str) if _file_path_str is not None else None
 
         try:
             _, first_line_no = inspect.getsourcelines(func)
@@ -235,7 +232,7 @@ class MonitoringHandlerFunc(MonitoringHandlerBase[PreRunInfoFunc, PostRunInfoFun
         items: Iterable[str],  # noqa: ARG002
         func: Callable[..., Any],
         **_: Any,  # to be compatible with the base class
-    ) -> tuple[PostRunInfoFunc, BaseException | None]:
+    ) -> tuple[PostRunInfoFunc, Optional[BaseException]]:
         start_time = time.perf_counter()
         try:
             ret = func(*pre_run_info.args, **pre_run_info.kwargs)

--- a/capsula/capture.py
+++ b/capsula/capture.py
@@ -1,17 +1,12 @@
-from __future__ import annotations
-
 __all__ = [
     "capture",
 ]
 
 import logging
 import subprocess
-from typing import TYPE_CHECKING
 
+from capsula.config import CapsulaConfig
 from capsula.context import Context
-
-if TYPE_CHECKING:
-    from capsula.config import CapsulaConfig
 
 logger = logging.getLogger(__name__)
 

--- a/capsula/config.py
+++ b/capsula/config.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import sys
 from datetime import datetime
-from pathlib import Path
+from pathlib import Path  # noqa: TCH003
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from capsula.file import CaptureFileConfig
+from capsula.file import CaptureFileConfig  # noqa: TCH001
 from capsula.globalvars import set_capsule_dir, set_capsule_name
 
 if sys.version_info < (3, 11):

--- a/capsula/config.py
+++ b/capsula/config.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import sys
 from datetime import datetime
-from pathlib import Path  # noqa: TCH003
+from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from capsula.file import CaptureFileConfig  # noqa: TCH001
+from capsula.file import CaptureFileConfig
 from capsula.globalvars import set_capsule_dir, set_capsule_name
 
 if sys.version_info < (3, 11):

--- a/capsula/config.py
+++ b/capsula/config.py
@@ -1,8 +1,7 @@
-from __future__ import annotations
-
 import sys
 from datetime import datetime
 from pathlib import Path
+from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -71,8 +70,8 @@ class CapsulaConfig(BaseModel):
     capture: CaptureConfig
     monitor: MonitorConfig
 
-    _capsule_directory: Path | None = None
-    _root_directory: Path | None = None
+    _capsule_directory: Optional[Path] = None
+    _root_directory: Optional[Path] = None
 
     @property
     def capsule(self) -> Path:

--- a/capsula/context.py
+++ b/capsula/context.py
@@ -1,12 +1,10 @@
-from __future__ import annotations
-
 import os
 import platform as pf
 import sys
 from abc import ABC, abstractmethod
 from pathlib import Path
 from shutil import copyfile, move
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal, Optional, Union
 
 if sys.version_info < (3, 11):
     from typing_extensions import Self
@@ -17,10 +15,8 @@ from cpuinfo import get_cpu_info
 from git.repo import Repo
 from pydantic import BaseModel, Field
 
+from capsula.config import CapsulaConfig
 from capsula.hash import compute_hash
-
-if TYPE_CHECKING:
-    from capsula.config import CapsulaConfig
 
 
 class ContextItem(BaseModel, ABC):
@@ -28,7 +24,7 @@ class ContextItem(BaseModel, ABC):
 
     @classmethod
     @abstractmethod
-    def capture(cls, config: CapsulaConfig) -> Self | dict[Any, Self]:
+    def capture(cls, config: CapsulaConfig) -> Union[Self, dict[Any, Self]]:
         """Capture the context item."""
         raise NotImplementedError
 
@@ -124,8 +120,8 @@ class GitInfo(ContextItem):
 
 
 class FileContext(ContextItem):
-    hash_algorithm: Literal["md5", "sha1", "sha256", "sha3"] | None
-    file_hash: str | None = Field(..., alias="hash")
+    hash_algorithm: Optional[Literal["md5", "sha1", "sha256", "sha3"]]
+    file_hash: Optional[str] = Field(..., alias="hash")
 
     @classmethod
     def capture(cls, config: CapsulaConfig) -> dict[Path, Self]:
@@ -162,7 +158,7 @@ class Context(ContextItem):
     # There are many duplicates between the platform and cpu info.
     # We could remove the duplicates, but it's not worth the effort.
     # We use the default factory to avoid the overhead of getting the CPU info, which is slow.
-    cpu: dict | None
+    cpu: Optional[dict]
 
     @classmethod
     def capture(cls, config: CapsulaConfig) -> Self:

--- a/capsula/file.py
+++ b/capsula/file.py
@@ -1,17 +1,18 @@
-from __future__ import annotations
-
-from typing import Literal
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field, model_validator
 
 
 class CaptureFileConfig(BaseModel):
-    hash_algorithm: Literal["md5", "sha1", "sha256", "sha3"] | None = Field(default=None, alias="hash")
+    hash_algorithm: Optional[Literal["md5", "sha1", "sha256", "sha3"]] = Field(
+        default=None,
+        alias="hash",
+    )
     copy_: bool = Field(default=False, alias="copy")
     move: bool = False
 
     @model_validator(mode="after")  # type: ignore
-    def exclusive_copy_move(cls, model: CaptureFileConfig) -> CaptureFileConfig:
+    def exclusive_copy_move(cls, model: "CaptureFileConfig") -> "CaptureFileConfig":
         if model.copy_ and model.move:
             msg = "Only one of copy or move can be true"
             raise ValueError(msg)

--- a/capsula/globalvars.py
+++ b/capsula/globalvars.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from pathlib import Path
 

--- a/capsula/globalvars.py
+++ b/capsula/globalvars.py
@@ -1,10 +1,9 @@
-from __future__ import annotations
-
 import os
 from pathlib import Path
+from typing import Union
 
 
-def set_capsule_dir(path: Path | str) -> None:
+def set_capsule_dir(path: Union[Path, str]) -> None:
     """Set the capsule directory used by the CLI."""
     os.environ["CAPSULA_CAPSULE_DIR"] = str(path)
 

--- a/examples/calculate_pi_cli.py
+++ b/examples/calculate_pi_cli.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import sys

--- a/examples/calculate_pi_cli.py
+++ b/examples/calculate_pi_cli.py
@@ -1,9 +1,8 @@
-from __future__ import annotations
-
 import logging
 import os
 import sys
 from pathlib import Path
+from typing import Optional
 
 import click
 import matplotlib.pyplot as plt
@@ -27,7 +26,7 @@ logger = logging.getLogger(__name__)
     help="The seed to use for the random number generator passed to numpy.random.default_rng.",
     default=None,
 )
-def main(n: int, seed: int | None = None) -> None:
+def main(n: int, seed: Optional[int] = None) -> None:
     """Calculate pi using the Monte Carlo method."""
     if n < 1:
         logger.error("n must be greater than or equal to 1.")

--- a/examples/calculate_pi_dec.py
+++ b/examples/calculate_pi_dec.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from pathlib import Path
 

--- a/examples/calculate_pi_dec.py
+++ b/examples/calculate_pi_dec.py
@@ -1,7 +1,6 @@
-from __future__ import annotations
-
 import logging
 from pathlib import Path
+from typing import Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -16,7 +15,7 @@ logger = logging.getLogger(__name__)
     include_return_value=True,
     items=("calculate-pi-dec",),
 )
-def main(n: int, seed: int | None = None) -> float:
+def main(n: int, seed: Optional[int] = None) -> float:
     """Calculate pi using the Monte Carlo method."""
     if n < 1:
         msg = "n must be greater than or equal to 1."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 packages = [{include = "capsula"}]
 
 [tool.poetry.dependencies]
-python = ">=3.10"
+python = ">=3.9"
 click = ">=8.1.3"
 pydantic = ">=2.0.2"
 py-cpuinfo = ">=9.0.0"
@@ -62,7 +62,7 @@ ignore_missing_imports = true
 [tool.black]
 line-length = 120
 include = '\.pyi?$'
-target-version = ['py310', 'py311']
+target-version = ['py39', 'py310', 'py311']
 
 exclude = '''
 /(
@@ -79,7 +79,7 @@ exclude = '''
 '''
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py39"
 # Same as Black.
 line-length = 120
 select = ["ALL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,9 @@ ignore = [
 # Allow Pydantic's `@model_validator` decorator to trigger class method treatment.
 classmethod-decorators = ["classmethod", "pydantic.model_validator"]
 
+[tool.ruff.flake8-type-checking]
+runtime-evaluated-base-classes = ["pydantic.BaseModel"]
+
 [tool.ruff.per-file-ignores]
 "capsula/*" = [
     "PT017"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,10 @@ classmethod-decorators = ["classmethod", "pydantic.model_validator"]
 [tool.ruff.flake8-type-checking]
 runtime-evaluated-base-classes = ["pydantic.BaseModel"]
 
+[tool.ruff.pyupgrade]
+# Keep runtime typing for Pydantic.
+keep-runtime-typing = true
+
 [tool.ruff.per-file-ignores]
 "capsula/*" = [
     "PT017"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-env_list = py311, py310
+env_list = py311, py310, py39
 minversion = 4.6.4
 
 [testenv]


### PR DESCRIPTION
- Add flake8-type-checking to pyproject.toml
- Update Python version in dependencies and tools
- Add Python 3.9 to tox environment list
- Add future annotations import to multiple files
- Remove unnecessary noqa comments in config.py
- Add runtime typing setting in pyupgrade config
- Update typing and remove unnecessary imports
- Replace union type hint with Optional in calculate_pi files
