### PR TITLE
Improve Clippy test lint configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ dbg_macro = { level = "warn", priority = 1 }
 decimal_literal_representation = { level = "warn", priority = 1 }
 derive_partial_eq_without_eq = { level = "allow", priority = 1 }  # We implement `Eq` only when necessary
 else_if_without_else = { level = "warn", priority = 1 }
-expect_used = { level = "allow", priority = 1 }  # TODO: change to "warn" later
+expect_used = { level = "warn", priority = 1 }
 indexing_slicing = { level = "allow", priority = 1 }  # TODO: change to "warn" later
 missing_errors_doc = { level = "allow", priority = 1 }  # TODO: change to "warn" later
 missing_panics_doc = { level = "allow", priority = 1 }  # TODO: change to "warn" later

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ missing_errors_doc = { level = "allow", priority = 1 }  # TODO: change to "warn"
 missing_panics_doc = { level = "allow", priority = 1 }  # TODO: change to "warn" later
 multiple_crate_versions = { level = "allow", priority = 1 }  # There is nothing we can do about this
 nursery = { level = "warn", priority = -1 }
-panic = { level = "allow", priority = 1 }  # TODO: change to "warn" later
+panic = { level = "warn", priority = 1 }
 pedantic = { level = "warn", priority = -1 }
 perf = { level = "warn", priority = -1 }
 print_stderr = { level = "warn", priority = 1 }

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+allow-print-in-tests = true
+allow-unwrap-in-tests = true

--- a/crates/capsula-capture-command/tests/command_hook.rs
+++ b/crates/capsula-capture-command/tests/command_hook.rs
@@ -1,4 +1,5 @@
-#![expect(clippy::unwrap_used, reason = "unwrap is acceptable in test code")]
+// This integration test crate is only compiled for test targets.
+#![cfg(test)]
 
 use capsula_capture_command::CommandHook;
 use capsula_core::captured::Captured;

--- a/crates/capsula-capture-cwd/tests/cwd_context.rs
+++ b/crates/capsula-capture-cwd/tests/cwd_context.rs
@@ -1,3 +1,6 @@
+// This integration test crate is only compiled for test targets.
+#![cfg(test)]
+
 use capsula_capture_cwd::CwdHook;
 use capsula_core::captured::Captured;
 use capsula_core::hook::{Hook, PreRun, RuntimeParams};

--- a/crates/capsula-capture-env/tests/env_hook.rs
+++ b/crates/capsula-capture-env/tests/env_hook.rs
@@ -1,4 +1,5 @@
-#![expect(clippy::unwrap_used, reason = "unwrap is acceptable in test code")]
+// This integration test crate is only compiled for test targets.
+#![cfg(test)]
 
 use capsula_capture_env::EnvVarHook;
 use capsula_core::captured::Captured;

--- a/crates/capsula-capture-file/tests/file_hook.rs
+++ b/crates/capsula-capture-file/tests/file_hook.rs
@@ -1,5 +1,5 @@
 //! Tests for the `FileHook` capturing functionality.
-#![expect(clippy::unwrap_used, reason = "unwrap is acceptable in test code")]
+#![cfg(test)]
 
 use capsula_capture_file::FileHook;
 use capsula_core::captured::Captured;

--- a/crates/capsula-capture-git-repo/tests/git_hook.rs
+++ b/crates/capsula-capture-git-repo/tests/git_hook.rs
@@ -1,5 +1,5 @@
 //! Tests for the `GitHook` capturing functionality.
-#![expect(clippy::unwrap_used, reason = "unwrap is acceptable in test code")]
+#![cfg(test)]
 
 use capsula_capture_git_repo::GitHook;
 use capsula_core::captured::Captured;

--- a/crates/capsula-capture-git-repo/tests/git_hook.rs
+++ b/crates/capsula-capture-git-repo/tests/git_hook.rs
@@ -21,7 +21,7 @@ fn git_hook_captures_clean_repo() {
 
     // Initialize git repo
     Command::new("git")
-        .args(["init"])
+        .args(["init", "-b", "main"])
         .current_dir(&temp_dir)
         .output()
         .expect("git init failed");
@@ -34,6 +34,11 @@ fn git_hook_captures_clean_repo() {
         .unwrap();
     Command::new("git")
         .args(["config", "user.name", "Test User"])
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "commit.gpgSign", "false"])
         .current_dir(&temp_dir)
         .output()
         .unwrap();
