### PR TITLE
Remove eval-type-backport for Conda compatibility

### DIFF
--- a/capsula/_run.py
+++ b/capsula/_run.py
@@ -39,7 +39,7 @@ class CommandInfo(BaseModel):
 
 
 class CapsuleParams(BaseModel):
-    exec_info: FuncInfo | CommandInfo | None
+    exec_info: Union[FuncInfo, CommandInfo, None]
     run_dir: Path
     phase: Literal["pre", "in", "post"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ tomli = { version = ">=2.0.1", python = "<3.11" }
 typing-extensions = { version = ">=4.7.1", python = "<3.11" }
 orjson = ">=3.9.10"
 typer = ">=0.9.0"
-eval-type-backport = { version = ">=0.1.3", python = "<3.10" }
 
 [tool.poetry.group.dev.dependencies]
 ruff = "0.2.2"


### PR DESCRIPTION
- **Remove eval-type-backport dependency from pyproject.toml**
- **Update CapsuleParams to use Union type hint**
