### PR TITLE
fix(notify-slack): wrap bot token in SecretString to prevent leaks

### DIFF
--- a/crates/capsula-notify-slack/src/lib.rs
+++ b/crates/capsula-notify-slack/src/lib.rs
@@ -1,5 +1,7 @@
 mod error;
+mod secret;
 use crate::error::SlackNotifyError;
+use crate::secret::SecretString;
 use capsula_core::captured::Captured;
 use capsula_core::error::CapsulaResult;
 use capsula_core::hook::{Hook, PostRun, PreRun, RuntimeParams};
@@ -30,13 +32,13 @@ const MAX_SLACK_ATTACHMENTS: usize = 10;
 pub struct SlackNotifyHookConfig {
     channel: String,
     #[serde(default = "token_from_env")]
-    token: String,
+    token: SecretString,
     #[serde(default)]
     attachment_globs: Vec<String>,
 }
 
-fn token_from_env() -> String {
-    std::env::var("SLACK_BOT_TOKEN").unwrap_or_default()
+fn token_from_env() -> SecretString {
+    SecretString::new(std::env::var("SLACK_BOT_TOKEN").unwrap_or_default())
 }
 
 /// Build Slack Block Kit blocks for a run notification
@@ -546,7 +548,7 @@ impl Hook<PreRun> for SlackNotifyHook {
 
         // Send message with attachments
         let (response, attached_files) = send_slack_message(
-            &self.config.token,
+            self.config.token.expose(),
             &self.config.channel,
             &fallback_text,
             &blocks,
@@ -627,7 +629,7 @@ impl Hook<PostRun> for SlackNotifyHook {
 
         // Send message with attachments
         let (response, attached_files) = send_slack_message(
-            &self.config.token,
+            self.config.token.expose(),
             &self.config.channel,
             &fallback_text,
             &blocks,

--- a/crates/capsula-notify-slack/src/secret.rs
+++ b/crates/capsula-notify-slack/src/secret.rs
@@ -1,0 +1,75 @@
+use serde::{Deserialize, Serialize, Serializer};
+
+/// A string whose value is redacted in `Debug` and `Serialize` output.
+///
+/// Used to hold sensitive values (API tokens, credentials) so they do not
+/// leak into logs, captured hook outputs on disk, or database rows.
+///
+/// Deserialization accepts a plain string so existing config files keep
+/// working. Serialization always emits the literal `"***"` — this means the
+/// hook's `__meta.config` block will carry the placeholder rather than the
+/// real token.
+#[derive(Clone, Default, Deserialize)]
+#[serde(transparent)]
+pub struct SecretString(String);
+
+impl SecretString {
+    pub const fn new(value: String) -> Self {
+        Self(value)
+    }
+
+    pub fn expose(&self) -> &str {
+        &self.0
+    }
+
+    pub const fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl std::fmt::Debug for SecretString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("SecretString(***)")
+    }
+}
+
+impl Serialize for SecretString {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str("***")
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests may use unwrap for brevity")]
+mod tests {
+    use super::SecretString;
+
+    #[test]
+    fn debug_redacts_value() {
+        let s = SecretString::new("xoxb-super-secret".to_owned());
+        let rendered = format!("{s:?}");
+        assert_eq!(rendered, "SecretString(***)");
+        assert!(!rendered.contains("xoxb-super-secret"));
+    }
+
+    #[test]
+    fn serialize_emits_placeholder() {
+        let s = SecretString::new("xoxb-super-secret".to_owned());
+        let json = serde_json::to_string(&s).unwrap();
+        assert_eq!(json, "\"***\"");
+    }
+
+    #[test]
+    fn deserialize_reads_plain_string() {
+        let s: SecretString = serde_json::from_str("\"xoxb-super-secret\"").unwrap();
+        assert_eq!(s.expose(), "xoxb-super-secret");
+    }
+
+    #[test]
+    fn expose_returns_inner_value() {
+        let s = SecretString::new("abc".to_owned());
+        assert_eq!(s.expose(), "abc");
+        assert!(!s.is_empty());
+        assert!(SecretString::default().is_empty());
+    }
+}

--- a/crates/capsula-notify-slack/tests/slack_hook.rs
+++ b/crates/capsula-notify-slack/tests/slack_hook.rs
@@ -27,12 +27,15 @@ fn slack_hook_parses_config() {
             .and_then(|v| v.as_str()),
         Some("#test-channel")
     );
+    // The token is a secret and must be redacted when the config is serialized
+    // (e.g. into the `__meta.config` block of pre-run.json / post-run.json and
+    // into the server's `run_outputs.config` column).
     assert_eq!(
         serde_json::to_value(hook_config)
             .unwrap()
             .get("token")
             .and_then(|v| v.as_str()),
-        Some("xoxb-test-token")
+        Some("***")
     );
 }
 


### PR DESCRIPTION
Introduce a small SecretString newtype whose Debug and Serialize impls
redact the value to `***`. The Slack token now lives in a SecretString,
so the value no longer appears in:
- tracing output that formats the config with {:?}
- the hook's `__meta.config` block in pre-run.json / post-run.json
- the server's run_outputs.config column (which mirrors that JSON)

Deserialize still accepts a plain string so existing config files and
the SLACK_BOT_TOKEN fallback keep working; the real value is reached
only via an explicit `.expose()` call at the single send site.

Update the slack_hook_parses_config test to assert the redaction.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #893 
- <kbd>&nbsp;4&nbsp;</kbd> #892 
- <kbd>&nbsp;3&nbsp;</kbd> #891 
- <kbd>&nbsp;2&nbsp;</kbd> #889 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #890 
<!-- GitButler Footer Boundary Bottom -->