@@ -101,7 +106,7 @@ fn init_git_repo() -> std::path::PathBuf {
     fs::create_dir_all(&temp_dir).unwrap();
 
     Command::new("git")
-        .args(["init"])
+        .args(["init", "-b", "main"])
         .current_dir(&temp_dir)
         .output()
         .expect("git init failed");
@@ -480,7 +485,7 @@ fn git_hook_captures_dirty_repo_with_allow_dirty() {
 
     // Initialize git repo
     Command::new("git")
-        .args(["init"])
+        .args(["init", "-b", "main"])
         .current_dir(&temp_dir)
         .output()
         .expect("git init failed");
@@ -492,6 +497,11 @@ fn git_hook_captures_dirty_repo_with_allow_dirty() {
         .unwrap();
     Command::new("git")
         .args(["config", "user.name", "Test User"])
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "commit.gpgSign", "false"])
         .current_dir(&temp_dir)
         .output()
         .unwrap();
@@ -567,7 +577,7 @@ fn git_hook_requests_abort_for_dirty_repo_when_not_allowed() {
 
     // Initialize git repo
     Command::new("git")
-        .args(["init"])
+        .args(["init", "-b", "main"])
         .current_dir(&temp_dir)
         .output()
         .expect("git init failed");
@@ -579,6 +589,11 @@ fn git_hook_requests_abort_for_dirty_repo_when_not_allowed() {
         .unwrap();
     Command::new("git")
         .args(["config", "user.name", "Test User"])
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "commit.gpgSign", "false"])
         .current_dir(&temp_dir)
         .output()
         .unwrap();
@@ -639,7 +654,7 @@ fn git_hook_ignores_git_ignored_files() {
 
     // Initialize git repo
     Command::new("git")
-        .args(["init"])
+        .args(["init", "-b", "main"])
         .current_dir(&temp_dir)
         .output()
         .expect("git init failed");
@@ -651,6 +666,11 @@ fn git_hook_ignores_git_ignored_files() {
         .unwrap();
     Command::new("git")
         .args(["config", "user.name", "Test User"])
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "commit.gpgSign", "false"])
         .current_dir(&temp_dir)
         .output()
         .unwrap();
@@ -858,7 +878,7 @@ fn git_hook_detects_untracked_files_as_dirty() {
 
     // Initialize git repo
     Command::new("git")
-        .args(["init"])
+        .args(["init", "-b", "main"])
         .current_dir(&temp_dir)
         .output()
         .expect("git init failed");
@@ -870,6 +890,11 @@ fn git_hook_detects_untracked_files_as_dirty() {
         .unwrap();
     Command::new("git")
         .args(["config", "user.name", "Test User"])
+        .current_dir(&temp_dir)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "commit.gpgSign", "false"])
         .current_dir(&temp_dir)
         .output()
         .unwrap();

--- a/crates/capsula-capture-machine/tests/machine_hook.rs
+++ b/crates/capsula-capture-machine/tests/machine_hook.rs
@@ -1,4 +1,5 @@
-#![expect(clippy::unwrap_used, reason = "unwrap is acceptable in test code")]
+// This integration test crate is only compiled for test targets.
+#![cfg(test)]
 
 use capsula_capture_machine::MachineHook;
 use capsula_core::captured::Captured;

--- a/crates/capsula-cli/src/main.rs
+++ b/crates/capsula-cli/src/main.rs
@@ -115,9 +115,9 @@ enum VaultsCommands {
 fn run() -> Result<()> {
     debug!("Creating hook registries");
     let pre_run_hook_registry: capsula_registry::HookRegistry<PreRun> =
-        capsula_registry::standard_pre_run_hook_registry();
+        capsula_registry::standard_pre_run_hook_registry()?;
     let post_run_hook_registry: capsula_registry::HookRegistry<PostRun> =
-        capsula_registry::standard_post_run_hook_registry();
+        capsula_registry::standard_post_run_hook_registry()?;
 
     let cli = Cli::parse();
     let config_file_path = cli.config.unwrap_or_else(|| PathBuf::from("capsula.toml"));
@@ -387,10 +387,6 @@ path = \".\"
             all,
             server,
         } => {
-            if !all && run_id.is_none() {
-                anyhow::bail!("Either provide a run ID/name or use --all flag");
-            }
-
             let server_url =
                 resolve_server_url(server, config.server.as_deref()).ok_or_else(|| {
                     anyhow::anyhow!(
@@ -416,69 +412,70 @@ path = \".\"
                 }
             }
 
-            if all {
-                info!(
-                    "Pushing all runs from vault '{}' to server {}",
-                    vault_name, server_url
-                );
+            match (all, run_id) {
+                (true, _) => {
+                    info!(
+                        "Pushing all runs from vault '{}' to server {}",
+                        vault_name, server_url
+                    );
 
-                let mut success_count = 0;
-                let mut skip_count = 0;
-                let mut error_count = 0;
+                    let mut success_count = 0;
+                    let mut skip_count = 0;
+                    let mut error_count = 0;
 
-                for entry in walkdir::WalkDir::new(&vault_dir)
-                    .min_depth(2)
-                    .max_depth(2)
-                    .into_iter()
-                    .filter_entry(|e| e.file_type().is_dir())
-                {
-                    let entry = match entry {
-                        Ok(e) => e,
-                        Err(e) => {
-                            error!("Failed to read directory: {}", e);
-                            error_count += 1;
+                    for entry in walkdir::WalkDir::new(&vault_dir)
+                        .min_depth(2)
+                        .max_depth(2)
+                        .into_iter()
+                        .filter_entry(|e| e.file_type().is_dir())
+                    {
+                        let entry = match entry {
+                            Ok(e) => e,
+                            Err(e) => {
+                                error!("Failed to read directory: {}", e);
+                                error_count += 1;
+                                continue;
+                            }
+                        };
+
+                        let run_dir = entry.path();
+                        let capsula_dir = run_dir.join("_capsula");
+
+                        if !capsula_dir.exists() {
                             continue;
                         }
-                    };
 
-                    let run_dir = entry.path();
-                    let capsula_dir = run_dir.join("_capsula");
-
-                    if !capsula_dir.exists() {
-                        continue;
-                    }
-
-                    match push_single_run(run_dir, vault_name, &server_url, &client) {
-                        Ok(()) => success_count += 1,
-                        Err(e) => {
-                            if e.to_string().contains("already exists") {
-                                skip_count += 1;
-                            } else {
-                                error!("Failed to push run: {}", e);
-                                error_count += 1;
+                        match push_single_run(run_dir, vault_name, &server_url, &client) {
+                            Ok(()) => success_count += 1,
+                            Err(e) => {
+                                if e.to_string().contains("already exists") {
+                                    skip_count += 1;
+                                } else {
+                                    error!("Failed to push run: {}", e);
+                                    error_count += 1;
+                                }
                             }
                         }
                     }
+
+                    info!(
+                        "Push all completed: {} succeeded, {} skipped (already exist), {} failed",
+                        success_count, skip_count, error_count
+                    );
+
+                    if error_count > 0 {
+                        anyhow::bail!("{error_count} runs failed to push");
+                    }
                 }
+                (false, Some(run_id)) => {
+                    info!("Pushing run {} to server {}", run_id, server_url);
 
-                info!(
-                    "Push all completed: {} succeeded, {} skipped (already exist), {} failed",
-                    success_count, skip_count, error_count
-                );
+                    let run_dir = find_run_dir(&vault_dir, &run_id)?;
+                    push_single_run(&run_dir, vault_name, &server_url, &client)?;
 
-                if error_count > 0 {
-                    anyhow::bail!("{error_count} runs failed to push");
+                    info!("Push completed successfully");
                 }
-            } else {
-                let run_id = run_id
-                    .as_ref()
-                    .expect("run_id must be Some when all is false");
-                info!("Pushing run {} to server {}", run_id, server_url);
-
-                let run_dir = find_run_dir(&vault_dir, run_id)?;
-                push_single_run(&run_dir, vault_name, &server_url, &client)?;
-
-                info!("Push completed successfully");
+                (false, None) => anyhow::bail!("Either provide a run ID/name or use --all flag"),
             }
         }
         Commands::Tui => unreachable!("Handled above"),

--- a/crates/capsula-cli/tests/cli_integration.rs
+++ b/crates/capsula-cli/tests/cli_integration.rs
@@ -1,9 +1,5 @@
 //! Integration tests for the capsula CLI tool.
-#![expect(
-    clippy::unwrap_used,
-    clippy::panic,
-    reason = "Test code doesn't need production-level error handling"
-)]
+#![cfg(test)]
 
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;

--- a/crates/capsula-cli/tests/cli_integration.rs
+++ b/crates/capsula-cli/tests/cli_integration.rs
@@ -1,6 +1,7 @@
 //! Integration tests for the capsula CLI tool.
 #![expect(
     clippy::unwrap_used,
+    clippy::panic,
     reason = "Test code doesn't need production-level error handling"
 )]
 

--- a/crates/capsula-config/src/lib.rs
+++ b/crates/capsula-config/src/lib.rs
@@ -147,7 +147,6 @@ pub fn build_hooks<P: PhaseMarker>(
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "Tests can use unwrap")]
 mod tests {
     use super::*;
 

--- a/crates/capsula-config/tests/integration_test.rs
+++ b/crates/capsula-config/tests/integration_test.rs
@@ -1,5 +1,5 @@
-#![allow(clippy::print_stdout, reason = "Printing is acceptable in test code")]
-#![allow(clippy::print_stderr, reason = "Printing is acceptable in test code")]
+// This integration test crate is only compiled for test targets.
+#![cfg(test)]
 
 use capsula_config::CapsulaConfig;
 use std::path::Path;

--- a/crates/capsula-core/src/util.rs
+++ b/crates/capsula-core/src/util.rs
@@ -27,7 +27,6 @@ pub fn resolve_relative(path: &Path, project_root: &Path) -> std::io::Result<Pat
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "tests may use unwrap for brevity")]
 mod tests {
     use super::{hex_encode, resolve_relative};
     use std::path::Path;

--- a/crates/capsula-notify-slack/src/secret.rs
+++ b/crates/capsula-notify-slack/src/secret.rs
@@ -40,7 +40,6 @@ impl Serialize for SecretString {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "tests may use unwrap for brevity")]
 mod tests {
     use super::SecretString;
 

--- a/crates/capsula-notify-slack/tests/resolve_attachment_globs.rs
+++ b/crates/capsula-notify-slack/tests/resolve_attachment_globs.rs
@@ -1,5 +1,5 @@
 //! Tests for the `resolve_attachment_globs` function.
-#![expect(clippy::unwrap_used, reason = "unwrap is acceptable in test code")]
+#![cfg(test)]
 
 use capsula_notify_slack::resolve_attachment_globs;
 use std::fs;

--- a/crates/capsula-notify-slack/tests/slack_hook.rs
+++ b/crates/capsula-notify-slack/tests/slack_hook.rs
@@ -1,5 +1,5 @@
 //! Tests for the `SlackNotifyHook` implementation.
-#![expect(clippy::unwrap_used, reason = "unwrap is acceptable in test code")]
+#![cfg(test)]
 
 use capsula_core::hook::{Hook, PreRun};
 use capsula_notify_slack::SlackNotifyHook;

--- a/crates/capsula-registry/src/lib.rs
+++ b/crates/capsula-registry/src/lib.rs
@@ -176,10 +176,8 @@ where
 ///
 /// Each built-in hook type implements both `Hook<PreRun>` and `Hook<PostRun>`,
 /// so a single generic builder covers both phases and the pre/post fns below
-/// simply delegate. The inner `.expect(...)` calls are unreachable — the only
-/// registration error is `AlreadyRegistered`, and every type is registered
-/// exactly once.
-fn standard_hook_registry<P: PhaseMarker>() -> HookRegistry<P>
+/// simply delegate.
+fn standard_hook_registry<P: PhaseMarker>() -> Result<HookRegistry<P>, RegistryError>
 where
     capsula_capture_cwd::CwdHook: capsula_core::hook::Hook<P>,
     capsula_capture_git_repo::GitHook: capsula_core::hook::Hook<P>,
@@ -189,32 +187,23 @@ where
     capsula_capture_machine::MachineHook: capsula_core::hook::Hook<P>,
     capsula_notify_slack::SlackNotifyHook: capsula_core::hook::Hook<P>,
 {
-    RegistryBuilder::new()
-        .with_hook::<capsula_capture_cwd::CwdHook>()
-        .expect("capture-cwd registered exactly once")
-        .with_hook::<capsula_capture_git_repo::GitHook>()
-        .expect("capture-git-repo registered exactly once")
-        .with_hook::<capsula_capture_file::FileHook>()
-        .expect("capture-file registered exactly once")
-        .with_hook::<capsula_capture_env::EnvVarHook>()
-        .expect("capture-env registered exactly once")
-        .with_hook::<capsula_capture_command::CommandHook>()
-        .expect("capture-command registered exactly once")
-        .with_hook::<capsula_capture_machine::MachineHook>()
-        .expect("capture-machine registered exactly once")
-        .with_hook::<capsula_notify_slack::SlackNotifyHook>()
-        .expect("notify-slack registered exactly once")
-        .build()
+    Ok(RegistryBuilder::new()
+        .with_hook::<capsula_capture_cwd::CwdHook>()?
+        .with_hook::<capsula_capture_git_repo::GitHook>()?
+        .with_hook::<capsula_capture_file::FileHook>()?
+        .with_hook::<capsula_capture_env::EnvVarHook>()?
+        .with_hook::<capsula_capture_command::CommandHook>()?
+        .with_hook::<capsula_capture_machine::MachineHook>()?
+        .with_hook::<capsula_notify_slack::SlackNotifyHook>()?
+        .build())
 }
 
 /// Create a standard registry with all built-in hook types for pre-run phase
-#[must_use]
-pub fn standard_pre_run_hook_registry() -> HookRegistry<PreRun> {
+pub fn standard_pre_run_hook_registry() -> Result<HookRegistry<PreRun>, RegistryError> {
     standard_hook_registry::<PreRun>()
 }
 
 /// Create a standard registry with all built-in hook types for post-run phase
-#[must_use]
-pub fn standard_post_run_hook_registry() -> HookRegistry<PostRun> {
+pub fn standard_post_run_hook_registry() -> Result<HookRegistry<PostRun>, RegistryError> {
     standard_hook_registry::<PostRun>()
 }

--- a/crates/capsula-server/src/lib.rs
+++ b/crates/capsula-server/src/lib.rs
@@ -1398,7 +1398,6 @@ fn sanitize_relative_path(candidate: &str) -> Result<String, &'static str> {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "tests may use unwrap for brevity")]
 mod tests {
     use super::{content_disposition_inline, sanitize_relative_path};
 

--- a/crates/capsula-server/tests/api_tests.rs
+++ b/crates/capsula-server/tests/api_tests.rs
@@ -1,5 +1,6 @@
 //! Integration tests for Capsula server API endpoints.
-#![allow(clippy::unwrap_used, reason = "Test code")]
+#![cfg(test)]
+
 use capsula_server::{build_app, create_pool};
 use serde_json::json;
 use testcontainers_modules::{

--- a/crates/capsula-tui/src/app.rs
+++ b/crates/capsula-tui/src/app.rs
@@ -68,8 +68,8 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(config: LoadedConfig) -> Self {
-        Self {
+    pub fn new(config: LoadedConfig) -> Result<Self> {
+        Ok(Self {
             config,
             instant_run: false,
             error: None,
@@ -80,10 +80,10 @@ impl App {
             active_run: None,
             pending_action: None,
             last_completed_run: None,
-            pre_run_registry: capsula_registry::standard_pre_run_hook_registry(),
-            post_run_registry: capsula_registry::standard_post_run_hook_registry(),
+            pre_run_registry: capsula_registry::standard_pre_run_hook_registry()?,
+            post_run_registry: capsula_registry::standard_post_run_hook_registry()?,
             hit_areas: HitAreas::default(),
-        }
+        })
     }
 
     pub const fn is_running(&self) -> bool {

--- a/crates/capsula-tui/src/lib.rs
+++ b/crates/capsula-tui/src/lib.rs
@@ -25,6 +25,7 @@ use event::AppEvent;
 /// `vault_path_override` is an optional CLI override for the vault path.
 pub fn run(config_path: &Path, vault_path_override: Option<PathBuf>) -> Result<()> {
     let loaded = capsula_orchestration::setup::load_config(config_path, vault_path_override)?;
+    let mut app = App::new(loaded).context("Failed to create hook registries")?;
 
     // Install panic hook that restores the terminal before printing the panic message
     let original_hook = std::panic::take_hook();
@@ -40,8 +41,6 @@ pub fn run(config_path: &Path, vault_path_override: Option<PathBuf>) -> Result<(
         .context("Failed to set up terminal")?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend).context("Failed to create terminal")?;
-
-    let mut app = App::new(loaded);
 
     let result = run_loop(&mut terminal, &mut app);
 


### PR DESCRIPTION
## Summary
- configure Clippy to allow unwrap/expect/panic/print in test code
- mark integration test crates as cfg(test) instead of carrying per-file lint expectations
- remove production expect usage by propagating registry construction errors and matching push args directly
- make git hook tests independent of local default branch and signing config

## Verification
- just lint
- just test