### PR TITLE
Add run-dir command

### DIFF
--- a/crates/capsula-cli/src/main.rs
+++ b/crates/capsula-cli/src/main.rs
@@ -49,6 +49,11 @@ enum Commands {
         #[arg(trailing_var_arg = true)]
         cmd: Vec<String>,
     },
+    /// Print the run directory for a given run name
+    RunDir {
+        /// Run name to locate (e.g., happy-river)
+        run_name: String,
+    },
     List,
     Push {
         /// Run ID or name to push (e.g., 01HQXYZ... or chubby-back)
@@ -468,6 +473,70 @@ fn find_run_dir(vault_dir: &std::path::Path, run_id: &str) -> Result<PathBuf> {
     )
 }
 
+fn find_run_dir_by_name(vault_dir: &std::path::Path, run_name: &str) -> Result<PathBuf> {
+    let mut best_match: Option<(PathBuf, Option<DateTime<chrono::FixedOffset>>)> = None;
+    let mut match_count = 0usize;
+
+    for entry in walkdir::WalkDir::new(vault_dir)
+        .min_depth(2)
+        .max_depth(2)
+        .into_iter()
+        .filter_entry(|e| e.file_type().is_dir())
+    {
+        let entry = entry?;
+        let capsula_dir = entry.path().join("_capsula");
+        if !capsula_dir.exists() {
+            continue;
+        }
+
+        let metadata_path = capsula_dir.join("metadata.json");
+        if !metadata_path.exists() {
+            continue;
+        }
+
+        let metadata_content = std::fs::read_to_string(&metadata_path)?;
+        let metadata: RunMetadata = serde_json::from_str(&metadata_content)?;
+
+        if metadata.name != run_name {
+            continue;
+        }
+
+        match_count += 1;
+        let timestamp = DateTime::parse_from_rfc3339(&metadata.timestamp).ok();
+        match best_match {
+            None => {
+                best_match = Some((entry.path().to_path_buf(), timestamp));
+            }
+            Some((_, ref best_timestamp)) => {
+                let is_newer = match (timestamp, best_timestamp) {
+                    (Some(current), Some(best)) => current > *best,
+                    (Some(_), None) => true,
+                    _ => false,
+                };
+                if is_newer {
+                    best_match = Some((entry.path().to_path_buf(), timestamp));
+                }
+            }
+        }
+    }
+
+    if let Some((path, _)) = best_match {
+        if match_count > 1 {
+            warn!(
+                "Found {} runs named '{}'; returning the newest by timestamp.",
+                match_count, run_name
+            );
+        }
+        return Ok(path);
+    }
+
+    anyhow::bail!(
+        "Run with name '{}' not found in vault {}",
+        run_name,
+        vault_dir.display()
+    )
+}
+
 #[expect(
     clippy::too_many_lines,
     reason = "TODO: Refactor into smaller functions"
@@ -596,6 +665,10 @@ path = \".\"
                     timestamp_display, run.name, command_truncated
                 );
             }
+        }
+        Commands::RunDir { run_name } => {
+            let run_dir = find_run_dir_by_name(&vault_dir, &run_name)?;
+            println!("{}", run_dir.display());
         }
         Commands::Run { cmd } => {
             // Sanity check

--- a/crates/capsula-cli/tests/cli_integration.rs
+++ b/crates/capsula-cli/tests/cli_integration.rs
@@ -1,13 +1,12 @@
-#![allow(
+//! Integration tests for the capsula CLI tool.
+#![expect(
     clippy::unwrap_used,
-    clippy::uninlined_format_args,
-    clippy::redundant_closure_for_method_calls,
-    deprecated,
     reason = "Test code doesn't need production-level error handling"
 )]
 
-use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
+use serde::Deserialize;
 use std::fs;
 use std::path::PathBuf;
 use tempfile::TempDir;
@@ -18,15 +17,49 @@ fn create_test_config(dir: &TempDir, vault_name: &str) -> PathBuf {
     let config_content = format!(
         r#"
 [vault]
-name = "{}"
+name = "{vault_name}"
 
 [[pre-run.hooks]]
 id = "capture-cwd"
 "#,
-        vault_name
     );
     fs::write(&config_path, config_content).unwrap();
     config_path
+}
+
+#[derive(Deserialize)]
+struct TestRunMetadata {
+    name: String,
+}
+
+fn find_first_run(vault_dir: &std::path::Path) -> (PathBuf, String) {
+    let date_dirs: Vec<_> = fs::read_dir(vault_dir)
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|e| e.path().is_dir())
+        .collect();
+
+    for date_dir in date_dirs {
+        let run_dirs: Vec<_> = fs::read_dir(date_dir.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| e.path().is_dir())
+            .collect();
+
+        for run_dir in run_dirs {
+            let run_path = run_dir.path();
+            let metadata_path = run_path.join("_capsula").join("metadata.json");
+            if !metadata_path.exists() {
+                continue;
+            }
+
+            let content = fs::read_to_string(&metadata_path).unwrap();
+            let metadata: TestRunMetadata = serde_json::from_str(&content).unwrap();
+            return (run_path, metadata.name);
+        }
+    }
+
+    panic!("No run directory found");
 }
 
 #[test]
