### PR TITLE
Make FunctionContext optional

### DIFF
--- a/capsula/__init__.py
+++ b/capsula/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     "Encapsulator",
     "EnvVarContext",
     "FileContext",
+    "FunctionContext",
     "GitRepositoryContext",
     "JsonDumpReporter",
     "PlatformContext",
@@ -36,6 +37,7 @@ from ._context import (
     CwdContext,
     EnvVarContext,
     FileContext,
+    FunctionContext,
     GitRepositoryContext,
     PlatformContext,
 )

--- a/capsula/_context/__init__.py
+++ b/capsula/_context/__init__.py
@@ -5,7 +5,7 @@ __all__ = [
     "CwdContext",
     "EnvVarContext",
     "FileContext",
-    "FunctionCallContext",
+    "FunctionContext",
     "GitRepositoryContext",
     "PlatformContext",
 ]
@@ -15,6 +15,6 @@ from ._cpu import CpuContext
 from ._cwd import CwdContext
 from ._envvar import EnvVarContext
 from ._file import FileContext
-from ._function import FunctionCallContext
+from ._function import FunctionContext
 from ._git import GitRepositoryContext
 from ._platform import PlatformContext

--- a/capsula/_context/_function.py
+++ b/capsula/_context/_function.py
@@ -2,9 +2,14 @@ from __future__ import annotations
 
 import inspect
 from pathlib import Path
-from typing import Any, Callable, Mapping, Sequence, TypedDict
+from typing import TYPE_CHECKING, Any, Callable, Mapping, Sequence, TypedDict
+
+from capsula._run import FuncInfo
 
 from ._base import ContextBase
+
+if TYPE_CHECKING:
+    from capsula._run import CapsuleParams
 
 
 class _FunctionCallContextData(TypedDict):
@@ -15,6 +20,19 @@ class _FunctionCallContextData(TypedDict):
 
 
 class FunctionCallContext(ContextBase):
+    @classmethod
+    def builder(
+        cls,
+    ) -> Callable[[CapsuleParams], FunctionCallContext]:
+        def build(params: CapsuleParams) -> FunctionCallContext:
+            if not isinstance(params.exec_info, FuncInfo):
+                msg = "FunctionCallContext can only be built from a FuncInfo."
+                raise TypeError(msg)
+
+            return cls(params.exec_info.func, params.exec_info.args, params.exec_info.kwargs)
+
+        return build
+
     def __init__(self, function: Callable[..., Any], args: Sequence[Any], kwargs: Mapping[str, Any]) -> None:
         self._function = function
         self._args = args

--- a/capsula/_context/_function.py
+++ b/capsula/_context/_function.py
@@ -4,6 +4,8 @@ import inspect
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Mapping, Sequence, TypedDict
 
+from typing_extensions import Annotated, Doc
+
 from capsula._run import FuncInfo
 
 from ._base import ContextBase
@@ -21,11 +23,20 @@ class _FunctionContextData(TypedDict):
 
 
 class FunctionContext(ContextBase):
+    """Context to capture a function call."""
+
     @classmethod
     def builder(
         cls,
         *,
-        ignore: Container[str] = (),
+        ignore: Annotated[
+            Container[str],
+            Doc(
+                "Parameters to ignore when capturing the arguments. "
+                "This is useful when you pass values that you don't want to be in the output, "
+                "such as a large data structure or a function that is not serializable, or a secret.",
+            ),
+        ] = (),
     ) -> Callable[[CapsuleParams], FunctionContext]:
         def build(params: CapsuleParams) -> FunctionContext:
             if not isinstance(params.exec_info, FuncInfo):

--- a/capsula/_run.py
+++ b/capsula/_run.py
@@ -35,6 +35,7 @@ class FuncInfo:
     func: Callable[..., Any]
     args: tuple[Any, ...]
     kwargs: dict[str, Any]
+    pass_pre_run_capsule: bool
 
 
 @dataclass
@@ -250,7 +251,7 @@ class Run(Generic[_P, _T]):
         self._get_run_stack().get(block=False)
 
     def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _T:  # noqa: C901
-        func_info = FuncInfo(func=self._func, args=args, kwargs=kwargs)
+        func_info = FuncInfo(func=self._func, args=args, kwargs=kwargs, pass_pre_run_capsule=self._pass_pre_run_capsule)
         if self._run_dir_generator is None:
             msg = "run_dir_generator must be set before calling the function."
             raise ValueError(msg)

--- a/capsula/_run.py
+++ b/capsula/_run.py
@@ -13,7 +13,7 @@ from string import ascii_letters, digits
 from typing import TYPE_CHECKING, Any, Callable, Generic, Literal, TypeVar, Union, overload
 
 from ._backport import Concatenate, ParamSpec, Self, TypeAlias
-from ._context import ContextBase, FunctionContext
+from ._context import ContextBase
 from ._encapsulator import Encapsulator
 from ._reporter import ReporterBase
 from ._utils import search_for_project_root
