### PR TITLE
fix: replace framework-invariant panics with error values

### DIFF
--- a/crates/capsula-capture-file/src/error.rs
+++ b/crates/capsula-capture-file/src/error.rs
@@ -27,6 +27,9 @@ pub enum FileHookError {
     #[error("Invalid run directory: {path}")]
     InvalidRunDir { path: PathBuf },
 
+    #[error("capture-file hook requires an artifact directory but none was provided")]
+    ArtifactDirMissing,
+
     /// Failed to read file
     #[error("Failed to read file {path}: {source}")]
     ReadError {

--- a/crates/capsula-capture-file/src/lib.rs
+++ b/crates/capsula-capture-file/src/lib.rs
@@ -90,7 +90,7 @@ where
         let artifact_dir = params
             .artifact_dir
             .as_deref()
-            .expect("capture-file hook requires an artifact directory");
+            .ok_or(FileHookError::ArtifactDirMissing)?;
         self.run(metadata, artifact_dir).map_err(CapsulaError::from)
     }
 

--- a/crates/capsula-capture-git-repo/src/error.rs
+++ b/crates/capsula-capture-git-repo/src/error.rs
@@ -23,6 +23,9 @@ pub enum GitHookError {
     #[error("Run directory not specified and current directory could not be determined: {message}")]
     RunDirNotSpecified { message: String },
 
+    #[error("capture-git-repo hook requires an artifact directory but none was provided")]
+    ArtifactDirMissing,
+
     #[error("I/O error: {0}")]
     IoError(#[from] std::io::Error),
 }

--- a/crates/capsula-capture-git-repo/src/lib.rs
+++ b/crates/capsula-capture-git-repo/src/lib.rs
@@ -147,7 +147,7 @@ where
             let artifact_dir = params
                 .artifact_dir
                 .as_deref()
-                .expect("capture-git-repo hook requires an artifact directory");
+                .ok_or(GitHookError::ArtifactDirMissing)?;
             let diff_content = Self::diff_content(&repo)?;
             // Output to a patch file in the artifact directory
             let patch_file_path = artifact_dir.join(format!("{}.patch", self.config.name));

--- a/crates/capsula-server/src/lib.rs
+++ b/crates/capsula-server/src/lib.rs
@@ -157,6 +157,23 @@ async fn serve_style_css() -> impl IntoResponse {
     )
 }
 
+/// Serialize a handler's response body into a `Json<Value>`, falling back to an
+/// error envelope if `serde_json::to_value` fails instead of panicking.
+///
+/// In practice `to_value` does not fail for any of our `#[derive(Serialize)]`
+/// API response structs, but axum handlers should not abort the task on a
+/// should-be-impossible error — they should return a 500 body the client can
+/// parse.
+fn json_response<T: serde::Serialize>(value: T) -> Json<serde_json::Value> {
+    Json(serde_json::to_value(value).unwrap_or_else(|e| {
+        error!("Failed to serialize response body: {e}");
+        json!({
+            "status": "error",
+            "error": "response serialization failed"
+        })
+    }))
+}
+
 async fn index() -> impl IntoResponse {
     IndexTemplate
 }
@@ -451,7 +468,7 @@ async fn list_vaults(State(state): State<AppState>) -> impl IntoResponse {
                 status: "ok".to_string(),
                 vaults,
             };
-            Json(serde_json::to_value(response).expect("Failed to serialize VaultsResponse"))
+            json_response(response)
         }
         Err(e) => {
             error!("Failed to list vaults: {}", e);
@@ -459,7 +476,7 @@ async fn list_vaults(State(state): State<AppState>) -> impl IntoResponse {
                 status: "error".to_string(),
                 error: e.to_string(),
             };
-            Json(serde_json::to_value(response).expect("Failed to serialize ErrorResponse"))
+            json_response(response)
         }
     }
 }
@@ -494,7 +511,7 @@ async fn get_vault_info(
                 exists: true,
                 vault: Some(vault),
             };
-            Json(serde_json::to_value(response).expect("Failed to serialize VaultExistsResponse"))
+            json_response(response)
         }
         Ok(None) => {
             info!("Vault not found: {}", name);
@@ -503,7 +520,7 @@ async fn get_vault_info(
                 exists: false,
                 vault: None,
             };
-            Json(serde_json::to_value(response).expect("Failed to serialize VaultExistsResponse"))
+            json_response(response)
         }
         Err(e) => {
             error!("Failed to get vault info: {}", e);
@@ -511,7 +528,7 @@ async fn get_vault_info(
                 status: "error".to_string(),
                 error: e.to_string(),
             };
-            Json(serde_json::to_value(response).expect("Failed to serialize ErrorResponse"))
+            json_response(response)
         }
     }
 }
@@ -770,7 +787,7 @@ async fn search_runs(
         runs: results,
     };
 
-    Json(serde_json::to_value(response).expect("Failed to serialize SearchRunsResponse"))
+    json_response(response)
 }
 
 async fn create_run(
@@ -1278,7 +1295,7 @@ async fn upload_files(
         pre_run_hooks: pre_run_count,
         post_run_hooks: post_run_count,
     };
-    Json(serde_json::to_value(response).expect("Failed to serialize UploadResponse"))
+    json_response(response)
 }
 
 async fn download_file(


### PR DESCRIPTION
Two classes of `.expect()` replaced by proper error paths:

1. Hooks that declare `needs_artifact_dir()` used to `.expect()` on
   `RuntimeParams.artifact_dir`. A framework bug (hook declares it
   needs an artifact dir but orchestration fails to allocate one) now
   surfaces as a typed hook error instead of a process abort. Adds
   `FileHookError::ArtifactDirMissing` and
   `GitHookError::ArtifactDirMissing`.

2. Seven axum handlers in capsula-server called
   `serde_json::to_value(response).expect(...)`. On the should-be-
   impossible failure path, axum would abort the task and return a
   generic 500 with no body. Introduce `json_response(value)` which
   logs the serialization error and falls back to
   `{"status": "error", "error": "response serialization
   failed"}` — the client still gets a parseable body.

<!-- GitButler Footer Boundary Top -->
---
This is **part 6 of 6 in a stack** made with GitButler:
- <kbd>&nbsp;6&nbsp;</kbd> #894 👈 
- <kbd>&nbsp;5&nbsp;</kbd> #893 
- <kbd>&nbsp;4&nbsp;</kbd> #892 
- <kbd>&nbsp;3&nbsp;</kbd> #891 
- <kbd>&nbsp;2&nbsp;</kbd> #889 
- <kbd>&nbsp;1&nbsp;</kbd> #890 
<!-- GitButler Footer Boundary Bottom -->

