### PR TITLE
refactor(tui): make ui::draw pure by returning hit-test rects

### DIFF
--- a/crates/capsula-tui/src/app.rs
+++ b/crates/capsula-tui/src/app.rs
@@ -17,6 +17,18 @@ pub enum FocusTarget {
     EndButton,
 }
 
+/// Cache of the rectangles that `ui::draw` laid out during the most recent
+/// render. The event handler uses these for mouse hit-testing. `draw` returns
+/// a fresh `HitAreas` each frame instead of mutating [`App`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct HitAreas {
+    pub start_button: Option<Rect>,
+    pub end_button: Option<Rect>,
+    pub checkbox: Option<Rect>,
+    pub confirm_yes: Option<Rect>,
+    pub confirm_no: Option<Rect>,
+}
+
 /// Active run information displayed in the TUI.
 pub struct ActiveRun {
     pub run_name: String,
@@ -50,12 +62,9 @@ pub struct App {
     pre_run_registry: capsula_registry::HookRegistry<PreRun>,
     post_run_registry: capsula_registry::HookRegistry<PostRun>,
 
-    // Clickable areas for mouse support (set during rendering)
-    pub start_button_area: Option<Rect>,
-    pub end_button_area: Option<Rect>,
-    pub checkbox_area: Option<Rect>,
-    pub confirm_yes_area: Option<Rect>,
-    pub confirm_no_area: Option<Rect>,
+    /// Clickable areas from the most recent render. Updated by the main loop
+    /// after `ui::draw` returns; read by the mouse event handler for hit-testing.
+    pub hit_areas: HitAreas,
 }
 
 impl App {
@@ -73,11 +82,7 @@ impl App {
             last_completed_run: None,
             pre_run_registry: capsula_registry::standard_pre_run_hook_registry(),
             post_run_registry: capsula_registry::standard_post_run_hook_registry(),
-            start_button_area: None,
-            end_button_area: None,
-            checkbox_area: None,
-            confirm_yes_area: None,
-            confirm_no_area: None,
+            hit_areas: HitAreas::default(),
         }
     }
 

--- a/crates/capsula-tui/src/lib.rs
+++ b/crates/capsula-tui/src/lib.rs
@@ -60,9 +60,11 @@ pub fn run(config_path: &Path, vault_path_override: Option<PathBuf>) -> Result<(
 
 fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App) -> Result<()> {
     loop {
+        let mut hit_areas = app.hit_areas;
         terminal
-            .draw(|frame| ui::draw(frame, app))
+            .draw(|frame| hit_areas = ui::draw(frame, app))
             .context("Failed to draw frame")?;
+        app.hit_areas = hit_areas;
 
         // Execute pending actions after the redraw so the status message is visible
         if app.pending_action.is_some() {
@@ -113,13 +115,13 @@ fn handle_mouse(app: &mut App, mouse: crossterm::event::MouseEvent) {
 
     // In confirm-quit mode, only handle yes/no clicks
     if app.confirm_quit {
-        if let Some(area) = app.confirm_yes_area
+        if let Some(area) = app.hit_areas.confirm_yes
             && hit_test(x, y, area)
         {
             app.confirm_quit();
             return;
         }
-        if let Some(area) = app.confirm_no_area
+        if let Some(area) = app.hit_areas.confirm_no
             && hit_test(x, y, area)
         {
             app.cancel_quit();
@@ -129,19 +131,19 @@ fn handle_mouse(app: &mut App, mouse: crossterm::event::MouseEvent) {
 
     // Check interactive widgets
     if app.is_running() {
-        if let Some(area) = app.end_button_area
+        if let Some(area) = app.hit_areas.end_button
             && hit_test(x, y, area)
         {
             app.request_end_run();
         }
     } else {
-        if let Some(area) = app.start_button_area
+        if let Some(area) = app.hit_areas.start_button
             && hit_test(x, y, area)
         {
             app.request_start_run();
             return;
         }
-        if let Some(area) = app.checkbox_area
+        if let Some(area) = app.hit_areas.checkbox
             && hit_test(x, y, area)
         {
             app.toggle_instant_run();

--- a/crates/capsula-tui/src/ui.rs
+++ b/crates/capsula-tui/src/ui.rs
@@ -4,11 +4,12 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 
-use crate::app::{App, FocusTarget};
+use crate::app::{App, FocusTarget, HitAreas};
 use crate::widgets::{render_button, render_checkbox};
 
-pub fn draw(frame: &mut Frame, app: &mut App) {
+pub fn draw(frame: &mut Frame, app: &App) -> HitAreas {
     let area = frame.area();
+    let mut hit = HitAreas::default();
 
     // Outer frame
     let outer_block = Block::default()
@@ -21,9 +22,9 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     let inner = area.inner(Margin::new(2, 1));
 
     if app.is_running() {
-        draw_active_state(frame, inner, app);
+        draw_active_state(frame, inner, app, &mut hit);
     } else {
-        draw_idle_state(frame, inner, app);
+        draw_idle_state(frame, inner, app, &mut hit);
     }
 
     // Status message (shown during hook execution)
@@ -46,11 +47,13 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
 
     // Confirm quit overlay
     if app.confirm_quit {
-        draw_confirm_quit(frame, area, app);
+        draw_confirm_quit(frame, area, &mut hit);
     }
+
+    hit
 }
 
-fn draw_idle_state(frame: &mut Frame, area: Rect, app: &mut App) {
+fn draw_idle_state(frame: &mut Frame, area: Rect, app: &App, hit: &mut HitAreas) {
     let chunks = Layout::vertical([
         Constraint::Length(3), // Vault info
         Constraint::Length(1), // Spacing
@@ -65,7 +68,7 @@ fn draw_idle_state(frame: &mut Frame, area: Rect, app: &mut App) {
 
     // Instant run checkbox
     let checkbox_area = Rect::new(chunks[2].x, chunks[2].y, chunks[2].width.min(30), 1);
-    app.checkbox_area = Some(render_checkbox(
+    hit.checkbox = Some(render_checkbox(
         frame,
         checkbox_area,
         "Instant run",
@@ -77,7 +80,7 @@ fn draw_idle_state(frame: &mut Frame, area: Rect, app: &mut App) {
     let button_width = area.width.min(30);
     let button_x = area.x + (area.width.saturating_sub(button_width)) / 2;
     let button_area = Rect::new(button_x, chunks[4].y, button_width, 3);
-    app.start_button_area = Some(render_button(
+    hit.start_button = Some(render_button(
         frame,
         button_area,
         "Start Run",
@@ -86,7 +89,7 @@ fn draw_idle_state(frame: &mut Frame, area: Rect, app: &mut App) {
     ));
 }
 
-fn draw_active_state(frame: &mut Frame, area: Rect, app: &mut App) {
+fn draw_active_state(frame: &mut Frame, area: Rect, app: &App, hit: &mut HitAreas) {
     let chunks = Layout::vertical([
         Constraint::Length(3), // Vault info
         Constraint::Length(1), // Spacing
@@ -136,7 +139,7 @@ fn draw_active_state(frame: &mut Frame, area: Rect, app: &mut App) {
     let button_width = area.width.min(30);
     let button_x = area.x + (area.width.saturating_sub(button_width)) / 2;
     let button_area = Rect::new(button_x, chunks[4].y, button_width, 3);
-    app.end_button_area = Some(render_button(
+    hit.end_button = Some(render_button(
         frame,
         button_area,
         "End Run",
@@ -260,7 +263,7 @@ fn draw_footer(frame: &mut Frame, area: Rect) {
     frame.render_widget(footer, footer_area);
 }
 
-fn draw_confirm_quit(frame: &mut Frame, area: Rect, app: &mut App) {
+fn draw_confirm_quit(frame: &mut Frame, area: Rect, hit: &mut HitAreas) {
     let popup_width = 46_u16;
     let popup_height = 7_u16;
     let popup_x = area.x + (area.width.saturating_sub(popup_width)) / 2;
@@ -323,6 +326,6 @@ fn draw_confirm_quit(frame: &mut Frame, area: Rect, app: &mut App) {
         no_area,
     );
 
-    app.confirm_yes_area = Some(yes_area);
-    app.confirm_no_area = Some(no_area);
+    hit.confirm_yes = Some(yes_area);
+    hit.confirm_no = Some(no_area);
 }


### PR DESCRIPTION
ui::draw previously took `&mut App` and wrote the laid-out
rectangles for each clickable widget back onto the app
(`checkbox_area`, `start_button_area`, etc.). Rendering with a
side-effect coupled layout to the view and prevented testing the view
in isolation.

Introduce `HitAreas`, a small plain struct containing all the
click-target rectangles. `draw` now takes `&App` and returns a
fresh `HitAreas` each frame; the main loop stores the returned
value on `app.hit_areas` and the mouse event handler reads it from
there. The five `pub` `Option<Rect>` fields on `App` collapse
into a single `hit_areas: HitAreas` field.