@@ -277,8 +277,6 @@ class Run(Generic[_P, _T]):
         for watcher_generator in self._in_run_watcher_generators:
             watcher = watcher_generator(params)
             in_run_enc.add_watcher(watcher)
-
-        in_run_enc.add_context(FunctionContext(self._func, args, kwargs))
 
         try:
             with self, in_run_enc, in_run_enc.watch():

--- a/capsula/_run.py
+++ b/capsula/_run.py
@@ -13,7 +13,7 @@ from string import ascii_letters, digits
 from typing import TYPE_CHECKING, Any, Callable, Generic, Literal, TypeVar, Union, overload
 
 from ._backport import Concatenate, ParamSpec, Self, TypeAlias
-from ._context import ContextBase, FunctionCallContext
+from ._context import ContextBase, FunctionContext
 from ._encapsulator import Encapsulator
 from ._reporter import ReporterBase
 from ._utils import search_for_project_root
@@ -278,7 +278,7 @@ class Run(Generic[_P, _T]):
             watcher = watcher_generator(params)
             in_run_enc.add_watcher(watcher)
 
-        in_run_enc.add_context(FunctionCallContext(self._func, args, kwargs))
+        in_run_enc.add_context(FunctionContext(self._func, args, kwargs))
 
         try:
             with self, in_run_enc, in_run_enc.watch():

--- a/docs/contexts/function.md
+++ b/docs/contexts/function.md
@@ -1,0 +1,48 @@
+# `FunctionContext`
+
+The `FunctionContext` captures the arguments of a function.
+It can be created using the `capsula.FunctionContext.builder` method or the `capsula.FunctionContext.__init__` method.
+
+::: capsula.FunctionContext.builder
+::: capsula.FunctionContext.__init__
+
+## Configuration example
+
+### Via `capsula.toml`
+
+!!! warning
+    Configuring the `FunctionContext` via `capsula.toml` is not recommended because `capsula enc` will fail as there is no target function to capture.
+
+```toml
+[pre-run]
+contexts = [
+  { type = "FunctionContext" },
+]
+```
+
+### Via `@capsula.context` decorator
+
+```python
+import capsula
+
+@capsula.run()
+@capsula.context(capsula.FunctionContext.builder(), mode="pre")
+def func(arg1, arg2): ...
+```
+
+## Output example
+
+The following is an example of the output of the `FunctionContext`, reported by the [`JsonDumpReporter`](../reporters/json_dump.md):
+
+```json
+"function": {
+  "calculate_pi": {
+    "file_path": "examples/simple_decorator.py",
+    "first_line_no": 6,
+    "bound_args": {
+      "n_samples": 1000,
+      "seed": 42
+    }
+  }
+}
+```

--- a/docs/contexts/index.md
+++ b/docs/contexts/index.md
@@ -6,6 +6,7 @@ Capsula provides several built-in contexts that you can capture. The following i
 - [`CpuContext`](cpu.md) - Captures the CPU information.
 - [`CwdContext`](cwd.md) - Captures the current working directory.
 - [`EnvVarContext`](envvar.md) - Captures the environment variables.
-<!-- - [`FileContext`](file.md) -->
+- [`FileContext`](file.md) - Captures the file information.
+- [`FunctionContext`](function.md) - Captures the arguments of a function.
 - [`GitRepositoryContext`](git.md) - Captures the Git repository information.
 - [`PlatformContext`](platform.md) - Captures the Python version.

--- a/examples/decorator.py
+++ b/examples/decorator.py
@@ -29,6 +29,7 @@ PROJECT_ROOT = capsula.search_for_project_root(__file__)
 @capsula.watcher(capsula.TimeWatcher("calculation_time"))
 @capsula.context(capsula.FileContext.builder("pi.txt", move=True), mode="post")
 @capsula.reporter(capsula.JsonDumpReporter.builder(), mode="all")
+@capsula.context(capsula.FunctionContext.builder(), mode="pre")
 @capsula.pass_pre_run_capsule
 def calculate_pi(pre_run_capsule: capsula.Capsule, *, n_samples: int = 1_000, seed: int = 42) -> None:
     logger.info(f"Calculating pi with {n_samples} samples.")

--- a/examples/simple_decorator.py
+++ b/examples/simple_decorator.py
@@ -4,6 +4,7 @@ import capsula
 
 
 @capsula.run()
+@capsula.context(capsula.FunctionContext.builder(), mode="pre")
 @capsula.context(capsula.FileContext.builder("pi.txt", move=True), mode="post")
 def calculate_pi(n_samples: int = 1_000, seed: int = 42) -> None:
     random.seed(seed)


### PR DESCRIPTION
- **Add builder method to FunctionCallContext**
- **Rename to FunctionContext**
- **Change _FunctionContextData with bound arguments**
- **Remove FunctionContext in the Run.__call__**
- **Add pass_pre_run_capsule to FuncInfo**
- **Expose FunctionContext**
- **Handle the case where pre_run_capsule is in the function signature**
- **Add FunctionContext to the decorator example**
- **Add FunctionContext to the simple decorator example**
- **Add FunctionContext docs**
- **Add doc**
