### PR TITLE
fix: correctness and polish across crates

### DIFF
--- a/crates/capsula-api-types/src/lib.rs
+++ b/crates/capsula-api-types/src/lib.rs
@@ -20,7 +20,7 @@ pub struct VaultsResponse {
 }
 
 /// Response from the vault exists endpoint
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct VaultExistsResponse {
     pub status: String,
     pub exists: bool,

--- a/crates/capsula-capture-git-repo/src/lib.rs
+++ b/crates/capsula-capture-git-repo/src/lib.rs
@@ -72,11 +72,7 @@ where
         config: &serde_json::Value,
         project_root: &std::path::Path,
     ) -> CapsulaResult<Self> {
-        let config: GitHookConfig = serde_json::from_value(config.clone()).map_err(|e| {
-            capsula_core::error::CapsulaError::Configuration {
-                message: format!("Invalid git hook configuration: {e}"),
-            }
-        })?;
+        let config: GitHookConfig = serde_json::from_value(config.clone())?;
 
         let working_dir = capsula_core::util::resolve_relative(&config.path, project_root)?;
 
@@ -229,7 +225,9 @@ impl GitHook {
 
         let mut diff_content = String::new();
         diff.print(git2::DiffFormat::Patch, |_, _, line| {
-            diff_content.push_str(std::str::from_utf8(line.content()).unwrap_or(""));
+            // Non-UTF-8 bytes (e.g. binary blobs in a diff) become
+            // replacement characters rather than being silently dropped.
+            diff_content.push_str(&String::from_utf8_lossy(line.content()));
             true
         })
         .map_err(GitHookError::from)?;

--- a/crates/capsula-orchestration/src/vault.rs
+++ b/crates/capsula-orchestration/src/vault.rs
@@ -103,6 +103,26 @@ pub fn list_runs(vault_dir: &Path) -> Result<Vec<RunMetadata>> {
     Ok(runs)
 }
 
+/// Assert that `run_dir` is a descendant of `vault_dir` once both have been
+/// resolved through symlinks. Defends against a metadata file that names a
+/// run outside of its parent vault.
+fn ensure_within_vault(run_dir: &Path, vault_dir: &Path) -> Result<PathBuf> {
+    let canonical_vault = vault_dir
+        .canonicalize()
+        .with_context(|| format!("Failed to canonicalize vault {}", vault_dir.display()))?;
+    let canonical_run = run_dir
+        .canonicalize()
+        .with_context(|| format!("Failed to canonicalize run dir {}", run_dir.display()))?;
+    if !canonical_run.starts_with(&canonical_vault) {
+        anyhow::bail!(
+            "Run directory {} is outside vault {}",
+            canonical_run.display(),
+            canonical_vault.display()
+        );
+    }
+    Ok(run_dir.to_path_buf())
+}
+
 /// Find a run directory by ID or name.
 pub fn find_run_dir(vault_dir: &Path, run_id: &str) -> Result<PathBuf> {
     for entry in walkdir::WalkDir::new(vault_dir)
@@ -128,13 +148,13 @@ pub fn find_run_dir(vault_dir: &Path, run_id: &str) -> Result<PathBuf> {
         if let Some(id) = metadata.get("id").and_then(|v| v.as_str())
             && id == run_id
         {
-            return Ok(entry.path().to_path_buf());
+            return ensure_within_vault(entry.path(), vault_dir);
         }
 
         if let Some(name) = metadata.get("name").and_then(|v| v.as_str())
             && name == run_id
         {
-            return Ok(entry.path().to_path_buf());
+            return ensure_within_vault(entry.path(), vault_dir);
         }
     }
 
@@ -200,7 +220,7 @@ pub fn find_run_dir_by_name(vault_dir: &Path, run_name: &str) -> Result<PathBuf>
                 match_count, run_name
             );
         }
-        return Ok(path);
+        return ensure_within_vault(&path, vault_dir);
     }
 
     anyhow::bail!(


### PR DESCRIPTION
- capsula-capture-git-repo: replace `from_utf8(...).unwrap_or("")`
  in diff extraction with `String::from_utf8_lossy` so binary diff
  chunks render as replacement characters instead of being silently
  dropped.
- capsula-capture-git-repo: drop the manual `serde_json::Error` →
  `CapsulaError::Configuration` wrapper in `from_config` in favor
  of the `?` operator; the blanket `From` in capsula-core already
  produces an appropriate error.
- capsula-orchestration::vault: add `ensure_within_vault` and call
  it from both `find_run_dir` and `find_run_dir_by_name` so a
  metadata file pointing at a path outside its parent vault (via
  symlinks or similar) is rejected rather than silently returned.
- capsula-api-types: derive `Eq` on `VaultExistsResponse` (its
  fields already all implement Eq); brings it in line with the other
  response types.