@@ -34,7 +67,7 @@ fn test_capsula_run_creates_run_directory() {
     let temp_dir = TempDir::new().unwrap();
     let config_path = create_test_config(&temp_dir, "test-vault");
 
-    let mut cmd = Command::cargo_bin("capsula").unwrap();
+    let mut cmd = cargo_bin_cmd!("capsula");
     cmd.current_dir(temp_dir.path())
         .arg("--config")
         .arg(&config_path)
@@ -51,7 +84,7 @@ fn test_capsula_run_creates_run_directory() {
     // Check that at least one run directory exists
     let date_dirs: Vec<_> = fs::read_dir(&vault_dir)
         .unwrap()
-        .filter_map(|e| e.ok())
+        .filter_map(Result::ok)
         .filter(|e| e.path().is_dir())
         .collect();
 
@@ -64,7 +97,7 @@ fn test_capsula_run_creates_run_directory() {
     for date_dir in date_dirs {
         let run_dirs: Vec<_> = fs::read_dir(date_dir.path())
             .unwrap()
-            .filter_map(|e| e.ok())
+            .filter_map(Result::ok)
             .filter(|e| e.path().is_dir())
             .collect();
 
@@ -92,12 +125,42 @@ fn test_capsula_run_creates_run_directory() {
 }
 
 #[test]
+fn test_capsula_run_dir_prints_path() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_path = create_test_config(&temp_dir, "test-vault");
+
+    let mut cmd = cargo_bin_cmd!("capsula");
+    cmd.current_dir(temp_dir.path())
+        .arg("--config")
+        .arg(&config_path)
+        .arg("run")
+        .arg("echo")
+        .arg("hello");
+
+    cmd.assert().success();
+
+    let vault_dir = temp_dir.path().join(".capsula").join("test-vault");
+    let (run_dir, run_name) = find_first_run(&vault_dir);
+
+    let mut cmd = cargo_bin_cmd!("capsula");
+    cmd.current_dir(temp_dir.path())
+        .arg("--config")
+        .arg(&config_path)
+        .arg("run-dir")
+        .arg(&run_name);
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(run_dir.to_string_lossy().as_ref()));
+}
+
+#[test]
 fn test_capsula_list_shows_runs() {
     let temp_dir = TempDir::new().unwrap();
     let config_path = create_test_config(&temp_dir, "test-vault");
 
     // First, create a run
-    let mut cmd = Command::cargo_bin("capsula").unwrap();
+    let mut cmd = cargo_bin_cmd!("capsula");
     cmd.current_dir(temp_dir.path())
         .arg("--config")
         .arg(&config_path)
@@ -108,7 +171,7 @@ fn test_capsula_list_shows_runs() {
     cmd.assert().success();
 
     // Now list runs
-    let mut cmd = Command::cargo_bin("capsula").unwrap();
+    let mut cmd = cargo_bin_cmd!("capsula");
     cmd.current_dir(temp_dir.path())
         .arg("--config")
         .arg(&config_path)
@@ -127,7 +190,7 @@ fn test_capsula_push_requires_server_url() {
     let config_path = create_test_config(&temp_dir, "test-vault");
 
     // First, create a run
-    let mut cmd = Command::cargo_bin("capsula").unwrap();
+    let mut cmd = cargo_bin_cmd!("capsula");
     cmd.current_dir(temp_dir.path())
         .arg("--config")
         .arg(&config_path)
@@ -138,7 +201,7 @@ fn test_capsula_push_requires_server_url() {
     cmd.assert().success();
 
     // Try to push without server URL (should fail)
-    let mut cmd = Command::cargo_bin("capsula").unwrap();
+    let mut cmd = cargo_bin_cmd!("capsula");
     cmd.current_dir(temp_dir.path())
         .arg("--config")
         .arg(&config_path)
@@ -156,7 +219,7 @@ fn test_capsula_vaults_list_requires_server_url() {
     let config_path = create_test_config(&temp_dir, "test-vault");
 
     // Try to list vaults without server URL (should fail)
-    let mut cmd = Command::cargo_bin("capsula").unwrap();
+    let mut cmd = cargo_bin_cmd!("capsula");
     cmd.current_dir(temp_dir.path())
         .arg("--config")
         .arg(&config_path)
@@ -172,7 +235,7 @@ fn test_capsula_vaults_list_requires_server_url() {
 fn test_capsula_run_with_nonexistent_config() {
     let temp_dir = TempDir::new().unwrap();
 
-    let mut cmd = Command::cargo_bin("capsula").unwrap();
+    let mut cmd = cargo_bin_cmd!("capsula");
     cmd.current_dir(temp_dir.path())
         .arg("--config")
         .arg("nonexistent.toml")
@@ -190,7 +253,7 @@ fn test_capsula_run_without_command() {
     let temp_dir = TempDir::new().unwrap();
     let config_path = create_test_config(&temp_dir, "test-vault");
 
-    let mut cmd = Command::cargo_bin("capsula").unwrap();
+    let mut cmd = cargo_bin_cmd!("capsula");
     cmd.current_dir(temp_dir.path())
         .arg("--config")
         .arg(&config_path)
@@ -217,7 +280,7 @@ id = "capture-cwd"
     fs::write(&config_path, config_content).unwrap();
 
     // Create a run to ensure config is valid
-    let mut cmd = Command::cargo_bin("capsula").unwrap();
+    let mut cmd = cargo_bin_cmd!("capsula");
     cmd.current_dir(temp_dir.path())
         .arg("--config")
         .arg(&config_path)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -92,3 +92,19 @@ TIMESTAMP (UTC)      NAME                  COMMAND
 2025-01-09 14:30:28  clever-mountain       python script.py
 2025-01-09 14:30:26  quiet-lake            cargo build --release
 ```
+
+## `capsula run-dir`
+
+Print the run directory for a run name.
+
+### Usage
+
+```bash
+capsula run-dir <RUN_NAME>
+```
+
+### Example
+
+```bash
+capsula run-dir happy-river
+```


### PR DESCRIPTION
## Summary
- Add `capsula run-dir` subcommand to print the run directory for a given run name.
- Prefer the newest run when duplicate names exist.
- Update CLI docs and integration tests; fix clippy warnings in tests.