### PR TITLE
Embed static CSS into server binary, remove CAPSULA_STATIC_DIR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,7 +743,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1733,12 +1732,6 @@ dependencies = [
  "http-body",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "http-range-header"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 
 [[package]]
 name = "httparse"
@@ -4578,24 +4571,14 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
- "http-body-util",
- "http-range-header",
- "httpdate",
  "iri-string",
- "mime",
- "mime_guess",
- "percent-encoding",
  "pin-project-lite",
- "tokio",
- "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["io"] }
 toml = "1.0"
-tower-http = { version = "0.6", features = ["fs", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ulid = { version = "1", features = ["serde"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,7 @@ RUN useradd --create-home --uid 1000 capsula
 # Copy binary from builder
 COPY --from=builder /usr/src/capsula-workspace/target/release/capsula-server /usr/local/bin/capsula-server
 
-# Copy static files for web UI
-COPY --from=builder /usr/src/capsula-workspace/crates/capsula-server/static /app/static
+# Copy templates for web UI
 COPY --from=builder /usr/src/capsula-workspace/crates/capsula-server/templates /app/templates
 
 # Copy migrations
@@ -45,8 +44,6 @@ WORKDIR /app
 # Switch to non-root user
 USER capsula
 
-# Set static files directory for runtime
-ENV CAPSULA_STATIC_DIR=/app/static
 ENV CAPSULA_STORAGE_PATH=/app/storage
 
 # Run the server

--- a/crates/capsula-server/Cargo.toml
+++ b/crates/capsula-server/Cargo.toml
@@ -27,7 +27,6 @@ sqlx = { workspace = true, features = ["migrate"] }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
-tower-http = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 

--- a/crates/capsula-server/src/lib.rs
+++ b/crates/capsula-server/src/lib.rs
@@ -134,7 +134,7 @@ pub fn build_app(pool: PgPool, storage_path: PathBuf, max_body_size: usize) -> R
 
 async fn serve_style_css() -> impl IntoResponse {
     (
-        [(header::CONTENT_TYPE, "text/css")],
+        [(header::CONTENT_TYPE, mime_guess::mime::TEXT_CSS.as_ref())],
         include_str!("../static/style.css"),
     )
 }

--- a/crates/capsula-server/src/lib.rs
+++ b/crates/capsula-server/src/lib.rs
@@ -53,7 +53,6 @@ use sha2::{Digest, Sha256};
 use sqlx::PgPool;
 use std::collections::VecDeque;
 use std::path::PathBuf;
-use tower_http::services::ServeDir;
 use tracing::{error, info, warn};
 
 #[derive(Clone)]
@@ -110,10 +109,6 @@ pub async fn create_pool(database_url: &str, max_connections: u32) -> Result<PgP
 }
 
 pub fn build_app(pool: PgPool, storage_path: PathBuf, max_body_size: usize) -> Router {
-    let static_dir: PathBuf = std::env::var("CAPSULA_STATIC_DIR")
-        .expect("CAPSULA_STATIC_DIR environment variable must be set")
-        .into();
-
     let state = AppState { pool, storage_path };
 
     Router::new()
@@ -132,9 +127,16 @@ pub fn build_app(pool: PgPool, storage_path: PathBuf, max_body_size: usize) -> R
             "/api/v1/upload",
             post(upload_files).layer(DefaultBodyLimit::max(max_body_size)),
         )
-        .nest_service("/static", ServeDir::new(static_dir))
+        .route("/static/style.css", get(serve_style_css))
         .fallback(not_found)
         .with_state(state)
+}
+
+async fn serve_style_css() -> impl IntoResponse {
+    (
+        [(header::CONTENT_TYPE, "text/css")],
+        include_str!("../static/style.css"),
+    )
 }
 
 async fn index() -> impl IntoResponse {

--- a/crates/capsula-server/tests/api_tests.rs
+++ b/crates/capsula-server/tests/api_tests.rs
@@ -16,15 +16,6 @@ struct TestContext {
 
 impl TestContext {
     async fn new() -> Self {
-        // Set CAPSULA_STATIC_DIR for tests (content doesn't need to exist for API tests)
-        let static_dir = std::env::temp_dir().join("capsula-test-static");
-        // SAFETY: We set this before spawning any threads, and never modify it again.
-        // Each test runs in a separate process, so no cross-test interference.
-        #[expect(unsafe_code, reason = "Required for test setup; see safety comment")]
-        unsafe {
-            std::env::set_var("CAPSULA_STATIC_DIR", &static_dir);
-        }
-
         let container = Postgres::default()
             .with_tag("18")
             .with_env_var("POSTGRES_USER", "capsula")


### PR DESCRIPTION
## Summary
- Embed `style.css` into the server binary using `include_str!()` instead of serving from the filesystem via `ServeDir`
- Remove the `CAPSULA_STATIC_DIR` environment variable requirement — users no longer need to locate and specify static assets to run the server
- Remove `tower-http` dependency (no longer used)
- Clean up Dockerfile (no longer copies static files or sets the env var)

## Test plan
- [x] `just lint` passes
- [x] `just test` passes (all 87 tests)
- [x] Manually verified server starts without `CAPSULA_STATIC_DIR` and serves CSS at `/static/style.css` with correct content-type

🤖 Generated with [Claude Code](https://claude.ai/claude-code)