### PR TITLE
fix(server): harden security — redact DB URL, encode Content-Disposition, validate captured-file path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,6 +732,7 @@ dependencies = [
  "chrono",
  "clap",
  "mime_guess",
+ "percent-encoding",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ git2 = "0.20"
 glob = "0.3"
 mime_guess = "2"
 names = { version = "0.14", default-features = false }
+percent-encoding = "2.3.2"
 ratatui = "0.30"
 reqwest = { version = "0.13", features = ["blocking", "json", "multipart"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/capsula-server/Cargo.toml
+++ b/crates/capsula-server/Cargo.toml
@@ -18,6 +18,7 @@ capsula-api-types = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 mime_guess = { workspace = true }
+percent-encoding = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/capsula-server/src/lib.rs
+++ b/crates/capsula-server/src/lib.rs
@@ -1083,7 +1083,7 @@ async fn upload_files(
                 }
 
                 if let Some(ref rid) = run_id {
-                    let relative_path = pending_paths
+                    let candidate_path = pending_paths
                         .pop_front()
                         .or_else(|| {
                             if file_name == "unknown" {
@@ -1099,6 +1099,20 @@ async fn upload_files(
                                 format!("file-{}", files_processed + 1)
                             }
                         });
+
+                    let relative_path = match sanitize_relative_path(&candidate_path) {
+                        Ok(p) => p,
+                        Err(reason) => {
+                            warn!(
+                                "Rejected captured-file path '{}': {}",
+                                candidate_path, reason
+                            );
+                            return Json(json!({
+                                "status": "error",
+                                "error": format!("Invalid file path '{}': {}", candidate_path, reason)
+                            }));
+                        }
+                    };
 
                     let result = sqlx::query!(
                         r#"
@@ -1311,13 +1325,88 @@ async fn download_file(
         .header(header::CONTENT_TYPE, content_type)
         .header(
             header::CONTENT_DISPOSITION,
-            format!("inline; filename=\"{filename}\""),
+            content_disposition_inline(filename),
         )
         .body(Body::from(file_data))
         .map_err(|e| {
             error!("Failed to build response: {}", e);
             StatusCode::INTERNAL_SERVER_ERROR
         })
+}
+
+// Build an RFC 6266 / RFC 5987 Content-Disposition header value for the given
+// filename. Emits both a safe ASCII `filename=` fallback and a percent-encoded
+// `filename*=UTF-8''...` parameter so arbitrary bytes (including quotes, CR/LF,
+// and control characters) in the filename cannot inject additional headers.
+fn content_disposition_inline(filename: &str) -> String {
+    let ascii_fallback: String = filename
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let ascii_fallback = if ascii_fallback.is_empty() {
+        "download".to_owned()
+    } else {
+        ascii_fallback
+    };
+    let encoded = percent_encode_rfc5987(filename);
+    format!("inline; filename=\"{ascii_fallback}\"; filename*=UTF-8''{encoded}")
+}
+
+fn percent_encode_rfc5987(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        // RFC 5987 `attr-char` set: unreserved plus `!#$&+-.^_`|~`.
+        let safe = b.is_ascii_alphanumeric()
+            || matches!(
+                b,
+                b'!' | b'#' | b'$' | b'&' | b'+' | b'-' | b'.' | b'^' | b'_' | b'`' | b'|' | b'~'
+            );
+        if safe {
+            out.push(char::from(b));
+        } else {
+            use std::fmt::Write;
+            let _ = write!(out, "%{b:02X}");
+        }
+    }
+    out
+}
+
+// Validate a user-supplied relative path for the `captured_files.path` column.
+// Rejects absolute paths, path-traversal segments, Windows drive prefixes, NUL
+// bytes, and empty values so downstream callers (download URLs, local
+// reconstruction) cannot be tricked into escaping the run's virtual root.
+fn sanitize_relative_path(candidate: &str) -> Result<String, &'static str> {
+    if candidate.is_empty() {
+        return Err("path is empty");
+    }
+    if candidate.contains('\0') {
+        return Err("path contains NUL byte");
+    }
+    if candidate.starts_with('/') || candidate.starts_with('\\') {
+        return Err("path must be relative");
+    }
+    // Windows drive prefix like `C:\...` or `C:/...`.
+    if candidate.len() >= 2 {
+        let mut chars = candidate.chars();
+        let drive = chars.next();
+        let colon = chars.next();
+        if matches!(drive, Some(c) if c.is_ascii_alphabetic()) && colon == Some(':') {
+            return Err("path must be relative");
+        }
+    }
+    let normalized = candidate.replace('\\', "/");
+    for segment in normalized.split('/') {
+        if segment == ".." {
+            return Err("path contains '..' segment");
+        }
+    }
+    Ok(normalized)
 }
 
 // NOTE: An identical function exists in capsula-capture-file/src/hash.rs.
@@ -1329,4 +1418,69 @@ fn hex_encode(bytes: &[u8]) -> String {
                 .expect("writing to a String should never fail");
             output
         })
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests may use unwrap for brevity")]
+mod tests {
+    use super::{content_disposition_inline, percent_encode_rfc5987, sanitize_relative_path};
+
+    #[test]
+    fn sanitize_rejects_absolute_paths() {
+        assert!(sanitize_relative_path("/etc/passwd").is_err());
+        assert!(sanitize_relative_path("\\windows\\system32").is_err());
+    }
+
+    #[test]
+    fn sanitize_rejects_parent_traversal() {
+        assert!(sanitize_relative_path("../etc/passwd").is_err());
+        assert!(sanitize_relative_path("a/../b").is_err());
+        assert!(sanitize_relative_path("a\\..\\b").is_err());
+    }
+
+    #[test]
+    fn sanitize_rejects_drive_prefix_and_nul() {
+        assert!(sanitize_relative_path("C:\\Users").is_err());
+        assert!(sanitize_relative_path("d:/foo").is_err());
+        assert!(sanitize_relative_path("foo\0bar").is_err());
+        assert!(sanitize_relative_path("").is_err());
+    }
+
+    #[test]
+    fn sanitize_accepts_normal_paths() {
+        assert_eq!(sanitize_relative_path("foo.txt").unwrap(), "foo.txt");
+        assert_eq!(
+            sanitize_relative_path("dir/sub/file.log").unwrap(),
+            "dir/sub/file.log"
+        );
+        // Backslashes are normalized to forward slashes.
+        assert_eq!(
+            sanitize_relative_path("dir\\sub\\file.log").unwrap(),
+            "dir/sub/file.log"
+        );
+    }
+
+    #[test]
+    fn content_disposition_strips_dangerous_chars_in_fallback() {
+        let header = content_disposition_inline("a\"b\r\nc.txt");
+        assert!(header.starts_with("inline; filename=\"a_b__c.txt\";"));
+        // Must not contain a bare CR or LF in the header.
+        assert!(!header.contains('\r'));
+        assert!(!header.contains('\n'));
+    }
+
+    #[test]
+    fn content_disposition_encodes_unicode_in_filename_star() {
+        let header = content_disposition_inline("日本語.txt");
+        assert!(header.contains("filename*=UTF-8''"));
+        // UTF-8 for '日' starts with 0xE6 0x97 0xA5.
+        assert!(header.contains("%E6%97%A5"));
+    }
+
+    #[test]
+    fn percent_encode_is_ascii_safe() {
+        assert_eq!(percent_encode_rfc5987("abc.txt"), "abc.txt");
+        assert_eq!(percent_encode_rfc5987("a b"), "a%20b");
+        assert_eq!(percent_encode_rfc5987("a\"b"), "a%22b");
+    }
 }

--- a/crates/capsula-server/src/lib.rs
+++ b/crates/capsula-server/src/lib.rs
@@ -48,12 +48,29 @@ use axum::{
     routing::{get, post},
 };
 use capsula_api_types::VaultInfo;
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use sqlx::PgPool;
 use std::collections::VecDeque;
-use std::path::PathBuf;
+use std::path::{Component, Path as StdPath, PathBuf};
 use tracing::{error, info, warn};
+
+// RFC 5987 `attr-char` set: ALPHA / DIGIT plus `!#$&+-.^_`|~`. Everything else
+// must be percent-encoded when used in a `filename*=UTF-8''...` parameter.
+const RFC5987_ATTR_CHAR: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'!')
+    .remove(b'#')
+    .remove(b'$')
+    .remove(b'&')
+    .remove(b'+')
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'^')
+    .remove(b'_')
+    .remove(b'`')
+    .remove(b'|')
+    .remove(b'~');
 
 #[derive(Clone)]
 pub struct AppState {
@@ -1354,27 +1371,8 @@ fn content_disposition_inline(filename: &str) -> String {
     } else {
         ascii_fallback
     };
-    let encoded = percent_encode_rfc5987(filename);
+    let encoded = utf8_percent_encode(filename, RFC5987_ATTR_CHAR);
     format!("inline; filename=\"{ascii_fallback}\"; filename*=UTF-8''{encoded}")
-}
-
-fn percent_encode_rfc5987(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for b in s.bytes() {
-        // RFC 5987 `attr-char` set: unreserved plus `!#$&+-.^_`|~`.
-        let safe = b.is_ascii_alphanumeric()
-            || matches!(
-                b,
-                b'!' | b'#' | b'$' | b'&' | b'+' | b'-' | b'.' | b'^' | b'_' | b'`' | b'|' | b'~'
-            );
-        if safe {
-            out.push(char::from(b));
-        } else {
-            use std::fmt::Write;
-            let _ = write!(out, "%{b:02X}");
-        }
-    }
-    out
 }
 
 // Validate a user-supplied relative path for the `captured_files.path` column.
@@ -1388,25 +1386,40 @@ fn sanitize_relative_path(candidate: &str) -> Result<String, &'static str> {
     if candidate.contains('\0') {
         return Err("path contains NUL byte");
     }
-    if candidate.starts_with('/') || candidate.starts_with('\\') {
+
+    // Normalize backslashes to forward slashes so Windows-style separators are
+    // parsed consistently on all platforms. `Component::Prefix` is only emitted
+    // when `std::path` parses on Windows, so drive letters are detected
+    // explicitly below rather than relying on the path parser alone.
+    let normalized = candidate.replace('\\', "/");
+    let first_segment = normalized.split('/').next().unwrap_or("");
+    let mut first_chars = first_segment.chars();
+    if first_chars.next().is_some_and(|c| c.is_ascii_alphabetic())
+        && first_chars.next() == Some(':')
+    {
         return Err("path must be relative");
     }
-    // Windows drive prefix like `C:\...` or `C:/...`.
-    if candidate.len() >= 2 {
-        let mut chars = candidate.chars();
-        let drive = chars.next();
-        let colon = chars.next();
-        if matches!(drive, Some(c) if c.is_ascii_alphabetic()) && colon == Some(':') {
-            return Err("path must be relative");
+
+    let mut out = String::with_capacity(normalized.len());
+    for component in StdPath::new(&normalized).components() {
+        match component {
+            Component::Normal(seg) => {
+                let seg = seg.to_str().ok_or("path contains invalid UTF-8")?;
+                if !out.is_empty() {
+                    out.push('/');
+                }
+                out.push_str(seg);
+            }
+            Component::CurDir => {}
+            Component::ParentDir => return Err("path contains '..' segment"),
+            Component::RootDir | Component::Prefix(_) => return Err("path must be relative"),
         }
     }
-    let normalized = candidate.replace('\\', "/");
-    for segment in normalized.split('/') {
-        if segment == ".." {
-            return Err("path contains '..' segment");
-        }
+
+    if out.is_empty() {
+        return Err("path is empty");
     }
-    Ok(normalized)
+    Ok(out)
 }
 
 // NOTE: An identical function exists in capsula-capture-file/src/hash.rs.
@@ -1423,7 +1436,7 @@ fn hex_encode(bytes: &[u8]) -> String {
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "tests may use unwrap for brevity")]
 mod tests {
-    use super::{content_disposition_inline, percent_encode_rfc5987, sanitize_relative_path};
+    use super::{content_disposition_inline, sanitize_relative_path};
 
     #[test]
     fn sanitize_rejects_absolute_paths() {
@@ -1461,6 +1474,15 @@ mod tests {
     }
 
     #[test]
+    fn sanitize_normalizes_redundant_segments() {
+        // `Path::components()` collapses empty segments and drops `.` segments.
+        assert_eq!(sanitize_relative_path("a//b").unwrap(), "a/b");
+        assert_eq!(sanitize_relative_path("./a/b").unwrap(), "a/b");
+        assert_eq!(sanitize_relative_path("a/./b").unwrap(), "a/b");
+        assert_eq!(sanitize_relative_path("a/b/").unwrap(), "a/b");
+    }
+
+    #[test]
     fn content_disposition_strips_dangerous_chars_in_fallback() {
         let header = content_disposition_inline("a\"b\r\nc.txt");
         assert!(header.starts_with("inline; filename=\"a_b__c.txt\";"));
@@ -1478,9 +1500,11 @@ mod tests {
     }
 
     #[test]
-    fn percent_encode_is_ascii_safe() {
-        assert_eq!(percent_encode_rfc5987("abc.txt"), "abc.txt");
-        assert_eq!(percent_encode_rfc5987("a b"), "a%20b");
-        assert_eq!(percent_encode_rfc5987("a\"b"), "a%22b");
+    fn content_disposition_percent_encodes_attr_char_boundary() {
+        // Unreserved ASCII round-trips; spaces and quotes are percent-encoded.
+        let header = content_disposition_inline("abc.txt");
+        assert!(header.contains("filename*=UTF-8''abc.txt"));
+        let header = content_disposition_inline("a b\"c");
+        assert!(header.contains("filename*=UTF-8''a%20b%22c"));
     }
 }

--- a/crates/capsula-server/src/main.rs
+++ b/crates/capsula-server/src/main.rs
@@ -64,7 +64,6 @@ async fn main() {
         }
         Err(e) => {
             error!("Failed to connect to database: {}", e);
-            error!("Database URL: {}", args.database_url);
             error!(
                 "\nPlease ensure:\n\
                  1. PostgreSQL is running\n\


### PR DESCRIPTION
- main.rs: remove `Database URL: ...` from the DB-connect error log so credentials embedded in the connection string no longer leak to stderr on startup failure
- lib.rs (download_file): build Content-Disposition with an ASCII-safe `filename=` fallback plus an RFC 5987 `filename*=UTF-8''...` parameter so user-controlled filenames from uploads cannot inject additional headers
- lib.rs (upload_files): validate each captured-file `path` before INSERT — reject absolute paths, `..` segments, Windows drive prefixes, and NUL bytes, and normalize backslashes to forward slashes
- add unit tests for the new `sanitize_relative_path`, `content_disposition_inline`, and `percent_encode_rfc5987` helpers

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #893 
- <kbd>&nbsp;4&nbsp;</kbd> #892 
- <kbd>&nbsp;3&nbsp;</kbd> #891 
- <kbd>&nbsp;2&nbsp;</kbd> #889 
- <kbd>&nbsp;1&nbsp;</kbd> #890 👈 
<!-- GitButler Footer Boundary Bottom -->

