### PR TITLE
Add `run-start` and `run-end` subcommands for manual run lifecycle

### DIFF
--- a/crates/capsula-cli/src/main.rs
+++ b/crates/capsula-cli/src/main.rs
@@ -49,6 +49,20 @@ enum Commands {
         #[arg(trailing_var_arg = true)]
         cmd: Vec<String>,
     },
+    /// Start a manual run: create run directory and execute pre-run hooks
+    ///
+    /// Use this when you want to capture context before and after an external
+    /// process (e.g., a GUI-triggered analysis) that capsula does not manage.
+    /// The auto-generated run name is printed to stdout so callers can capture it
+    /// (e.g., `name=$(capsula run-start)`), then later finalize with `run-end`.
+    RunStart,
+    /// End a manual run: execute post-run hooks for an existing run
+    ///
+    /// Finalizes a run previously started with `run-start`.
+    RunEnd {
+        /// Name of the run to finalize (as printed by `run-start`)
+        run_name: String,
+    },
     /// Print the run directory for a given run name
     RunDir {
         /// Run name to locate (e.g., happy-river)
@@ -241,6 +255,7 @@ fn build_and_run_hooks<P: PhaseMarker>(
 
 #[derive(Debug, Deserialize)]
 struct RunMetadata {
+    id: Ulid,
     name: String,
     command: Vec<String>,
     timestamp: String,
@@ -779,6 +794,123 @@ path = \".\"
                         post_json_path.display()
                     )
                 })?;
+        }
+        Commands::RunStart => {
+            debug!("Creating run-start metadata");
+            let run = Run::<()> {
+                id: Ulid::new(),
+                name: Generator::default()
+                    .next()
+                    .with_context(|| "Failed to generate a random name for the run")?,
+                command: vec![],
+                run_dir: (),
+                project_root: project_root.clone(),
+            };
+
+            info!("Run ID: {}, Name: {}", run.id, run.name);
+            debug!("Setting up run directory in vault: {}", vault_dir.display());
+            let run = run.setup_run_dir(&vault_dir, 5)?;
+            info!("Run directory: {}", run.run_dir.to_string_lossy());
+
+            let capsula_dir = run.run_dir.join("_capsula");
+            std::fs::create_dir(&capsula_dir).with_context(|| {
+                format!(
+                    "Failed to create _capsula directory in run directory {}",
+                    run.run_dir.display()
+                )
+            })?;
+
+            let run_metadata_path = capsula_dir.join("metadata.json");
+            std::fs::write(&run_metadata_path, serde_json::to_string_pretty(&run)?).with_context(
+                || {
+                    format!(
+                        "Failed to write metadata to {}",
+                        run_metadata_path.display()
+                    )
+                },
+            )?;
+
+            debug!("Executing pre-run hooks");
+            let pre_params = RuntimeParams::<PreRun>::default();
+            let (pre_json, should_abort) = build_and_run_hooks(
+                &run,
+                &pre_params,
+                &config.pre_run,
+                &pre_run_hook_registry,
+                &project_root,
+            )
+            .context("Failed to execute pre-run hooks")?;
+            debug!("Pre-run hooks completed");
+
+            let pre_json_path = capsula_dir.join("pre-run.json");
+            std::fs::write(&pre_json_path, serde_json::to_string_pretty(&pre_json)?).with_context(
+                || {
+                    format!(
+                        "Failed to write pre-run hook results to {}",
+                        pre_json_path.display()
+                    )
+                },
+            )?;
+
+            if should_abort {
+                warn!("A pre-run hook requested abort.");
+            }
+
+            // Print run name to stdout for callers to capture
+            println!("{}", run.name);
+        }
+        Commands::RunEnd { run_name } => {
+            let run_dir = find_run_dir_by_name(&vault_dir, &run_name)?;
+            let capsula_dir = run_dir.join("_capsula");
+
+            let post_run_path = capsula_dir.join("post-run.json");
+            if post_run_path.exists() {
+                anyhow::bail!(
+                    "Run '{run_name}' has already been finalized (post-run.json already exists)"
+                );
+            }
+
+            let metadata_path = capsula_dir.join("metadata.json");
+            let metadata_content = std::fs::read_to_string(&metadata_path).with_context(|| {
+                format!("Failed to read metadata from {}", metadata_path.display())
+            })?;
+            let metadata: RunMetadata =
+                serde_json::from_str(&metadata_content).with_context(|| {
+                    format!("Failed to parse metadata from {}", metadata_path.display())
+                })?;
+
+            let run = Run {
+                id: metadata.id,
+                name: metadata.name,
+                command: metadata.command,
+                run_dir,
+                project_root: project_root.clone(),
+            };
+
+            info!("Finalizing run: {} (ID: {})", run.name, run.id);
+
+            debug!("Executing post-run hooks");
+            let post_params = RuntimeParams::<PostRun>::default();
+            let (post_json, _should_abort) = build_and_run_hooks::<PostRun>(
+                &run,
+                &post_params,
+                &config.post_run,
+                &post_run_hook_registry,
+                &project_root,
+            )
+            .context("Failed to execute post-run hooks")?;
+            debug!("Post-run hooks completed");
+
+            let post_json_path = capsula_dir.join("post-run.json");
+            std::fs::write(&post_json_path, serde_json::to_string_pretty(&post_json)?)
+                .with_context(|| {
+                    format!(
+                        "Failed to write post-run hook results to {}",
+                        post_json_path.display()
+                    )
+                })?;
+
+            info!("Run '{}' finalized successfully", run_name);
         }
         Commands::Push {
             run_id,

--- a/crates/capsula-cli/tests/cli_integration.rs
+++ b/crates/capsula-cli/tests/cli_integration.rs
@@ -27,6 +27,25 @@ id = "capture-cwd"
     config_path
 }
 
