### PR TITLE
Hide (commit: unknown) if Git commit is unknown

### DIFF
--- a/crates/capsula-cli/build.rs
+++ b/crates/capsula-cli/build.rs
@@ -8,13 +8,15 @@ fn main() {
 
     let git_hash = match output {
         Ok(output) if output.status.success() => String::from_utf8(output.stdout)
-            .unwrap_or_else(|_| "unknown".to_string())
-            .trim()
-            .to_string(),
-        _ => "unknown".to_string(),
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty()),
+        _ => None,
     };
 
-    println!("cargo:rustc-env=GIT_HASH={git_hash}");
+    // Set GIT_HASH to actual hash or empty string if not available
+    let git_hash_value = git_hash.as_deref().unwrap_or("");
+    println!("cargo:rustc-env=GIT_HASH={git_hash_value}");
 
     // Rerun if HEAD changes (new commit)
     println!("cargo:rerun-if-changed=../../.git/HEAD");

--- a/crates/capsula-cli/src/main.rs
+++ b/crates/capsula-cli/src/main.rs
@@ -18,12 +18,16 @@ use tracing::{debug, error, info, warn};
 use tracing_subscriber::{EnvFilter, fmt};
 use ulid::Ulid;
 
-const VERSION: &str = concat!(
-    env!("CARGO_PKG_VERSION"),
-    " (commit: ",
-    env!("GIT_HASH"),
-    ")"
-);
+const VERSION: &str = if env!("GIT_HASH").is_empty() {
+    env!("CARGO_PKG_VERSION")
+} else {
+    concat!(
+        env!("CARGO_PKG_VERSION"),
+        " (commit: ",
+        env!("GIT_HASH"),
+        ")"
+    )
+};
 
 #[derive(Parser, Debug)]
 #[command(name = "capsula", bin_name = "capsula", version = VERSION, about = "Capsula CLI")]


### PR DESCRIPTION
When installed from crates.io (most of the cases), the Git commit SHA is unknown.