### PR TITLE
Make some Clippy config explicit in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,10 @@ all = "warn"
 allow_attributes = { level = "warn", priority = 1 }
 allow_attributes_without_reason = { level = "warn", priority = 1 }
 cargo = { level = "warn", priority = -1 }
+complexity = { level = "warn", priority = -1 }
+correctness = { level = "deny", priority = -1 }  # deny-by-default
 dbg_macro = { level = "warn", priority = 1 }
+decimal_literal_representation = { level = "warn", priority = 1 }
 derive_partial_eq_without_eq = { level = "allow", priority = 1 }  # We implement `Eq` only when necessary
 else_if_without_else = { level = "warn", priority = 1 }
 expect_used = { level = "allow", priority = 1 }  # TODO: change to "warn" later
@@ -75,8 +78,11 @@ multiple_crate_versions = { level = "allow", priority = 1 }  # There is nothing 
 nursery = { level = "warn", priority = -1 }
 panic = { level = "allow", priority = 1 }  # TODO: change to "warn" later
 pedantic = { level = "warn", priority = -1 }
+perf = { level = "warn", priority = -1 }
 print_stderr = { level = "warn", priority = 1 }
 print_stdout = { level = "warn", priority = 1 }
+style = { level = "warn", priority = -1 }  # warn-by-default
+suspicious = { level = "warn", priority = -1 }
 todo = { level = "warn", priority = 1 }
 undocumented_unsafe_blocks = { level = "warn", priority = 1 }
 unimplemented = { level = "warn", priority = 1 }


### PR DESCRIPTION
## Title

Make Clippy lint group configurations explicit in `Cargo.toml`

## Description

Add explicit configuration for Clippy lint groups that were previously using implicit defaults.

### Changes

Adds the following lint group configurations to `[workspace.lints.clippy]`:

- `complexity = { level = "warn", priority = -1 }`
- `correctness = { level = "deny", priority = -1 }` - Makes deny-by-default explicit
- `decimal_literal_representation = { level = "warn", priority = 1 }`
- `perf = { level = "warn", priority = -1 }`
- `style = { level = "warn", priority = -1 }` - Makes warn-by-default explicit
- `suspicious = { level = "warn", priority = -1 }`
