### PR TITLE
docs: update output directory structure for per-hook artifact dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,18 @@ Capsula creates an organized directory:
 ```
 .capsula/my-project/2025-01-09/143022-happy-river/
 ├── _capsula/
-│   ├── metadata.json      # What ran, when, and where
-│   ├── pre-run.json       # Environment before
-│   ├── command.json       # Command output
-│   └── post-run.json      # Results after
-└── output.txt             # Your output file
+│   ├── metadata.json           # What ran, when, and where
+│   ├── pre-run.json            # Environment before
+│   ├── command.json            # Command output
+│   └── post-run.json           # Results after
+├── pre-0-capture-git-repo/     # Per-hook artifact directory
+└── post-0-capture-file/        # Per-hook artifact directory
+    └── output.txt              # Your output file
 ```
+
+Hooks that produce file artifacts (e.g., `capture-file`, `capture-git-repo`) each
+get a dedicated subdirectory named `{phase}-{index}-{hook_id}/`, which prevents
+filename collisions between hooks.
 
 ## Why Use Capsula?
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -70,13 +70,19 @@ Capsula stores everything in `.capsula/`:
 
 ```
 .capsula/my-project/2025-01-09/143022-happy-river/
-├── _capsula/              # Metadata directory
-│   ├── metadata.json      # Run info (ID, name, command, timestamp)
-│   ├── pre-run.json       # Pre-run hook outputs
-│   ├── command.json       # Command execution results
-│   └── post-run.json      # Post-run hook outputs
-└── output.txt             # Your captured file
+├── _capsula/                   # Metadata directory
+│   ├── metadata.json           # Run info (ID, name, command, timestamp)
+│   ├── pre-run.json            # Pre-run hook outputs
+│   ├── command.json            # Command execution results
+│   └── post-run.json           # Post-run hook outputs
+├── pre-0-capture-git-repo/     # Artifacts from the capture-git-repo hook
+└── post-0-capture-file/        # Artifacts from the capture-file hook
+    └── output.txt              # Your captured file
 ```
+
+Hooks that produce file artifacts (e.g., `capture-file`, `capture-git-repo`) each
+get a dedicated subdirectory named `{phase}-{index}-{hook_id}/`. This prevents
+filename collisions between hooks and keeps each hook's outputs isolated.
 
 View what the pre-run hooks recorded:
 

--- a/docs/hooks/capture-file.md
+++ b/docs/hooks/capture-file.md
@@ -30,9 +30,15 @@ Captures files by copying them, moving them, or computing their hash.
 
 ### Mode Options
 
-- `"copy"` - Copies files to run directory, leaves originals
-- `"move"` - Moves files to run directory, removes originals
+- `"copy"` - Copies files to the hook's artifact directory, leaves originals
+- `"move"` - Moves files to the hook's artifact directory, removes originals
 - `"none"` - Only computes hash, doesn't copy or move
+
+!!! note "Per-hook artifact directory"
+    When `mode` is `"copy"` or `"move"`, files are placed in a per-hook
+    artifact directory named `{phase}-{index}-capture-file/` under the run
+    directory (e.g., `post-0-capture-file/`). This prevents filename
+    collisions between different `capture-file` hooks.
 
 ### Example
 
@@ -60,13 +66,13 @@ hash = "sha256"
   "files": [
     {
       "src": "results/data.csv",
-      "dst": ".capsula/my-vault/2025-01-09/143022-happy-river/results/data.csv",
+      "dst": ".capsula/my-vault/2025-01-09/143022-happy-river/post-0-capture-file/data.csv",
       "hash": "a1b2c3d4e5f6...",
       "copied": true
     },
     {
       "src": "results/summary.csv",
-      "dst": ".capsula/my-vault/2025-01-09/143022-happy-river/results/summary.csv",
+      "dst": ".capsula/my-vault/2025-01-09/143022-happy-river/post-0-capture-file/summary.csv",
       "hash": "b2c3d4e5f6g7...",
       "copied": true
     }

--- a/docs/hooks/capture-git-repo.md
+++ b/docs/hooks/capture-git-repo.md
@@ -20,7 +20,7 @@ Captures git repository state including commit hash, branch, and whether there a
 
 | Option | Type | Description |
 | -------- | ------ | ------------- |
-| `name` | string | Name used for the patch file when the repository has uncommitted changes |
+| `name` | string | Base name used for the patch file (`<name>.patch`) when the repository has uncommitted changes |
 | `path` | string | Path to the git repository (`.` for current directory) |
 
 ### Optional Options
@@ -93,6 +93,12 @@ tag_head = true
   "tag": null
 }
 ```
+
+!!! note "Patch file location"
+    When the repository is dirty (and the hook is allowed to proceed), Capsula
+    writes the diff to `<name>.patch` inside the hook's artifact directory,
+    located at `{phase}-{index}-capture-git-repo/` under the run directory
+    (e.g., `pre-0-capture-git-repo/my-project.patch`).
 
 !!! warning "Abort Behavior"
     When `allow_dirty = false` and the repository is dirty, Capsula saves the hook output showing the dirty state, then aborts before running your command.

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,12 +44,18 @@ Capsula creates an organized directory:
 ```
 .capsula/my-project/2025-01-09/143022-happy-river/
 ├── _capsula/
-│   ├── metadata.json      # What ran, when, and where
-│   ├── pre-run.json       # Environment before
-│   ├── command.json       # Command output
-│   └── post-run.json      # Results after
-└── output.txt             # Your output file
+│   ├── metadata.json           # What ran, when, and where
+│   ├── pre-run.json            # Environment before
+│   ├── command.json            # Command output
+│   └── post-run.json           # Results after
+├── pre-0-capture-git-repo/     # Per-hook artifact directory
+└── post-0-capture-file/        # Per-hook artifact directory
+    └── output.txt              # Your output file
 ```
+
+Hooks that produce file artifacts (e.g., `capture-file`, `capture-git-repo`) each
+get a dedicated subdirectory named `{phase}-{index}-{hook_id}/`, which prevents
+filename collisions between hooks.
 
 ## Why Use Capsula?
 


### PR DESCRIPTION
Reflect the v0.12.0 (#863) change that places hook artifacts in
per-hook subdirectories named `{phase}-{index}-{hook_id}/` under the
run directory, instead of writing them directly to the run root.

- README.md, docs/index.md, docs/getting-started.md: update the
  example directory tree.
- docs/hooks/capture-file.md: update `mode` descriptions, add a note
  about the per-hook artifact directory, and fix the example `dst`
  paths.
- docs/hooks/capture-git-repo.md: clarify that the patch file is
  written to the artifact directory and document its naming.