### PR TITLE
Python 3.8 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.11", "3.10", "3.9"] #, "3.8", "3.7", "3.6"]
+        python-version: ["3.11", "3.10", "3.9", "3.8"] #, "3.7", "3.6"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.11", "3.10", "3.9", "3.8"] #, "3.7", "3.6"]
+        python-version: ["3.11", "3.10", "3.9", "3.8"]
 
     steps:
     - uses: actions/checkout@v3

--- a/capsula/__main__.py
+++ b/capsula/__main__.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import logging
 import sys
-from collections.abc import Iterable
 from pathlib import Path
 
 if sys.version_info < (3, 11):
@@ -8,11 +9,16 @@ if sys.version_info < (3, 11):
 else:
     import tomllib
 
+from typing import TYPE_CHECKING
+
 import click
 
 from capsula._monitor import MonitoringHandlerCli
 from capsula.capture import capture as capture_core
 from capsula.config import CapsulaConfig
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 @click.group()

--- a/capsula/_monitor.py
+++ b/capsula/_monitor.py
@@ -6,11 +6,10 @@ import time
 import traceback
 import warnings
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable, Sequence
 from functools import wraps
 from pathlib import Path
 from shutil import copyfile, move
-from typing import Any, Dict, Generic, List, Literal, Mapping, Optional, Tuple, TypeVar
+from typing import Any, Callable, Dict, Generic, Iterable, List, Literal, Mapping, Optional, Sequence, Tuple, TypeVar
 
 if sys.version_info < (3, 11):
     import tomli as tomllib

--- a/capsula/config.py
+++ b/capsula/config.py
@@ -1,7 +1,7 @@
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -22,7 +22,7 @@ def _to_hyphen_case(string: str) -> str:
 
 
 class GitConfig(BaseModel):
-    repositories: dict[str, Path] = Field(default_factory=dict)
+    repositories: Dict[str, Path] = Field(default_factory=dict)
 
 
 class CaptureConfig(BaseModel):
@@ -39,22 +39,22 @@ class CaptureConfig(BaseModel):
 
     include_cpu: bool = True
 
-    pre_capture_commands: list[str] = Field(default_factory=list)
+    pre_capture_commands: List[str] = Field(default_factory=list)
 
-    environment_variables: list[str] = Field(default_factory=list)
+    environment_variables: List[str] = Field(default_factory=list)
 
-    files: dict[Path, CaptureFileConfig] = Field(default_factory=dict)
+    files: Dict[Path, CaptureFileConfig] = Field(default_factory=dict)
 
     git: GitConfig = Field(default_factory=GitConfig)
 
 
 class MonitorItemConfig(BaseModel):
-    files: dict[Path, CaptureFileConfig] = Field(default_factory=dict)
+    files: Dict[Path, CaptureFileConfig] = Field(default_factory=dict)
 
 
 class MonitorConfig(BaseModel):
     capture: bool = True
-    items: dict[str, MonitorItemConfig] = Field(default_factory=dict, alias="item")
+    items: Dict[str, MonitorItemConfig] = Field(default_factory=dict, alias="item")
 
 
 class CapsulaConfig(BaseModel):

--- a/capsula/context.py
+++ b/capsula/context.py
@@ -4,7 +4,7 @@ import sys
 from abc import ABC, abstractmethod
 from pathlib import Path
 from shutil import copyfile, move
-from typing import Any, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 if sys.version_info < (3, 11):
     from typing_extensions import Self
@@ -24,7 +24,7 @@ class ContextItem(BaseModel, ABC):
 
     @classmethod
     @abstractmethod
-    def capture(cls, config: CapsulaConfig) -> Union[Self, dict[Any, Self]]:
+    def capture(cls, config: CapsulaConfig) -> Union[Self, Dict[Any, Self]]:
         """Capture the context item."""
         raise NotImplementedError
 
@@ -98,10 +98,10 @@ class GitInfo(ContextItem):
     path: Path
     sha: str
     branch: str
-    remotes: list[GitRemote]
+    remotes: List[GitRemote]
 
     @classmethod
-    def capture(cls, config: CapsulaConfig) -> dict[str, Self]:
+    def capture(cls, config: CapsulaConfig) -> Dict[str, Self]:
         git_infos = {}
         for name, path in config.capture.git.repositories.items():
             repo = Repo(config.root_directory / path)
@@ -124,7 +124,7 @@ class FileContext(ContextItem):
     file_hash: Optional[str] = Field(..., alias="hash")
 
     @classmethod
-    def capture(cls, config: CapsulaConfig) -> dict[Path, Self]:
+    def capture(cls, config: CapsulaConfig) -> Dict[Path, Self]:
         files = {}
         for relative_path, file_config in config.capture.files.items():
             path = config.root_directory / relative_path
@@ -149,16 +149,16 @@ class Context(ContextItem):
 
     platform: Platform
 
-    environment_variables: dict[str, str]
+    environment_variables: Dict[str, str]
 
-    git: dict[str, GitInfo]
+    git: Dict[str, GitInfo]
 
-    files: dict[Path, FileContext]
+    files: Dict[Path, FileContext]
 
     # There are many duplicates between the platform and cpu info.
     # We could remove the duplicates, but it's not worth the effort.
     # We use the default factory to avoid the overhead of getting the CPU info, which is slow.
-    cpu: Optional[dict]
+    cpu: Optional[Dict]
 
     @classmethod
     def capture(cls, config: CapsulaConfig) -> Self:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ pytest = ">=7.4.0"
 optional = true
 
 [tool.poetry.group.examples.dependencies]
-numpy = ">=1.25.0"
+numpy = ">=1.24.0"
 matplotlib = ">=3.7.1"
 
 [tool.poetry.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 packages = [{include = "capsula"}]
 
 [tool.poetry.dependencies]
-python = ">=3.9"
+python = ">=3.8"
 click = ">=8.1.3"
 pydantic = ">=2.0.2"
 py-cpuinfo = ">=9.0.0"
@@ -62,7 +62,7 @@ ignore_missing_imports = true
 [tool.black]
 line-length = 120
 include = '\.pyi?$'
-target-version = ['py39', 'py310', 'py311']
+target-version = ['py38', 'py39', 'py310', 'py311']
 
 exclude = '''
 /(
@@ -79,7 +79,7 @@ exclude = '''
 '''
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py38"
 # Same as Black.
 line-length = 120
 select = ["ALL"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-env_list = py311, py310, py39
+env_list = py311, py310, py39, py38
 minversion = 4.6.4
 
 [testenv]


### PR DESCRIPTION
- Add Python 3.8 to test workflow matrix
- Update Python version dependency to >=3.8
- Update type hints for Python 3.8
- Add Python 3.8 to tox testing environments
- Change import source from abc to typing to support Python 3.8
- Remove comment
