### PR TITLE
Add `require_pushed` option to `capture-git-repo` hook

### DIFF
--- a/crates/capsula-capture-git-repo/src/lib.rs
+++ b/crates/capsula-capture-git-repo/src/lib.rs
@@ -193,20 +193,6 @@ impl GitHook {
             }
         }
 
-        // Check tags: HEAD is directly pointed to by a tag.
-        // Tags are not remote-specific, but a pushed tag keeps the commit accessible.
-        for reference in repo.references().map_err(GitHookError::from)? {
-            let reference = reference.map_err(GitHookError::from)?;
-            if let Some(name) = reference.name()
-                && name.starts_with("refs/tags/")
-                && let Ok(tag_commit) = reference.peel_to_commit()
-                && tag_commit.id() == head_oid
-            {
-                debug!("HEAD ({head_oid}) found in tag: {name}");
-                return Ok(true);
-            }
-        }
-
         Ok(false)
     }
 

--- a/crates/capsula-capture-git-repo/tests/git_hook.rs
+++ b/crates/capsula-capture-git-repo/tests/git_hook.rs
@@ -462,58 +462,6 @@ fn git_hook_custom_remote() {
 }
 
 #[test]
-fn git_hook_detects_tagged_commit_as_pushed() {
-    // Arrange - create a tag on HEAD (no remote push)
-    let temp_dir = init_git_repo();
-
-    let run_dir = temp_dir.join("run");
-    fs::create_dir_all(&run_dir).unwrap();
-
-    // Create a lightweight tag (disable signing to avoid GPG prompts in test)
-    Command::new("git")
-        .args(["tag", "--no-sign", "v1.0"])
-        .current_dir(&temp_dir)
-        .output()
-        .expect("git tag failed");
-
-    let config = json!({
-        "name": "test-repo",
-        "path": ".",
-        "require_pushed": true,
-    });
-    let hook = <GitHook as Hook<PreRun>>::from_config(&config, &temp_dir).expect("from_config ok");
-
-    let run_metadata = PreparedRun {
-        id: Ulid::new(),
-        name: "test-run".to_string(),
-        command: vec![],
-        run_dir,
-        project_root: temp_dir.clone(),
-    };
-    let params = RuntimeParams::<PreRun>::default();
-
-    // Act
-    let captured = hook.run(&run_metadata, &params).expect("run ok");
-    let json = captured
-        .serialize_json()
-        .expect("serialization should succeed");
-
-    // Assert - tag points to HEAD, so it should be considered pushed
-    assert_eq!(
-        json.get("is_pushed").and_then(serde_json::Value::as_bool),
-        Some(true),
-        "Tagged commit should be detected as pushed"
-    );
-    assert!(
-        !captured.abort_requested(),
-        "Should not abort when commit is tagged"
-    );
-
-    // Cleanup
-    fs::remove_dir_all(&temp_dir).ok();
-}
-
-#[test]
 fn git_hook_captures_dirty_repo_with_allow_dirty() {
     // Arrange - create a git repository with uncommitted changes
     let temp_dir = std::env::temp_dir().join(format!("capsula_git_test_{}", Ulid::new()));

--- a/docs/hooks/capture-git-repo.md
+++ b/docs/hooks/capture-git-repo.md
@@ -93,12 +93,11 @@ remote = "origin"
     When `allow_dirty = false` and the repository is dirty, Capsula saves the hook output showing the dirty state, then aborts before running your command.
 
 !!! warning "Abort Behavior (push check)"
-    When `require_pushed = true` and the HEAD commit is not reachable from any remote branch or tag, Capsula saves the hook output, then aborts before running your command.
+    When `require_pushed = true` and the HEAD commit is not reachable from any remote branch, Capsula saves the hook output, then aborts before running your command.
 
 !!! note "Push check details"
-    - The push check verifies that the HEAD commit is reachable from a remote-tracking branch of the configured remote, or pointed to by a local tag. It does **not** require HEAD to be at the tip of a remote branch — ancestor commits are also considered pushed.
+    - The push check verifies that the HEAD commit is reachable from a remote-tracking branch of the configured remote. It does **not** require HEAD to be at the tip of a remote branch — ancestor commits are also considered pushed.
     - The check relies on local remote-tracking references. Run `git fetch` before `capsula run` if you need up-to-date remote state.
-    - Local tags are checked, but a local tag does not guarantee the tag has been pushed to the remote.
 
 !!! warning "Squash merge and commit reachability"
     Even if `require_pushed = true` passes at the time of the run, the commit may later become unreachable if the branch is squash-merged and deleted. After a squash merge, the original commits are replaced by a single new commit on the target branch, and the original commit SHAs are no longer reachable. To preserve commit reachability, use **merge commits** (not squash merge) when merging branches that contain experiment runs.


### PR DESCRIPTION
## Summary

Add `require_pushed` and `remote` config options to the `capture-git-repo` hook. When `require_pushed = true`, the hook verifies that the HEAD commit is reachable from the configured remote, aborting the run if it is not. This ensures that others can access the exact commit used for an experiment.

## Motivation

If HEAD is not pushed to a remote, the commit may be removed locally (e.g., by garbage collection), making it impossible for others to reproduce the results. This option provides a safeguard against running experiments on unpushed commits.

## Changes

### Config

Two new optional fields in `capture-git-repo` hook configuration:

| Option | Type | Default | Description |
|--------|------|---------|-------------|
| `require_pushed` | boolean | `false` | If `true`, abort when HEAD is not pushed to remote |
| `remote` | string | `"origin"` | Remote to check against |

```toml
[[pre-run.hooks]]
id = "capture-git-repo"
name = "my-project"
path = "."
allow_dirty = false
require_pushed = true
remote = "origin"
```

### Push check logic

The check verifies that the HEAD commit is reachable from any remote-tracking branch of the configured remote (via `graph_descendant_of` — ancestor commits count as pushed).

The check does **not** auto-fetch. It relies on local remote-tracking refs. Users should run `git fetch` beforehand if freshness matters.

### Output

A new `is_pushed` boolean field is added to the hook's JSON output, always populated regardless of the `require_pushed` setting.

### Files modified

- `crates/capsula-capture-git-repo/src/lib.rs` -- config, output struct, `check_pushed()` logic, abort logic
- `crates/capsula-capture-git-repo/tests/git_hook.rs` -- 5 new test cases + test helpers
- `docs/hooks/capture-git-repo.md` -- documentation for new options and caveats

## Caveats (documented)

- **No auto-fetch**: The check uses local remote-tracking refs. If refs are stale, the check may produce inaccurate results.
- **Squash merge**: Even if `require_pushed` passes at run time, the commit may later become unreachable if the branch is squash-merged and deleted. Merge commits (not squash merge) are recommended for branches containing experiment runs.

## Tests

5 new integration tests:

- `git_hook_detects_pushed_commit`
- `git_hook_detects_unpushed_commit`
- `git_hook_aborts_on_unpushed_when_required`
- `git_hook_pushed_commit_behind_remote` (ancestor check)
- `git_hook_custom_remote`

All workspace tests pass. Clippy and fmt are clean.
