### PR TITLE
chore: prune dead code and abandoned stubs

### DIFF
--- a/crates/capsula-capture-machine/Cargo.toml
+++ b/crates/capsula-capture-machine/Cargo.toml
@@ -17,7 +17,6 @@ serde_json = { workspace = true }
 sysinfo = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-# whoami = { workspace = true }
 
 [dev-dependencies]
 ulid = { workspace = true }

--- a/crates/capsula-capture-machine/src/error.rs
+++ b/crates/capsula-capture-machine/src/error.rs
@@ -4,21 +4,9 @@ use thiserror::Error;
 /// Machine hook specific errors
 #[derive(Debug, Error)]
 pub enum MachineHookError {
-    /// Failed to collect system information
-    #[error("Failed to collect system information: {message}")]
-    SystemInfoError { message: String },
-
     /// Failed to get OS information
     #[error("Failed to get OS information")]
     OsInfoError,
-
-    /// Failed to get CPU information
-    #[error("Failed to get CPU information")]
-    CpuInfoError,
-
-    /// Failed to get memory information
-    #[error("Failed to get memory information")]
-    MemoryInfoError,
 
     /// Failed to get hostname
     #[error("Failed to get hostname")]

--- a/crates/capsula-capture-machine/src/lib.rs
+++ b/crates/capsula-capture-machine/src/lib.rs
@@ -32,9 +32,7 @@ pub struct MachineCaptured {
     kernel_version: String,
     architecture: String,
     cpus: Vec<CpuInfo>,
-    // pub cpu_cores: usize,
     total_memory: u64,
-    // pub user: String,
     hostname: String,
 }
 

--- a/crates/capsula-server/src/models.rs
+++ b/crates/capsula-server/src/models.rs
@@ -37,16 +37,6 @@ pub struct ListRunsQuery {
     pub vault: Option<String>,
     pub limit: Option<i64>,
     pub offset: Option<i64>,
-    #[expect(
-        dead_code,
-        reason = "Reserved for future time-based filtering functionality"
-    )]
-    pub from: Option<String>, // ISO 8601 timestamp
-    #[expect(
-        dead_code,
-        reason = "Reserved for future time-based filtering functionality"
-    )]
-    pub to: Option<String>, // ISO 8601 timestamp
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
- capture-machine lib.rs: drop the commented-out `cpu_cores` and
  `user` fields from `MachineCaptured`.
- capture-machine Cargo.toml: drop the commented-out `whoami`
  workspace-dep line that had paired with the `user` field.
- capture-machine error.rs: drop `SystemInfoError`, `CpuInfoError`,
  and `MemoryInfoError` variants — none were ever constructed.
- capsula-server models.rs: drop the `from` and `to` fields on
  `ListRunsQuery` that have been sitting behind an `#[expect(
  dead_code)]` annotation. If/when time-range filtering is added, it
  should use the already-implemented timestamp filters in the search
  endpoint.