### PR TITLE
refactor(core): share helpers across crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,6 +729,7 @@ dependencies = [
  "askama_web",
  "axum",
  "capsula-api-types",
+ "capsula-core",
  "chrono",
  "clap",
  "mime_guess",

--- a/crates/capsula-capture-command/src/lib.rs
+++ b/crates/capsula-capture-command/src/lib.rs
@@ -48,8 +48,7 @@ where
         let config: CommandHookConfig = serde_json::from_value(config.clone())?;
 
         let working_dir = match &config.cwd {
-            Some(cwd) if cwd.is_absolute() => cwd.clone(),
-            Some(cwd) => project_root.join(cwd).canonicalize()?,
+            Some(cwd) => capsula_core::util::resolve_relative(cwd, project_root)?,
             None => project_root.to_path_buf(),
         };
 

--- a/crates/capsula-capture-file/src/hash.rs
+++ b/crates/capsula-capture-file/src/hash.rs
@@ -1,3 +1,4 @@
+use capsula_core::util::hex_encode;
 use sha2::Digest;
 use sha2::Sha256;
 use std::fs::File;
@@ -19,15 +20,4 @@ pub fn file_digest_sha256(path: impl AsRef<Path>) -> std::io::Result<String> {
     }
 
     Ok(hex_encode(hasher.finalize().as_ref()))
-}
-
-// NOTE: An identical function exists in capsula-server/src/lib.rs.
-fn hex_encode(bytes: &[u8]) -> String {
-    bytes
-        .iter()
-        .fold(String::with_capacity(bytes.len() * 2), |mut output, b| {
-            std::fmt::Write::write_fmt(&mut output, format_args!("{b:02x}"))
-                .expect("writing to a String should never fail");
-            output
-        })
 }

--- a/crates/capsula-capture-git-repo/src/lib.rs
+++ b/crates/capsula-capture-git-repo/src/lib.rs
@@ -78,11 +78,7 @@ where
             }
         })?;
 
-        let working_dir = if config.path.is_absolute() {
-            config.path.clone()
-        } else {
-            project_root.join(&config.path).canonicalize()?
-        };
+        let working_dir = capsula_core::util::resolve_relative(&config.path, project_root)?;
 
         Ok(Self {
             config,

--- a/crates/capsula-cli/src/main.rs
+++ b/crates/capsula-cli/src/main.rs
@@ -195,11 +195,7 @@ path = \".\"
             let capsula_dir = run_dir.join("_capsula");
 
             // Read metadata (always required)
-            let metadata_path = capsula_dir.join("metadata.json");
-            let metadata: serde_json::Value = serde_json::from_str(
-                &std::fs::read_to_string(&metadata_path)
-                    .with_context(|| format!("Failed to read {}", metadata_path.display()))?,
-            )?;
+            let metadata = capsula_orchestration::vault::read_run_metadata_json(&run_dir)?;
 
             // Read optional files
             let pre_run = read_json_if_exists(&capsula_dir.join("pre-run.json"))?;
@@ -364,14 +360,7 @@ path = \".\"
                 );
             }
 