+/// Helper to create a capsula.toml config with both pre-run and post-run hooks
+fn create_test_config_with_post_run(dir: &TempDir, vault_name: &str) -> PathBuf {
+    let config_path = dir.path().join("capsula.toml");
+    let config_content = format!(
+        r#"
+[vault]
+name = "{vault_name}"
+
+[[pre-run.hooks]]
+id = "capture-cwd"
+
+[[post-run.hooks]]
+id = "capture-cwd"
+"#,
+    );
+    fs::write(&config_path, config_content).unwrap();
+    config_path
+}
+
 #[derive(Deserialize)]
 struct TestRunMetadata {
     name: String,
@@ -289,4 +308,167 @@ id = "capture-cwd"
         .arg("test");
 
     cmd.assert().success();
+}
+
+#[test]
+fn test_run_start_creates_directory_and_pre_run() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_path = create_test_config_with_post_run(&temp_dir, "test-vault");
+
+    let mut cmd = cargo_bin_cmd!("capsula");
+    cmd.current_dir(temp_dir.path())
+        .arg("--config")
+        .arg(&config_path)
+        .arg("run-start");
+
+    let output = cmd.assert().success();
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+    let run_name = stdout.trim();
+    assert!(
+        !run_name.is_empty(),
+        "run-start should print run name to stdout"
+    );
+
+    let vault_dir = temp_dir.path().join(".capsula").join("test-vault");
+    assert!(vault_dir.exists(), "Vault directory should exist");
+
+    let (run_dir, found_name) = find_first_run(&vault_dir);
+    assert_eq!(found_name, run_name);
+
+    let capsula_dir = run_dir.join("_capsula");
+    assert!(
+        capsula_dir.join("metadata.json").exists(),
+        "metadata.json should exist"
+    );
+    assert!(
+        capsula_dir.join("pre-run.json").exists(),
+        "pre-run.json should exist"
+    );
+    assert!(
+        !capsula_dir.join("command.json").exists(),
+        "command.json should NOT exist"
+    );
+    assert!(
+        !capsula_dir.join("post-run.json").exists(),
+        "post-run.json should NOT exist"
+    );
+}
+
+#[test]
+fn test_run_start_prints_name_to_stdout() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_path = create_test_config(&temp_dir, "test-vault");
+
+    let mut cmd = cargo_bin_cmd!("capsula");
+    cmd.current_dir(temp_dir.path())
+        .arg("--config")
+        .arg(&config_path)
+        .arg("run-start");
+
+    let output = cmd.assert().success();
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    assert_eq!(
+        lines.len(),
+        1,
+        "stdout should contain exactly one line (the run name)"
+    );
+    // Run names from the `names` crate are two hyphenated words
+    assert!(
+        lines[0].contains('-'),
+        "Run name should be hyphenated (e.g., 'happy-river')"
+    );
+}
+
+#[test]
+fn test_run_end_creates_post_run() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_path = create_test_config_with_post_run(&temp_dir, "test-vault");
+
+    // First, start a run
+    let mut cmd = cargo_bin_cmd!("capsula");
+    cmd.current_dir(temp_dir.path())
+        .arg("--config")
+        .arg(&config_path)
+        .arg("run-start");
+
+    let output = cmd.assert().success();
+    let run_name = String::from_utf8(output.get_output().stdout.clone())
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // Now end the run
+    let mut cmd = cargo_bin_cmd!("capsula");
+    cmd.current_dir(temp_dir.path())
+        .arg("--config")
+        .arg(&config_path)
+        .arg("run-end")
+        .arg(&run_name);
+
+    cmd.assert().success();
+
+    let vault_dir = temp_dir.path().join(".capsula").join("test-vault");
+    let (run_dir, _) = find_first_run(&vault_dir);
+    let capsula_dir = run_dir.join("_capsula");
+    assert!(
+        capsula_dir.join("post-run.json").exists(),
+        "post-run.json should exist after run-end"
+    );
+}
+
+#[test]
+fn test_run_end_nonexistent_name_fails() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_path = create_test_config(&temp_dir, "test-vault");
+
+    let mut cmd = cargo_bin_cmd!("capsula");
+    cmd.current_dir(temp_dir.path())
+        .arg("--config")
+        .arg(&config_path)
+        .arg("run-end")
+        .arg("nonexistent-run");
+
+    cmd.assert().failure();
+}
+
+#[test]
+fn test_run_end_already_finalized_fails() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_path = create_test_config_with_post_run(&temp_dir, "test-vault");
+
+    // Start a run
+    let mut cmd = cargo_bin_cmd!("capsula");
+    cmd.current_dir(temp_dir.path())
+        .arg("--config")
+        .arg(&config_path)
+        .arg("run-start");
+
+    let output = cmd.assert().success();
+    let run_name = String::from_utf8(output.get_output().stdout.clone())
+        .unwrap()
+        .trim()
+        .to_string();
+
+    // End the run (first time - should succeed)
+    let mut cmd = cargo_bin_cmd!("capsula");
+    cmd.current_dir(temp_dir.path())
+        .arg("--config")
+        .arg(&config_path)
+        .arg("run-end")
+        .arg(&run_name);
+
+    cmd.assert().success();
+
+    // End the run again (should fail)
+    let mut cmd = cargo_bin_cmd!("capsula");
+    cmd.current_dir(temp_dir.path())
+        .arg("--config")
+        .arg(&config_path)
+        .arg("run-end")
+        .arg(&run_name);
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("already been finalized"));
 }


### PR DESCRIPTION
## Summary

Adds two new subcommands to support a manual run lifecycle where pre-run and post-run hooks are invoked separately, without a command execution in between.

### Use case

A GUI-triggered analysis runs independently (not managed by capsula). A script needs to capture context before and after the analysis using the same run directory:

```bash
# Before analysis
name=$(capsula run-start 2>/dev/null)

# ... external analysis runs independently ...

# After analysis
capsula run-end "$name"
```

### New subcommands

- **`capsula run-start`**: Creates a new run directory, executes pre-run hooks, and prints the auto-generated run name to stdout. All other output goes to stderr via tracing, so the name can be captured cleanly.
- **`capsula run-end <run-name>`**: Finds an existing run directory by name, executes post-run hooks, and writes `post-run.json`. Guards against double-finalization.

### Changes

- `crates/capsula-cli/src/main.rs`: Added `RunStart` and `RunEnd` command variants and their handlers. Added `id` field to `RunMetadata` struct (backwards-compatible).
- `crates/capsula-cli/tests/cli_integration.rs`: Added 5 integration tests covering the new subcommands.

No changes to core, config, registry, or hook crates.