### PR TITLE
Document `name` field for `capture-git-repo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ name = "my-project"
 
 [[pre-run.hooks]]
 id = "capture-git-repo"
+name = "my-project"
 path = "."
 
 [[post-run.hooks]]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,6 +81,7 @@ Pre-run hooks are executed **before** your command, in the order listed.
 ```toml
 [[pre-run.hooks]]
 id = "capture-git-repo"
+name = "my-project"
 path = "."
 
 [[pre-run.hooks]]
@@ -108,6 +109,7 @@ name = "research-experiments"
 
 [[pre-run.hooks]]
 id = "capture-git-repo"
+name = "research"
 path = "."
 allow_dirty = false
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,6 +29,7 @@ name = "my-project"
 
 [[pre-run.hooks]]
 id = "capture-git-repo"
+name = "my-project"
 path = "."
 allow_dirty = true
 

--- a/docs/hooks/capture-git-repo.md
+++ b/docs/hooks/capture-git-repo.md
@@ -19,6 +19,7 @@ Captures git repository state including commit hash, branch, and whether there a
 
 | Option | Type | Description |
 | -------- | ------ | ------------- |
+| `name` | string | Name used for the patch file when the repository has uncommitted changes |
 | `path` | string | Path to the git repository (`.` for current directory) |
 
 ### Optional Options
@@ -32,6 +33,7 @@ Captures git repository state including commit hash, branch, and whether there a
 ```toml
 [[pre-run.hooks]]
 id = "capture-git-repo"
+name = "my-project"
 path = "."
 allow_dirty = false
 ```
@@ -45,6 +47,7 @@ allow_dirty = false
   "__meta": {
     "id": "capture-git-repo",
     "config": {
+      "name": "my-project",
       "path": ".",
       "allow_dirty": false
     },
@@ -64,6 +67,7 @@ allow_dirty = false
   "__meta": {
     "id": "capture-git-repo",
     "config": {
+      "name": "my-project",
       "path": ".",
       "allow_dirty": true
     },

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ name = "my-project"
 
 [[pre-run.hooks]]
 id = "capture-git-repo"
+name = "my-project"
 path = "."
 
 [[post-run.hooks]]


### PR DESCRIPTION
## Summary

Add the missing `name` field to all documentation examples for the `capture-git-repo` hook.

## Problem

The `capture-git-repo` hook requires a `name` field in its configuration (used to generate the `.patch` file name when the repository is dirty), but all documentation examples omitted it. This caused users to encounter `missing field 'name'` errors when following the docs.

## Changes

- `docs/hooks/capture-git-repo.md`: Added `name` to the Required Options table, the TOML example, and both JSON output examples
- `docs/getting-started.md`: Added `name` to the "Your First Run" example
- `docs/configuration.md`: Added `name` to the Pre-Run Hooks and Complete Example sections
- `docs/index.md`: Added `name` to the Quick Example
- `README.md`: Added `name` to the Quick Example

Closes #760