-            let metadata_path = capsula_dir.join("metadata.json");
-            let metadata_content = std::fs::read_to_string(&metadata_path).with_context(|| {
-                format!("Failed to read metadata from {}", metadata_path.display())
-            })?;
-            let metadata: capsula_orchestration::vault::RunMetadata =
-                serde_json::from_str(&metadata_content).with_context(|| {
-                    format!("Failed to parse metadata from {}", metadata_path.display())
-                })?;
+            let metadata = capsula_orchestration::vault::read_run_metadata(&run_dir)?;
 
             let run = Run {
                 id: metadata.id,

--- a/crates/capsula-core/src/lib.rs
+++ b/crates/capsula-core/src/lib.rs
@@ -2,3 +2,4 @@ pub mod captured;
 pub mod error;
 pub mod hook;
 pub mod run;
+pub mod util;

--- a/crates/capsula-core/src/util.rs
+++ b/crates/capsula-core/src/util.rs
@@ -1,0 +1,62 @@
+//! Small pure-helper utilities shared across Capsula crates.
+
+use std::path::{Path, PathBuf};
+
+/// Encode bytes as a lowercase hexadecimal string.
+#[must_use]
+pub fn hex_encode(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .fold(String::with_capacity(bytes.len() * 2), |mut output, b| {
+            use std::fmt::Write;
+            let _ = write!(output, "{b:02x}");
+            output
+        })
+}
+
+/// Resolve a path that may be absolute or relative to `project_root`.
+///
+/// For absolute paths, returns a clone. For relative paths, joins against
+/// `project_root` and canonicalizes (which requires the path to exist).
+pub fn resolve_relative(path: &Path, project_root: &Path) -> std::io::Result<PathBuf> {
+    if path.is_absolute() {
+        Ok(path.to_path_buf())
+    } else {
+        project_root.join(path).canonicalize()
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests may use unwrap for brevity")]
+mod tests {
+    use super::{hex_encode, resolve_relative};
+    use std::path::Path;
+
+    #[test]
+    fn hex_encode_empty() {
+        assert_eq!(hex_encode(&[]), "");
+    }
+
+    #[test]
+    fn hex_encode_single_bytes() {
+        assert_eq!(hex_encode(&[0x00]), "00");
+        assert_eq!(hex_encode(&[0xff]), "ff");
+        assert_eq!(hex_encode(&[0xab, 0xcd, 0xef]), "abcdef");
+    }
+
+    #[test]
+    fn resolve_relative_passes_absolute_through() {
+        let abs = Path::new("/does/not/exist/absolute");
+        let resolved = resolve_relative(abs, Path::new("/tmp")).unwrap();
+        assert_eq!(resolved, abs);
+    }
+
+    #[test]
+    fn resolve_relative_joins_relative_and_canonicalizes() {
+        // project_root = cwd so canonicalize can resolve it.
+        let cwd = std::env::current_dir().unwrap();
+        let resolved = resolve_relative(Path::new("."), &cwd).unwrap();
+        // canonicalize resolves symlinks; on macOS this is /private/var/... etc.
+        assert_eq!(resolved, cwd.canonicalize().unwrap());
+    }
+}

--- a/crates/capsula-orchestration/src/push.rs
+++ b/crates/capsula-orchestration/src/push.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use std::path::Path;
 use tracing::{debug, info};
 
@@ -12,10 +12,7 @@ pub fn push_single_run(
     let capsula_dir = run_dir.join("_capsula");
 
     // Read metadata
-    let metadata_path = capsula_dir.join("metadata.json");
-    let metadata_content = std::fs::read_to_string(&metadata_path)
-        .with_context(|| format!("Failed to read metadata from {}", metadata_path.display()))?;
-    let metadata: serde_json::Value = serde_json::from_str(&metadata_content)?;
+    let metadata = crate::vault::read_run_metadata_json(run_dir)?;
 
     let run_name = metadata["name"].as_str().unwrap_or("unknown");
     info!("Pushing run: {}", run_name);

--- a/crates/capsula-orchestration/src/vault.rs
+++ b/crates/capsula-orchestration/src/vault.rs
@@ -14,6 +14,27 @@ pub struct RunMetadata {
     pub timestamp: String,
 }
 
+/// Read and parse `{run_dir}/_capsula/metadata.json`.
+pub fn read_run_metadata(run_dir: &Path) -> Result<RunMetadata> {
+    let metadata_path = run_dir.join("_capsula").join("metadata.json");
+    let content = std::fs::read_to_string(&metadata_path)
+        .with_context(|| format!("Failed to read metadata from {}", metadata_path.display()))?;
+    serde_json::from_str::<RunMetadata>(&content)
+        .with_context(|| format!("Failed to parse metadata from {}", metadata_path.display()))
+}
+
+/// Read and parse `{run_dir}/_capsula/metadata.json` as raw JSON.
+///
+/// Used by callers (e.g. the CLI `show` command) that consume metadata
+/// fields beyond the structured [`RunMetadata`] struct.
+pub fn read_run_metadata_json(run_dir: &Path) -> Result<serde_json::Value> {
+    let metadata_path = run_dir.join("_capsula").join("metadata.json");
+    let content = std::fs::read_to_string(&metadata_path)
+        .with_context(|| format!("Failed to read metadata from {}", metadata_path.display()))?;
+    serde_json::from_str::<serde_json::Value>(&content)
+        .with_context(|| format!("Failed to parse metadata from {}", metadata_path.display()))
+}
+
 /// List all runs in a vault directory, sorted by timestamp (newest first).
 pub fn list_runs(vault_dir: &Path) -> Result<Vec<RunMetadata>> {
     let mut runs = Vec::new();

--- a/crates/capsula-server/Cargo.toml
+++ b/crates/capsula-server/Cargo.toml
@@ -15,6 +15,7 @@ askama = { workspace = true }
 askama_web = { workspace = true }
 axum = { workspace = true }
 capsula-api-types = { workspace = true }
+capsula-core = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 mime_guess = { workspace = true }

--- a/crates/capsula-server/src/lib.rs
+++ b/crates/capsula-server/src/lib.rs
@@ -48,6 +48,7 @@ use axum::{
     routing::{get, post},
 };
 use capsula_api_types::VaultInfo;
+use capsula_core::util::hex_encode;
 use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -1420,17 +1421,6 @@ fn sanitize_relative_path(candidate: &str) -> Result<String, &'static str> {
         return Err("path is empty");
     }
     Ok(out)
-}
-
-// NOTE: An identical function exists in capsula-capture-file/src/hash.rs.
-fn hex_encode(bytes: &[u8]) -> String {
-    bytes
-        .iter()
-        .fold(String::with_capacity(bytes.len() * 2), |mut output, b| {
-            std::fmt::Write::write_fmt(&mut output, format_args!("{b:02x}"))
-                .expect("writing to a String should never fail");
-            output
-        })
 }
 
 #[cfg(test)]

--- a/crates/capsula-tui/src/app.rs
+++ b/crates/capsula-tui/src/app.rs
@@ -5,7 +5,7 @@ use capsula_core::hook::{PostRun, PreRun};
 use capsula_core::run::Run;
 use capsula_orchestration::run::{create_and_setup_run, run_post_hooks, run_pre_hooks};
 use capsula_orchestration::setup::LoadedConfig;
-use capsula_orchestration::vault::{RunMetadata, find_run_dir_by_name};
+use capsula_orchestration::vault::find_run_dir_by_name;
 use ratatui::layout::Rect;
 use tracing::info;
 
@@ -195,9 +195,7 @@ impl App {
         let run_dir = find_run_dir_by_name(&self.config.vault_dir, &active.run_name)?;
         let capsula_dir = run_dir.join("_capsula");
 
-        let metadata_path = capsula_dir.join("metadata.json");
-        let metadata_content = std::fs::read_to_string(&metadata_path)?;
-        let metadata: RunMetadata = serde_json::from_str(&metadata_content)?;
+        let metadata = capsula_orchestration::vault::read_run_metadata(&run_dir)?;
 
         let run = Run {
             id: metadata.id,


### PR DESCRIPTION
Extract three cross-crate utilities so identical copies can be deleted:

- `capsula_core::util::hex_encode`: was duplicated in
  capsula-capture-file/src/hash.rs and capsula-server/src/lib.rs.
  Both call sites now import the core version; the marker comment
  ("An identical function exists in ...") goes away.
- `capsula_core::util::resolve_relative`: was duplicated in
  capsula-capture-command (for `cwd`) and capsula-capture-git-repo
  (for `path`); both now call the shared helper.
- `capsula_orchestration::vault::read_run_metadata` and
  `read_run_metadata_json`: centralize the
  read-file-then-serde_json::from_str pattern for
  `_capsula/metadata.json`, previously written four times with
  slightly different error contexts across the CLI, push, and TUI.

Adds capsula-core as a dep of capsula-server; the new util module
carries unit tests for both helpers.

<!-- GitButler Footer Boundary Top -->
---
This is **part 5 of 6 in a stack** made with GitButler:
- <kbd>&nbsp;6&nbsp;</kbd> #894 
- <kbd>&nbsp;5&nbsp;</kbd> #893 👈 
- <kbd>&nbsp;4&nbsp;</kbd> #892 
- <kbd>&nbsp;3&nbsp;</kbd> #891 
- <kbd>&nbsp;2&nbsp;</kbd> #889 
- <kbd>&nbsp;1&nbsp;</kbd> #890 
<!-- GitButler Footer Boundary Bottom -->

