### PR TITLE
Fix release tag authentication

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Get the version
         id: get-version
@@ -26,11 +26,10 @@ jobs:
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions"
-          git -c "http.https://github.com/.extraheader=AUTHORIZATION: bearer ${GITHUB_TOKEN}" fetch --tags
+          git fetch --tags
           git tag --annotate "v${STEPS_GET_VERSION_OUTPUTS_VERSION}" --message="v${STEPS_GET_VERSION_OUTPUTS_VERSION}"
-          git -c "http.https://github.com/.extraheader=AUTHORIZATION: bearer ${GITHUB_TOKEN}" push origin "v${STEPS_GET_VERSION_OUTPUTS_VERSION}"
+          git push origin "v${STEPS_GET_VERSION_OUTPUTS_VERSION}"
         env:
-          GITHUB_TOKEN: ${{ github.token }}
           STEPS_GET_VERSION_OUTPUTS_VERSION: ${{ steps.get-version.outputs.version }}
 
   publish:


### PR DESCRIPTION
## Summary

- Restore checkout-managed credentials for the release workflow tag job.
- Use plain `git fetch --tags` and `git push` now that `actions/checkout` provides the scoped token.
- Keep the safer environment-variable version interpolation and leave credential persistence disabled in jobs that do not push.

## Rationale

The latest release workflow failed in `Create a Git tag` after PR #955 disabled checkout-managed credentials and attempted to authenticate Git operations with a manual bearer extraheader. The runner could not find usable HTTPS credentials and failed before publishing.

The `create-tag` job intentionally pushes a release tag and already has `contents: write`, so restoring checkout-managed credentials only in this job keeps the permission boundary narrow while making authenticated Git operations work again.

## Validation

- `pre-commit run check-yaml --files .github/workflows/release.yaml`
- `pre-commit run zizmor --files .github/workflows/release.yaml`
- `just lint`
- `just test`

Note: the first sandboxed `just lint` and `just test` attempts failed because Cargo could not resolve `static.crates.io`; rerunning with normal network access passed.