### PR TITLE
feat(server): add ParameterMatch structured filter to search API

### DIFF
--- a/crates/capsula-api-types/src/lib.rs
+++ b/crates/capsula-api-types/src/lib.rs
@@ -60,6 +60,83 @@ pub struct HookFilter {
     pub output_filter: String,
 }
 
+/// Comparison operator for parameter matching
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ComparisonOp {
+    /// Exact equality
+    Eq,
+    /// Not equal
+    Ne,
+    /// Greater than
+    Gt,
+    /// Greater than or equal
+    Ge,
+    /// Less than
+    Lt,
+    /// Less than or equal
+    Le,
+}
+
+/// A structured filter for parameter-capturing hooks (e.g., `capture-json`,
+/// `capture-toml`, ...).
+///
+/// Targets `run_outputs` rows whose `output` JSON has the shape:
+///
+/// ```text
+/// { "file": "<configured-path>", "parameters": { ...parsed... } }
+/// ```
+///
+/// The server selects matching rows structurally (by the presence of both
+/// the `file` and `parameters` top-level fields) — it is decoupled from
+/// the concrete `hook_id`, so any future hook that emits this shape works
+/// automatically.
+///
+/// Constraints (validated server-side):
+///
+/// - At least one of `file` / `parameter` must be specified.
+/// - If `parameter` is present, `operator` and `value` must also be present.
+/// - If `parameter` is absent, `operator` and `value` must also be absent.
+/// - Specifying `parameter` without `file` emits a server-side warning,
+///   since the match will scan across every parameter-capturing row of
+///   the run regardless of which file it came from.
+///
+/// # Example
+///
+/// ```json
+/// {
+///     "phase": "pre",
+///     "file": "config/sat1/orbit.json",
+///     "parameter": "a",
+///     "operator": "ge",
+///     "value": 1.0
+/// }
+/// ```
+///
+/// generates `$.parameters.a ? (@ >= 1.0)` against the row whose
+/// `file == "config/sat1/orbit.json"`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ParameterMatch {
+    /// Phase: `"pre"` or `"post"`
+    pub phase: String,
+    /// Optional exact match on the captured `file` field. Omitting this
+    /// causes the match to apply across every parameter-capturing row of
+    /// the run; the server logs a warning when this happens.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    /// Dot path within the captured `parameters` object (e.g., `"lr"`,
+    /// `"sat1.orbit.a"`). When present, `operator` and `value` are required.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parameter: Option<String>,
+    /// Comparison operator (required iff `parameter` is present).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operator: Option<ComparisonOp>,
+    /// Value to compare against — number, string, or boolean. Required
+    /// iff `parameter` is present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<serde_json::Value>,
+}
+
 /// Fields that can be included in search response
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -101,6 +178,11 @@ pub struct SearchRunsRequest {
     /// Hook output filters (AND logic)
     #[serde(default)]
     pub hook_filters: Vec<HookFilter>,
+    /// Structured parameter match filters for parameter-capturing hooks
+    /// (`capture-json`, `capture-toml`, ...). Each entry is an independent
+    /// EXISTS subquery; multiple entries are AND-combined.
+    #[serde(default)]
+    pub parameter_matches: Vec<ParameterMatch>,
     /// What to include in response
     #[serde(default)]
     pub include: Vec<IncludeField>,

--- a/crates/capsula-api-types/src/lib.rs
+++ b/crates/capsula-api-types/src/lib.rs
@@ -81,25 +81,28 @@ pub enum ComparisonOp {
 /// A structured filter for parameter-capturing hooks (e.g., `capture-json`,
 /// `capture-toml`, ...).
 ///
-/// Targets `run_outputs` rows whose `output` JSON has the shape:
+/// Targets `run_outputs` rows produced by hooks whose `output` has a
+/// top-level `content` field:
 ///
 /// ```text
-/// { "file": "<configured-path>", "parameters": { ...parsed... } }
+/// output: { "content": { ...parsed file contents... } }
+/// config: { "path": "<configured-path>", ... }
 /// ```
 ///
-/// The server selects matching rows structurally (by the presence of both
-/// the `file` and `parameters` top-level fields) — it is decoupled from
-/// the concrete `hook_id`, so any future hook that emits this shape works
+/// The server selects matching rows structurally (by the presence of
+/// the `content` top-level field) — decoupled from the concrete
+/// `hook_id`, so any future hook that emits this shape works
 /// automatically.
 ///
 /// Constraints (validated server-side):
 ///
-/// - At least one of `file` / `parameter` must be specified.
+/// - At least one of `file` / `hook_index` / `parameter` must be specified.
 /// - If `parameter` is present, `operator` and `value` must also be present.
 /// - If `parameter` is absent, `operator` and `value` must also be absent.
-/// - Specifying `parameter` without `file` emits a server-side warning,
-///   since the match will scan across every parameter-capturing row of
-///   the run regardless of which file it came from.
+/// - Specifying `parameter` without `file` (and without `hook_index`)
+///   emits a server-side warning, since the match will scan across
+///   every parameter-capturing row of the run regardless of which
+///   file it came from.
 ///
 /// # Example
 ///
@@ -113,18 +116,40 @@ pub enum ComparisonOp {
 /// }
 /// ```
 ///
-/// generates `$.parameters.a ? (@ >= 1.0)` against the row whose
-/// `file == "config/sat1/orbit.json"`.
+/// generates `$.content.a ? (@ >= 1.0)` against the row whose
+/// `config.path == "config/sat1/orbit.json"`.
+///
+/// # Example — using `hook_index`
+///
+/// Pin the match to the hook at position 1 (0-indexed) in the phase's
+/// array, useful when several entries share the same file / `hook_id`:
+///
+/// ```json
+/// {
+///     "phase": "pre",
+///     "hook_index": 1,
+///     "parameter": "a",
+///     "operator": "ge",
+///     "value": 1.0
+/// }
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ParameterMatch {
     /// Phase: `"pre"` or `"post"`
     pub phase: String,
-    /// Optional exact match on the captured `file` field. Omitting this
-    /// causes the match to apply across every parameter-capturing row of
-    /// the run; the server logs a warning when this happens.
+    /// Optional exact match on the captured file path (compared against
+    /// `run_outputs.config->>'path'`). Omitting this causes the match to
+    /// apply across every parameter-capturing row of the run; the server
+    /// logs a warning when neither `file` nor `hook_index` is supplied.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub file: Option<String>,
-    /// Dot path within the captured `parameters` object (e.g., `"lr"`,
+    /// Optional exact match on the 0-based position of the hook in
+    /// `capsula.toml`'s `pre_run` / `post_run` list. Useful when several
+    /// entries share the same file / `hook_id` and disambiguation by
+    /// position is needed (e.g., "the 2nd `capture-json`").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hook_index: Option<i32>,
+    /// Dot path within the captured `content` object (e.g., `"lr"`,
     /// `"sat1.orbit.a"`). When present, `operator` and `value` are required.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parameter: Option<String>,

--- a/crates/capsula-api-types/src/lib.rs
+++ b/crates/capsula-api-types/src/lib.rs
@@ -78,88 +78,70 @@ pub enum ComparisonOp {
     Le,
 }
 
-/// A structured filter for parameter-capturing hooks (e.g., `capture-json`,
+/// Hook execution phase.
+///
+/// Serialized as `"pre"` / `"post"` on the wire.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Phase {
+    Pre,
+    Post,
+}
+
+/// A single `<parameter> <operator> <value>` comparison inside the
+/// captured `content` object. See [`ParameterMatch::conditions`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ParameterCondition {
+    pub parameter: String,
+    pub operator: ComparisonOp,
+    pub value: serde_json::Value,
+}
+
+/// A structured filter over parameter-capturing hooks (`capture-json`,
 /// `capture-toml`, ...).
 ///
-/// Targets `run_outputs` rows produced by hooks whose `output` has a
-/// top-level `content` field:
+/// Selects `run_outputs` rows structurally by the presence of a
+/// top-level `content` field, then optionally pins by `file` /
+/// `hook_index` and/or filters by `conditions`.
 ///
-/// ```text
-/// output: { "content": { ...parsed file contents... } }
-/// config: { "path": "<configured-path>", ... }
-/// ```
+/// # Why `conditions` is a list, not a single `parameter` + `operator` + `value`
 ///
-/// The server selects matching rows structurally (by the presence of
-/// the `content` top-level field) — decoupled from the concrete
-/// `hook_id`, so any future hook that emits this shape works
-/// automatically.
+/// Two entries at the `parameter_matches` level are AND-combined across
+/// *rows* — `lr >= 0.005` in one entry and `lr <= 0.05` in another are
+/// satisfied by a run that has *some* row above the lower bound and
+/// *some (possibly different)* row below the upper. Bundling them
+/// inside one `ParameterMatch` compiles both into a single `JSONPath`
+/// predicate applied to the same row, which is what a caller writing a
+/// range actually wants.
 ///
-/// Constraints (validated server-side):
-///
-/// - At least one of `file` / `hook_index` / `parameter` must be specified.
-/// - If `parameter` is present, `operator` and `value` must also be present.
-/// - If `parameter` is absent, `operator` and `value` must also be absent.
-/// - Specifying `parameter` without `file` (and without `hook_index`)
-///   emits a server-side warning, since the match will scan across
-///   every parameter-capturing row of the run regardless of which
-///   file it came from.
-///
-/// # Example
+/// # Example — range on the same field
 ///
 /// ```json
 /// {
 ///     "phase": "pre",
-///     "file": "config/sat1/orbit.json",
-///     "parameter": "a",
-///     "operator": "ge",
-///     "value": 1.0
+///     "file": "train.json",
+///     "conditions": [
+///         { "parameter": "lr", "operator": "ge", "value": 0.005 },
+///         { "parameter": "lr", "operator": "le", "value": 0.05 }
+///     ]
 /// }
 /// ```
 ///
-/// generates `$.content.a ? (@ >= 1.0)` against the row whose
-/// `config.path == "config/sat1/orbit.json"`.
-///
-/// # Example — using `hook_index`
-///
-/// Pin the match to the hook at position 1 (0-indexed) in the phase's
-/// array, useful when several entries share the same file / `hook_id`:
-///
-/// ```json
-/// {
-///     "phase": "pre",
-///     "hook_index": 1,
-///     "parameter": "a",
-///     "operator": "ge",
-///     "value": 1.0
-/// }
-/// ```
+/// compiles to `$ ? (@.content.lr >= 0.005 && @.content.lr <= 0.05)`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ParameterMatch {
-    /// Phase: `"pre"` or `"post"`
-    pub phase: String,
-    /// Optional exact match on the captured file path (compared against
-    /// `run_outputs.config->>'path'`). Omitting this causes the match to
-    /// apply across every parameter-capturing row of the run; the server
-    /// logs a warning when neither `file` nor `hook_index` is supplied.
+    pub phase: Phase,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub file: Option<String>,
-    /// Optional exact match on the 0-based position of the hook in
-    /// `capsula.toml`'s `pre_run` / `post_run` list. Useful when several
-    /// entries share the same file / `hook_id` and disambiguation by
-    /// position is needed (e.g., "the 2nd `capture-json`").
+    /// 0-based position of the hook in `capsula.toml`'s `pre_run` /
+    /// `post_run` list. `i32` for parity with the DB column; negatives
+    /// are rejected server-side.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hook_index: Option<i32>,
-    /// Dot path within the captured `content` object (e.g., `"lr"`,
-    /// `"sat1.orbit.a"`). When present, `operator` and `value` are required.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub parameter: Option<String>,
-    /// Comparison operator (required iff `parameter` is present).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub operator: Option<ComparisonOp>,
-    /// Value to compare against — number, string, or boolean. Required
-    /// iff `parameter` is present.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub value: Option<serde_json::Value>,
+    /// May be empty when `file` or `hook_index` is set — the match then
+    /// only asserts a parameter-capturing row exists.
+    #[serde(default)]
+    pub conditions: Vec<ParameterCondition>,
 }
 
 /// Fields that can be included in search response
@@ -203,9 +185,10 @@ pub struct SearchRunsRequest {
     /// Hook output filters (AND logic)
     #[serde(default)]
     pub hook_filters: Vec<HookFilter>,
-    /// Structured parameter match filters for parameter-capturing hooks
-    /// (`capture-json`, `capture-toml`, ...). Each entry is an independent
-    /// EXISTS subquery; multiple entries are AND-combined.
+    /// Independent `ParameterMatch` entries, AND-combined at the run
+    /// level. To share a row between two conditions (e.g. a range) put
+    /// them inside a single entry's `conditions`, not across entries —
+    /// see [`ParameterMatch`]. Capped at 32 entries per request.
     #[serde(default)]
     pub parameter_matches: Vec<ParameterMatch>,
     /// What to include in response

--- a/crates/capsula-server/src/lib.rs
+++ b/crates/capsula-server/src/lib.rs
@@ -582,9 +582,10 @@ async fn search_runs(
     Json(request): Json<models::SearchRunsRequest>,
 ) -> impl IntoResponse {
     info!(
-        "Searching runs: vault={:?}, hook_filters={}",
+        "Searching runs: vault={:?}, hook_filters={}, parameter_matches={}",
         request.vault,
-        request.hook_filters.len()
+        request.hook_filters.len(),
+        request.parameter_matches.len()
     );
 
     // Build the query

--- a/crates/capsula-server/src/models.rs
+++ b/crates/capsula-server/src/models.rs
@@ -164,22 +164,49 @@ pub enum ComparisonOp {
     Le,
 }
 
-/// Structured filter for parameter-capturing hooks. See the `capsula-api-types`
-/// documentation for the full semantics. The server validates constraints at
-/// query-build time.
+/// Hook execution phase. Wire form: `"pre"` / `"post"`. Any other value is
+/// rejected by `serde` at deserialize time (returns 4xx at the handler
+/// layer) rather than reaching the query builder.
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Phase {
+    Pre,
+    Post,
+}
+
+impl Phase {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Pre => "pre",
+            Self::Post => "post",
+        }
+    }
+}
+
+/// See `capsula-api-types::ParameterCondition`. Deserialize-only mirror.
+/// `deny_unknown_fields` catches typos in the wire payload up-front.
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ParameterCondition {
+    pub parameter: String,
+    pub operator: ComparisonOp,
+    pub value: JsonValue,
+}
+
+/// See `capsula-api-types::ParameterMatch`. Deserialize-only mirror.
+/// Validated at query-build time in `query::RunQueryBuilder::with_parameter_match`.
+/// `deny_unknown_fields` prevents e.g. an outer `"parameter"` (a common
+/// mistake after the flat→conditions rework) from being silently ignored.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ParameterMatch {
-    pub phase: String,
+    pub phase: Phase,
     #[serde(default)]
     pub file: Option<String>,
     #[serde(default)]
     pub hook_index: Option<i32>,
     #[serde(default)]
-    pub parameter: Option<String>,
-    #[serde(default)]
-    pub operator: Option<ComparisonOp>,
-    #[serde(default)]
-    pub value: Option<JsonValue>,
+    pub conditions: Vec<ParameterCondition>,
 }
 
 /// Fields that can be included in search response

--- a/crates/capsula-server/src/models.rs
+++ b/crates/capsula-server/src/models.rs
@@ -173,6 +173,8 @@ pub struct ParameterMatch {
     #[serde(default)]
     pub file: Option<String>,
     #[serde(default)]
+    pub hook_index: Option<i32>,
+    #[serde(default)]
     pub parameter: Option<String>,
     #[serde(default)]
     pub operator: Option<ComparisonOp>,

--- a/crates/capsula-server/src/models.rs
+++ b/crates/capsula-server/src/models.rs
@@ -126,6 +126,9 @@ pub struct SearchRunsRequest {
     /// Hook output filters (AND logic)
     #[serde(default)]
     pub hook_filters: Vec<HookFilter>,
+    /// Structured parameter match filters (AND logic)
+    #[serde(default)]
+    pub parameter_matches: Vec<ParameterMatch>,
     /// What to include in response
     #[serde(default)]
     pub include: Vec<IncludeField>,
@@ -147,6 +150,34 @@ pub struct HookFilter {
     pub config_filter: Option<String>,
     /// `JSONPath` expression to match against hook's output
     pub output_filter: String,
+}
+
+/// Comparison operator for parameter matching
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ComparisonOp {
+    Eq,
+    Ne,
+    Gt,
+    Ge,
+    Lt,
+    Le,
+}
+
+/// Structured filter for parameter-capturing hooks. See the `capsula-api-types`
+/// documentation for the full semantics. The server validates constraints at
+/// query-build time.
+#[derive(Debug, Deserialize)]
+pub struct ParameterMatch {
+    pub phase: String,
+    #[serde(default)]
+    pub file: Option<String>,
+    #[serde(default)]
+    pub parameter: Option<String>,
+    #[serde(default)]
+    pub operator: Option<ComparisonOp>,
+    #[serde(default)]
+    pub value: Option<JsonValue>,
 }
 
 /// Fields that can be included in search response

--- a/crates/capsula-server/src/query.rs
+++ b/crates/capsula-server/src/query.rs
@@ -213,14 +213,17 @@ impl RunQueryBuilder {
     ///    filter is decoupled from the concrete `hook_id`.
     /// 2. Optionally pins to a specific captured file by matching
     ///    `ro.config->>'path'` against the supplied `file`.
-    /// 3. Optionally adds a `JSONPath` predicate
+    /// 3. Optionally pins to a specific hook position in the phase's array
+    ///    by matching `ro.hook_index` against the supplied `hook_index`.
+    /// 4. Optionally adds a `JSONPath` predicate
     ///    `$.content.<parameter> ? (@ <op> <value>)` on `ro.output`.
     ///
     /// Validation:
     /// - `phase` must be `"pre"` or `"post"`.
-    /// - At least one of `file` / `parameter` must be specified.
+    /// - At least one of `file` / `hook_index` / `parameter` must be specified.
     /// - `parameter`, `operator`, and `value` are an all-or-nothing group.
-    /// - Specifying `parameter` without `file` emits a warning.
+    /// - Specifying `parameter` without either `file` or `hook_index`
+    ///   emits a warning.
     pub fn with_parameter_match(mut self, pm: &ParameterMatch) -> Result<Self, QueryError> {
         // Validate phase
         let phase = match pm.phase.as_str() {
@@ -243,18 +246,21 @@ impl RunQueryBuilder {
             }
         };
 
-        // At least one of file / parameter must be present, otherwise the
-        // filter would match every parameter-capturing row of the run.
-        if pm.file.is_none() && condition.is_none() {
+        // At least one of file / hook_index / parameter must be present,
+        // otherwise the filter would match every parameter-capturing row
+        // of the run.
+        if pm.file.is_none() && pm.hook_index.is_none() && condition.is_none() {
             return Err(QueryError::InvalidJsonPath(
-                "ParameterMatch requires at least one of 'file' or 'parameter'".to_string(),
+                "ParameterMatch requires at least one of 'file', 'hook_index', \
+                 or 'parameter'"
+                    .to_string(),
             ));
         }
 
-        if condition.is_some() && pm.file.is_none() {
+        if condition.is_some() && pm.file.is_none() && pm.hook_index.is_none() {
             tracing::warn!(
-                "ParameterMatch without 'file' will match across every \
-                 parameter-capturing row of the run; specify 'file' to narrow"
+                "ParameterMatch without 'file' or 'hook_index' will match across \
+                 every parameter-capturing row of the run; specify one to narrow"
             );
         }
 
@@ -272,6 +278,12 @@ impl RunQueryBuilder {
         if let Some(file) = &pm.file {
             conds.push(format!("ro.config->>'path' = ${}", self.param_index));
             self.bind_values.push(BindValue::String(file.clone()));
+            self.param_index += 1;
+        }
+
+        if let Some(hook_index) = pm.hook_index {
+            conds.push(format!("ro.hook_index = ${}", self.param_index));
+            self.bind_values.push(BindValue::I32(hook_index));
             self.param_index += 1;
         }
 
@@ -504,6 +516,7 @@ mod tests {
         let pm = ParameterMatch {
             phase: "pre".into(),
             file: Some("config/sat1/orbit.json".into()),
+            hook_index: None,
             parameter: Some("a".into()),
             operator: Some(ComparisonOp::Ge),
             value: Some(serde_json::json!(1.0)),
@@ -531,6 +544,7 @@ mod tests {
         let pm = ParameterMatch {
             phase: "pre".into(),
             file: Some("config.json".into()),
+            hook_index: None,
             parameter: None,
             operator: None,
             value: None,
@@ -549,6 +563,7 @@ mod tests {
         let pm = ParameterMatch {
             phase: "pre".into(),
             file: None,
+            hook_index: None,
             parameter: Some("lr".into()),
             operator: Some(ComparisonOp::Ge),
             value: Some(serde_json::json!(0.01)),
@@ -567,6 +582,7 @@ mod tests {
         let pm = ParameterMatch {
             phase: "pre".into(),
             file: None,
+            hook_index: None,
             parameter: None,
             operator: None,
             value: None,
@@ -582,6 +598,7 @@ mod tests {
         let pm = ParameterMatch {
             phase: "pre".into(),
             file: Some("c.json".into()),
+            hook_index: None,
             parameter: Some("lr".into()),
             operator: Some(ComparisonOp::Ge),
             // value missing
@@ -598,6 +615,7 @@ mod tests {
         let pm = ParameterMatch {
             phase: "during".into(),
             file: Some("c.json".into()),
+            hook_index: None,
             parameter: None,
             operator: None,
             value: None,
@@ -613,6 +631,7 @@ mod tests {
         let pm = ParameterMatch {
             phase: "pre".into(),
             file: None,
+            hook_index: None,
             parameter: Some("x; DROP TABLE".into()),
             operator: Some(ComparisonOp::Eq),
             value: Some(serde_json::json!(1)),
@@ -626,6 +645,7 @@ mod tests {
         let pm = ParameterMatch {
             phase: "post".into(),
             file: Some("results.json".into()),
+            hook_index: None,
             parameter: Some("metrics.max_temp".into()),
             operator: Some(ComparisonOp::Le),
             value: Some(serde_json::json!(85.0)),
@@ -647,5 +667,67 @@ mod tests {
         let expr = build_parameter_jsonpath("orbit", &ComparisonOp::Eq, &serde_json::json!("LEO"))
             .expect("valid string match");
         assert_eq!(expr, r#"$.content.orbit ? (@ == "LEO")"#);
+    }
+
+    #[test]
+    fn pm_hook_index_only_generates_hook_index_clause() {
+        let pm = ParameterMatch {
+            phase: "pre".into(),
+            file: None,
+            hook_index: Some(2),
+            parameter: None,
+            operator: None,
+            value: None,
+        };
+        let builder = RunQueryBuilder::new()
+            .with_parameter_match(&pm)
+            .expect("hook_index-only parameter match");
+        let query = builder.build_query();
+        assert!(query.contains("ro.output ? 'content'"));
+        assert!(query.contains("ro.hook_index = $"));
+        assert!(!query.contains("ro.config->>'path'"));
+        assert!(!query.contains("jsonb_path_exists"));
+        let has_hook_index = builder.bind_values().iter().any(|v| match v {
+            BindValue::I32(i) => *i == 2,
+            _ => false,
+        });
+        assert!(has_hook_index, "expected hook_index=2 in bind values");
+    }
+
+    #[test]
+    fn pm_hook_index_with_file_and_parameter_composes_all_clauses() {
+        let pm = ParameterMatch {
+            phase: "post".into(),
+            file: Some("config.json".into()),
+            hook_index: Some(1),
+            parameter: Some("lr".into()),
+            operator: Some(ComparisonOp::Eq),
+            value: Some(serde_json::json!(0.01)),
+        };
+        let builder = RunQueryBuilder::new()
+            .with_parameter_match(&pm)
+            .expect("hook_index + file + parameter compose");
+        let query = builder.build_query();
+        assert!(query.contains("ro.output ? 'content'"));
+        assert!(query.contains("ro.config->>'path'"));
+        assert!(query.contains("ro.hook_index = $"));
+        assert!(query.contains("jsonb_path_exists"));
+    }
+
+    #[test]
+    fn pm_hook_index_alone_satisfies_at_least_one_rule() {
+        let pm = ParameterMatch {
+            phase: "pre".into(),
+            file: None,
+            hook_index: Some(0),
+            parameter: None,
+            operator: None,
+            value: None,
+        };
+        let result = RunQueryBuilder::new().with_parameter_match(&pm);
+        assert!(
+            result.is_ok(),
+            "hook_index alone should satisfy the at-least-one rule"
+        );
     }
 }

--- a/crates/capsula-server/src/query.rs
+++ b/crates/capsula-server/src/query.rs
@@ -3,7 +3,7 @@
 //! This module provides a builder for constructing dynamic SQL queries
 //! that filter runs based on metadata and hook outputs using `JSONPath` expressions.
 
-use crate::models::{HookFilter, SearchRunsRequest, SortOrder};
+use crate::models::{ComparisonOp, HookFilter, ParameterMatch, SearchRunsRequest, SortOrder};
 use chrono::{DateTime, Utc};
 use sql_json_path::JsonPath;
 use std::fmt::Write;
@@ -95,6 +95,10 @@ impl RunQueryBuilder {
 
         for hook_filter in &request.hook_filters {
             builder = builder.with_hook_filter(hook_filter)?;
+        }
+
+        for parameter_match in &request.parameter_matches {
+            builder = builder.with_parameter_match(parameter_match)?;
         }
 
         builder.order = request.order.clone();
@@ -197,6 +201,100 @@ impl RunQueryBuilder {
         Ok(self)
     }
 
+    /// Add a structured parameter match filter targeting parameter-capturing
+    /// hooks (`capture-json`, `capture-toml`, ...).
+    ///
+    /// Those hooks share an output shape — a top-level `content` field
+    /// containing the parsed file — and store the configured path under
+    /// `__meta.config.path` (persisted in the `config` column of
+    /// `run_outputs`). This method:
+    ///
+    /// 1. Selects rows structurally with `ro.output ? 'content'`, so the
+    ///    filter is decoupled from the concrete `hook_id`.
+    /// 2. Optionally pins to a specific captured file by matching
+    ///    `ro.config->>'path'` against the supplied `file`.
+    /// 3. Optionally adds a `JSONPath` predicate
+    ///    `$.content.<parameter> ? (@ <op> <value>)` on `ro.output`.
+    ///
+    /// Validation:
+    /// - `phase` must be `"pre"` or `"post"`.
+    /// - At least one of `file` / `parameter` must be specified.
+    /// - `parameter`, `operator`, and `value` are an all-or-nothing group.
+    /// - Specifying `parameter` without `file` emits a warning.
+    pub fn with_parameter_match(mut self, pm: &ParameterMatch) -> Result<Self, QueryError> {
+        // Validate phase
+        let phase = match pm.phase.as_str() {
+            "pre" | "post" => pm.phase.clone(),
+            _ => {
+                return Err(QueryError::InvalidJsonPath(
+                    "phase must be 'pre' or 'post'".to_string(),
+                ));
+            }
+        };
+
+        // Validate the parameter/operator/value triple is all-or-nothing
+        let condition = match (&pm.parameter, &pm.operator, &pm.value) {
+            (None, None, None) => None,
+            (Some(p), Some(op), Some(v)) => Some((p.as_str(), op, v)),
+            _ => {
+                return Err(QueryError::InvalidJsonPath(
+                    "parameter, operator, and value must all be specified together".to_string(),
+                ));
+            }
+        };
+
+        // At least one of file / parameter must be present, otherwise the
+        // filter would match every parameter-capturing row of the run.
+        if pm.file.is_none() && condition.is_none() {
+            return Err(QueryError::InvalidJsonPath(
+                "ParameterMatch requires at least one of 'file' or 'parameter'".to_string(),
+            ));
+        }
+
+        if condition.is_some() && pm.file.is_none() {
+            tracing::warn!(
+                "ParameterMatch without 'file' will match across every \
+                 parameter-capturing row of the run; specify 'file' to narrow"
+            );
+        }
+
+        // Build EXISTS subquery
+        let mut conds = vec![
+            "ro.run_id = r.id".to_string(),
+            format!("ro.phase = ${}", self.param_index),
+        ];
+        self.bind_values.push(BindValue::String(phase));
+        self.param_index += 1;
+
+        // Structural filter: only parameter-capturing rows have `content`.
+        conds.push("ro.output ? 'content'".to_string());
+
+        if let Some(file) = &pm.file {
+            conds.push(format!("ro.config->>'path' = ${}", self.param_index));
+            self.bind_values.push(BindValue::String(file.clone()));
+            self.param_index += 1;
+        }
+
+        if let Some((param, op, value)) = condition {
+            let jsonpath = build_parameter_jsonpath(param, op, value)?;
+            Self::validate_jsonpath(&jsonpath)?;
+            conds.push(format!(
+                "jsonb_path_exists(ro.output, ${}::jsonpath)",
+                self.param_index
+            ));
+            self.bind_values.push(BindValue::String(jsonpath));
+            self.param_index += 1;
+        }
+
+        let exists = format!(
+            "EXISTS (SELECT 1 FROM run_outputs ro WHERE {})",
+            conds.join(" AND ")
+        );
+        self.hook_exists_clauses.push(exists);
+
+        Ok(self)
+    }
+
     /// Validate a `JSONPath` expression using SQL/JSON path parser
     ///
     /// Uses `sql-json-path` crate which is compatible with `PostgreSQL`'s SQL/JSON
@@ -280,6 +378,55 @@ impl RunQueryBuilder {
     }
 }
 
+/// Build a PostgreSQL-compatible `JSONPath` expression for a single
+/// parameter comparison inside the captured `content` object.
+///
+/// The path is rooted at `$.content` (the field produced by parameter-capturing
+/// hooks), e.g., `$.content.sat1.orbit.a ? (@ >= 1.0)`.
+fn build_parameter_jsonpath(
+    parameter: &str,
+    operator: &ComparisonOp,
+    value: &serde_json::Value,
+) -> Result<String, QueryError> {
+    // Validate parameter name (1-200 chars of [A-Za-z0-9_.])
+    if parameter.is_empty() || parameter.len() > 200 {
+        return Err(QueryError::InvalidJsonPath(
+            "parameter name must be 1-200 characters".to_string(),
+        ));
+    }
+    for ch in parameter.chars() {
+        if !ch.is_alphanumeric() && ch != '_' && ch != '.' {
+            return Err(QueryError::InvalidJsonPath(format!(
+                "parameter name contains invalid character: '{ch}'"
+            )));
+        }
+    }
+
+    let op_str = match operator {
+        ComparisonOp::Eq => "==",
+        ComparisonOp::Ne => "!=",
+        ComparisonOp::Gt => ">",
+        ComparisonOp::Ge => ">=",
+        ComparisonOp::Lt => "<",
+        ComparisonOp::Le => "<=",
+    };
+
+    let value_str = match value {
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::String(s) => {
+            format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
+        }
+        serde_json::Value::Bool(b) => b.to_string(),
+        _ => {
+            return Err(QueryError::InvalidJsonPath(
+                "value must be number, string, or boolean".to_string(),
+            ));
+        }
+    };
+
+    Ok(format!("$.content.{parameter} ? (@ {op_str} {value_str})"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -337,5 +484,168 @@ mod tests {
         assert!(query.contains("EXISTS"));
         assert!(query.contains("ro.config"));
         assert!(query.contains("ro.output"));
+    }
+
+    // ---- ParameterMatch ------------------------------------------------
+
+    fn bound_strings(builder: &RunQueryBuilder) -> Vec<String> {
+        builder
+            .bind_values()
+            .iter()
+            .filter_map(|v| match v {
+                BindValue::String(s) => Some(s.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn pm_file_and_parameter_generate_full_query() {
+        let pm = ParameterMatch {
+            phase: "pre".into(),
+            file: Some("config/sat1/orbit.json".into()),
+            parameter: Some("a".into()),
+            operator: Some(ComparisonOp::Ge),
+            value: Some(serde_json::json!(1.0)),
+        };
+        let builder = RunQueryBuilder::new()
+            .with_parameter_match(&pm)
+            .expect("valid parameter match");
+        let query = builder.build_query();
+        assert!(query.contains("EXISTS"));
+        assert!(query.contains("ro.output ? 'content'"));
+        assert!(query.contains("ro.config->>'path'"));
+        assert!(query.contains("jsonb_path_exists"));
+
+        let bound = bound_strings(&builder);
+        assert!(bound.contains(&"pre".to_string()));
+        assert!(bound.contains(&"config/sat1/orbit.json".to_string()));
+        assert!(
+            bound.iter().any(|s| s == "$.content.a ? (@ >= 1.0)"),
+            "expected JSONPath rooted at $.content, got bound values: {bound:?}"
+        );
+    }
+
+    #[test]
+    fn pm_file_only_omits_jsonpath() {
+        let pm = ParameterMatch {
+            phase: "pre".into(),
+            file: Some("config.json".into()),
+            parameter: None,
+            operator: None,
+            value: None,
+        };
+        let builder = RunQueryBuilder::new()
+            .with_parameter_match(&pm)
+            .expect("file-only parameter match");
+        let query = builder.build_query();
+        assert!(query.contains("ro.output ? 'content'"));
+        assert!(query.contains("ro.config->>'path'"));
+        assert!(!query.contains("jsonb_path_exists"));
+    }
+
+    #[test]
+    fn pm_parameter_only_omits_file_clause() {
+        let pm = ParameterMatch {
+            phase: "pre".into(),
+            file: None,
+            parameter: Some("lr".into()),
+            operator: Some(ComparisonOp::Ge),
+            value: Some(serde_json::json!(0.01)),
+        };
+        let builder = RunQueryBuilder::new()
+            .with_parameter_match(&pm)
+            .expect("parameter-only match (broad)");
+        let query = builder.build_query();
+        assert!(query.contains("ro.output ? 'content'"));
+        assert!(!query.contains("ro.config->>'path'"));
+        assert!(query.contains("jsonb_path_exists"));
+    }
+
+    #[test]
+    fn pm_rejects_empty_match() {
+        let pm = ParameterMatch {
+            phase: "pre".into(),
+            file: None,
+            parameter: None,
+            operator: None,
+            value: None,
+        };
+        let err = RunQueryBuilder::new()
+            .with_parameter_match(&pm)
+            .unwrap_err();
+        assert!(format!("{err:?}").contains("at least one"));
+    }
+
+    #[test]
+    fn pm_rejects_partial_triple() {
+        let pm = ParameterMatch {
+            phase: "pre".into(),
+            file: Some("c.json".into()),
+            parameter: Some("lr".into()),
+            operator: Some(ComparisonOp::Ge),
+            // value missing
+            value: None,
+        };
+        let err = RunQueryBuilder::new()
+            .with_parameter_match(&pm)
+            .unwrap_err();
+        assert!(format!("{err:?}").contains("all be specified together"));
+    }
+
+    #[test]
+    fn pm_rejects_invalid_phase() {
+        let pm = ParameterMatch {
+            phase: "during".into(),
+            file: Some("c.json".into()),
+            parameter: None,
+            operator: None,
+            value: None,
+        };
+        let err = RunQueryBuilder::new()
+            .with_parameter_match(&pm)
+            .unwrap_err();
+        assert!(format!("{err:?}").contains("phase"));
+    }
+
+    #[test]
+    fn pm_rejects_invalid_parameter_name() {
+        let pm = ParameterMatch {
+            phase: "pre".into(),
+            file: None,
+            parameter: Some("x; DROP TABLE".into()),
+            operator: Some(ComparisonOp::Eq),
+            value: Some(serde_json::json!(1)),
+        };
+        let result = RunQueryBuilder::new().with_parameter_match(&pm);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn pm_nested_dot_path_in_jsonpath() {
+        let pm = ParameterMatch {
+            phase: "post".into(),
+            file: Some("results.json".into()),
+            parameter: Some("metrics.max_temp".into()),
+            operator: Some(ComparisonOp::Le),
+            value: Some(serde_json::json!(85.0)),
+        };
+        let builder = RunQueryBuilder::new()
+            .with_parameter_match(&pm)
+            .expect("nested dot path");
+        let bound = bound_strings(&builder);
+        assert!(
+            bound
+                .iter()
+                .any(|s| s == "$.content.metrics.max_temp ? (@ <= 85.0)"),
+            "expected nested dot path in JSONPath, got: {bound:?}"
+        );
+    }
+
+    #[test]
+    fn pm_build_jsonpath_string_value_quoted() {
+        let expr = build_parameter_jsonpath("orbit", &ComparisonOp::Eq, &serde_json::json!("LEO"))
+            .expect("valid string match");
+        assert_eq!(expr, r#"$.content.orbit ? (@ == "LEO")"#);
     }
 }

--- a/crates/capsula-server/src/query.rs
+++ b/crates/capsula-server/src/query.rs
@@ -3,26 +3,31 @@
 //! This module provides a builder for constructing dynamic SQL queries
 //! that filter runs based on metadata and hook outputs using `JSONPath` expressions.
 
-use crate::models::{ComparisonOp, HookFilter, ParameterMatch, SearchRunsRequest, SortOrder};
+use crate::models::{
+    ComparisonOp, HookFilter, ParameterCondition, ParameterMatch, SearchRunsRequest, SortOrder,
+};
 use chrono::{DateTime, Utc};
 use sql_json_path::JsonPath;
 use std::fmt::Write;
 
-/// Maximum length for `JSONPath` expressions (prevents denial-of-service)
+/// `str::len` cap for `JSONPath` expressions passed to `sql-json-path`.
 const MAX_JSONPATH_LENGTH: usize = 500;
 
-/// Maximum LIMIT value: callers asking for more than this are clamped.
 const MAX_LIMIT: i64 = 1_000;
 
-/// Maximum OFFSET value: callers asking for more than this are clamped.
-/// Prevents slow-query `DoS` from a large `OFFSET` forcing a sequential scan.
+/// Guards against a large `OFFSET` forcing a sequential scan.
 const MAX_OFFSET: i64 = 100_000;
 
-/// Error types for query building
+/// Each entry becomes an independent `EXISTS`, so an unbounded list
+/// would let a caller stall the planner.
+const MAX_PARAMETER_MATCHES: usize = 32;
+
 #[derive(Debug, thiserror::Error)]
 pub enum QueryError {
     #[error("Invalid JSONPath expression: {0}")]
     InvalidJsonPath(String),
+    #[error("Invalid parameter match: {0}")]
+    InvalidParameterMatch(String),
 }
 
 /// Builder for constructing run search queries
@@ -97,6 +102,12 @@ impl RunQueryBuilder {
             builder = builder.with_hook_filter(hook_filter)?;
         }
 
+        if request.parameter_matches.len() > MAX_PARAMETER_MATCHES {
+            return Err(QueryError::InvalidParameterMatch(format!(
+                "at most {MAX_PARAMETER_MATCHES} parameter_matches entries are allowed, got {}",
+                request.parameter_matches.len()
+            )));
+        }
         for parameter_match in &request.parameter_matches {
             builder = builder.with_parameter_match(parameter_match)?;
         }
@@ -201,75 +212,61 @@ impl RunQueryBuilder {
         Ok(self)
     }
 
-    /// Add a structured parameter match filter targeting parameter-capturing
-    /// hooks (`capture-json`, `capture-toml`, ...).
-    ///
-    /// Those hooks share an output shape — a top-level `content` field
-    /// containing the parsed file — and store the configured path under
-    /// `__meta.config.path` (persisted in the `config` column of
-    /// `run_outputs`). This method:
-    ///
-    /// 1. Selects rows structurally with `ro.output ? 'content'`, so the
-    ///    filter is decoupled from the concrete `hook_id`.
-    /// 2. Optionally pins to a specific captured file by matching
-    ///    `ro.config->>'path'` against the supplied `file`.
-    /// 3. Optionally pins to a specific hook position in the phase's array
-    ///    by matching `ro.hook_index` against the supplied `hook_index`.
-    /// 4. Optionally adds a `JSONPath` predicate
-    ///    `$.content.<parameter> ? (@ <op> <value>)` on `ro.output`.
-    ///
-    /// Validation:
-    /// - `phase` must be `"pre"` or `"post"`.
-    /// - At least one of `file` / `hook_index` / `parameter` must be specified.
-    /// - `parameter`, `operator`, and `value` are an all-or-nothing group.
-    /// - Specifying `parameter` without either `file` or `hook_index`
-    ///   emits a warning.
+    /// Add a `ParameterMatch` filter — targets rows produced by
+    /// parameter-capturing hooks and combines phase / file / `hook_index`
+    /// pins with an optional multi-condition `JSONPath` predicate.
     pub fn with_parameter_match(mut self, pm: &ParameterMatch) -> Result<Self, QueryError> {
-        // Validate phase
-        let phase = match pm.phase.as_str() {
-            "pre" | "post" => pm.phase.clone(),
-            _ => {
-                return Err(QueryError::InvalidJsonPath(
-                    "phase must be 'pre' or 'post'".to_string(),
-                ));
-            }
-        };
-
-        // Validate the parameter/operator/value triple is all-or-nothing
-        let condition = match (&pm.parameter, &pm.operator, &pm.value) {
-            (None, None, None) => None,
-            (Some(p), Some(op), Some(v)) => Some((p.as_str(), op, v)),
-            _ => {
-                return Err(QueryError::InvalidJsonPath(
-                    "parameter, operator, and value must all be specified together".to_string(),
-                ));
-            }
-        };
-
-        // At least one of file / hook_index / parameter must be present,
-        // otherwise the filter would match every parameter-capturing row
-        // of the run.
-        if pm.file.is_none() && pm.hook_index.is_none() && condition.is_none() {
-            return Err(QueryError::InvalidJsonPath(
+        // At least one of file / hook_index / conditions is required —
+        // an unconstrained match would scan every parameter-capturing
+        // row of the run.
+        if pm.file.is_none() && pm.hook_index.is_none() && pm.conditions.is_empty() {
+            return Err(QueryError::InvalidParameterMatch(
                 "ParameterMatch requires at least one of 'file', 'hook_index', \
-                 or 'parameter'"
+                 or a non-empty 'conditions'"
                     .to_string(),
             ));
         }
 
-        if condition.is_some() && pm.file.is_none() && pm.hook_index.is_none() {
+        // `hook_index` is `i32` for parity with the DB column but the
+        // API contract is non-negative; reject negatives so callers see
+        // a clear error instead of an empty result set.
+        if let Some(hook_index) = pm.hook_index
+            && hook_index < 0
+        {
+            return Err(QueryError::InvalidParameterMatch(format!(
+                "hook_index must be non-negative, got {hook_index}"
+            )));
+        }
+
+        // Ordering operators on booleans have no defined JSONPath
+        // semantics — reject at the input layer instead of letting
+        // Postgres error out.
+        for c in &pm.conditions {
+            if matches!(c.value, serde_json::Value::Bool(_))
+                && matches!(
+                    c.operator,
+                    ComparisonOp::Gt | ComparisonOp::Ge | ComparisonOp::Lt | ComparisonOp::Le
+                )
+            {
+                return Err(QueryError::InvalidParameterMatch(
+                    "boolean value only supports 'eq' / 'ne' operators".to_string(),
+                ));
+            }
+        }
+
+        if !pm.conditions.is_empty() && pm.file.is_none() && pm.hook_index.is_none() {
             tracing::warn!(
                 "ParameterMatch without 'file' or 'hook_index' will match across \
                  every parameter-capturing row of the run; specify one to narrow"
             );
         }
 
-        // Build EXISTS subquery
         let mut conds = vec![
             "ro.run_id = r.id".to_string(),
             format!("ro.phase = ${}", self.param_index),
         ];
-        self.bind_values.push(BindValue::String(phase));
+        self.bind_values
+            .push(BindValue::String(pm.phase.as_str().to_string()));
         self.param_index += 1;
 
         // Structural filter: only parameter-capturing rows have `content`.
@@ -287,8 +284,8 @@ impl RunQueryBuilder {
             self.param_index += 1;
         }
 
-        if let Some((param, op, value)) = condition {
-            let jsonpath = build_parameter_jsonpath(param, op, value)?;
+        if !pm.conditions.is_empty() {
+            let jsonpath = build_conditions_jsonpath(&pm.conditions)?;
             Self::validate_jsonpath(&jsonpath)?;
             conds.push(format!(
                 "jsonb_path_exists(ro.output, ${}::jsonpath)",
@@ -390,58 +387,113 @@ impl RunQueryBuilder {
     }
 }
 
-/// Build a PostgreSQL-compatible `JSONPath` expression for a single
-/// parameter comparison inside the captured `content` object.
+/// Compile a list of conditions into a single `JSONPath` predicate.
 ///
-/// The path is rooted at `$.content` (the field produced by parameter-capturing
-/// hooks), e.g., `$.content.sat1.orbit.a ? (@ >= 1.0)`.
-fn build_parameter_jsonpath(
-    parameter: &str,
-    operator: &ComparisonOp,
-    value: &serde_json::Value,
-) -> Result<String, QueryError> {
-    // Validate parameter name (1-200 chars of [A-Za-z0-9_.])
-    if parameter.is_empty() || parameter.len() > 200 {
-        return Err(QueryError::InvalidJsonPath(
-            "parameter name must be 1-200 characters".to_string(),
-        ));
-    }
-    for ch in parameter.chars() {
-        if !ch.is_alphanumeric() && ch != '_' && ch != '.' {
-            return Err(QueryError::InvalidJsonPath(format!(
-                "parameter name contains invalid character: '{ch}'"
-            )));
-        }
+/// One condition emits the compact `$.content.<path> ? (@ <op> <val>)`
+/// form so single-parameter matches stay legible. Two or more emit the
+/// composable `$ ? (@.content.<p1> <op1> <v1> && ...)` form — the
+/// per-row AND that motivated putting conditions inside one entry
+/// (see `ParameterMatch::conditions` for the false-positive it avoids).
+fn build_conditions_jsonpath(conditions: &[ParameterCondition]) -> Result<String, QueryError> {
+    debug_assert!(
+        !conditions.is_empty(),
+        "caller must not pass empty conditions"
+    );
+
+    if conditions.len() == 1 {
+        let c = &conditions[0];
+        let path = build_path(&c.parameter)?;
+        let op = op_to_jsonpath(&c.operator);
+        let val = value_to_jsonpath(&c.value)?;
+        return Ok(format!("$.content.{path} ? (@ {op} {val})"));
     }
 
-    let op_str = match operator {
+    let mut parts = Vec::with_capacity(conditions.len());
+    for c in conditions {
+        let path = build_path(&c.parameter)?;
+        let op = op_to_jsonpath(&c.operator);
+        let val = value_to_jsonpath(&c.value)?;
+        parts.push(format!("@.content.{path} {op} {val}"));
+    }
+    Ok(format!("$ ? ({})", parts.join(" && ")))
+}
+
+/// Build the dot-path portion of a `JSONPath`, quoting segments that
+/// contain characters outside the bare-identifier set `[A-Za-z0-9_]`.
+///
+/// Quoting exists so keys with hyphens (`learning-rate`), spaces, or
+/// non-ASCII characters (`温度`) remain addressable without inviting
+/// injection — control characters and empty segments are still
+/// rejected, and `\` / `"` inside a segment are escaped.
+fn build_path(parameter: &str) -> Result<String, QueryError> {
+    if parameter.is_empty() {
+        return Err(QueryError::InvalidParameterMatch(
+            "parameter must not be empty".to_string(),
+        ));
+    }
+    if parameter.len() > 200 {
+        return Err(QueryError::InvalidParameterMatch(
+            "parameter must be at most 200 bytes".to_string(),
+        ));
+    }
+
+    let mut segments = Vec::new();
+    for seg in parameter.split('.') {
+        if seg.is_empty() {
+            return Err(QueryError::InvalidParameterMatch(
+                "parameter has an empty segment (leading, trailing, or consecutive '.')"
+                    .to_string(),
+            ));
+        }
+        for ch in seg.chars() {
+            if ch.is_control() {
+                return Err(QueryError::InvalidParameterMatch(format!(
+                    "parameter segment contains a control character: {ch:?}"
+                )));
+            }
+        }
+        segments.push(quote_segment_if_needed(seg));
+    }
+    Ok(segments.join("."))
+}
+
+fn quote_segment_if_needed(seg: &str) -> String {
+    if seg.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        seg.to_string()
+    } else {
+        format!("\"{}\"", seg.replace('\\', "\\\\").replace('"', "\\\""))
+    }
+}
+
+const fn op_to_jsonpath(op: &ComparisonOp) -> &'static str {
+    match op {
         ComparisonOp::Eq => "==",
         ComparisonOp::Ne => "!=",
         ComparisonOp::Gt => ">",
         ComparisonOp::Ge => ">=",
         ComparisonOp::Lt => "<",
         ComparisonOp::Le => "<=",
-    };
+    }
+}
 
-    let value_str = match value {
-        serde_json::Value::Number(n) => n.to_string(),
-        serde_json::Value::String(s) => {
-            format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
-        }
-        serde_json::Value::Bool(b) => b.to_string(),
-        _ => {
-            return Err(QueryError::InvalidJsonPath(
-                "value must be number, string, or boolean".to_string(),
-            ));
-        }
-    };
-
-    Ok(format!("$.content.{parameter} ? (@ {op_str} {value_str})"))
+fn value_to_jsonpath(value: &serde_json::Value) -> Result<String, QueryError> {
+    match value {
+        serde_json::Value::Number(n) => Ok(n.to_string()),
+        serde_json::Value::String(s) => Ok(format!(
+            "\"{}\"",
+            s.replace('\\', "\\\\").replace('"', "\\\"")
+        )),
+        serde_json::Value::Bool(b) => Ok(b.to_string()),
+        _ => Err(QueryError::InvalidParameterMatch(
+            "value must be number, string, or boolean".to_string(),
+        )),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::Phase;
 
     #[test]
     fn test_basic_query() {
@@ -511,16 +563,36 @@ mod tests {
             .collect()
     }
 
+    fn cond(parameter: &str, operator: ComparisonOp, value: serde_json::Value) -> ParameterCondition {
+        ParameterCondition {
+            parameter: parameter.to_string(),
+            operator,
+            value,
+        }
+    }
+
+    fn pm_with(
+        phase: Phase,
+        file: Option<&str>,
+        hook_index: Option<i32>,
+        conditions: Vec<ParameterCondition>,
+    ) -> ParameterMatch {
+        ParameterMatch {
+            phase,
+            file: file.map(str::to_string),
+            hook_index,
+            conditions,
+        }
+    }
+
     #[test]
-    fn pm_file_and_parameter_generate_full_query() {
-        let pm = ParameterMatch {
-            phase: "pre".into(),
-            file: Some("config/sat1/orbit.json".into()),
-            hook_index: None,
-            parameter: Some("a".into()),
-            operator: Some(ComparisonOp::Ge),
-            value: Some(serde_json::json!(1.0)),
-        };
+    fn pm_file_and_single_condition_generate_full_query() {
+        let pm = pm_with(
+            Phase::Pre,
+            Some("config/sat1/orbit.json"),
+            None,
+            vec![cond("a", ComparisonOp::Ge, serde_json::json!(1.0))],
+        );
         let builder = RunQueryBuilder::new()
             .with_parameter_match(&pm)
             .expect("valid parameter match");
@@ -535,20 +607,13 @@ mod tests {
         assert!(bound.contains(&"config/sat1/orbit.json".to_string()));
         assert!(
             bound.iter().any(|s| s == "$.content.a ? (@ >= 1.0)"),
-            "expected JSONPath rooted at $.content, got bound values: {bound:?}"
+            "expected single-condition compact form, got: {bound:?}"
         );
     }
 
     #[test]
     fn pm_file_only_omits_jsonpath() {
-        let pm = ParameterMatch {
-            phase: "pre".into(),
-            file: Some("config.json".into()),
-            hook_index: None,
-            parameter: None,
-            operator: None,
-            value: None,
-        };
+        let pm = pm_with(Phase::Pre, Some("config.json"), None, vec![]);
         let builder = RunQueryBuilder::new()
             .with_parameter_match(&pm)
             .expect("file-only parameter match");
@@ -559,18 +624,16 @@ mod tests {
     }
 
     #[test]
-    fn pm_parameter_only_omits_file_clause() {
-        let pm = ParameterMatch {
-            phase: "pre".into(),
-            file: None,
-            hook_index: None,
-            parameter: Some("lr".into()),
-            operator: Some(ComparisonOp::Ge),
-            value: Some(serde_json::json!(0.01)),
-        };
+    fn pm_condition_only_omits_file_clause() {
+        let pm = pm_with(
+            Phase::Pre,
+            None,
+            None,
+            vec![cond("lr", ComparisonOp::Ge, serde_json::json!(0.01))],
+        );
         let builder = RunQueryBuilder::new()
             .with_parameter_match(&pm)
-            .expect("parameter-only match (broad)");
+            .expect("condition-only match (broad)");
         let query = builder.build_query();
         assert!(query.contains("ro.output ? 'content'"));
         assert!(!query.contains("ro.config->>'path'"));
@@ -579,14 +642,7 @@ mod tests {
 
     #[test]
     fn pm_rejects_empty_match() {
-        let pm = ParameterMatch {
-            phase: "pre".into(),
-            file: None,
-            hook_index: None,
-            parameter: None,
-            operator: None,
-            value: None,
-        };
+        let pm = pm_with(Phase::Pre, None, None, vec![]);
         let err = RunQueryBuilder::new()
             .with_parameter_match(&pm)
             .unwrap_err();
@@ -594,91 +650,269 @@ mod tests {
     }
 
     #[test]
-    fn pm_rejects_partial_triple() {
-        let pm = ParameterMatch {
-            phase: "pre".into(),
-            file: Some("c.json".into()),
-            hook_index: None,
-            parameter: Some("lr".into()),
-            operator: Some(ComparisonOp::Ge),
-            // value missing
-            value: None,
-        };
-        let err = RunQueryBuilder::new()
-            .with_parameter_match(&pm)
-            .unwrap_err();
-        assert!(format!("{err:?}").contains("all be specified together"));
-    }
-
-    #[test]
     fn pm_rejects_invalid_phase() {
-        let pm = ParameterMatch {
-            phase: "during".into(),
-            file: Some("c.json".into()),
-            hook_index: None,
-            parameter: None,
-            operator: None,
-            value: None,
-        };
+        // Invalid phase is rejected by `Phase`'s serde impl before the
+        // request reaches the builder — locks in that no unknown string
+        // can flow through.
+        let json = serde_json::json!({ "phase": "during", "file": "c.json" });
+        let err = serde_json::from_value::<ParameterMatch>(json).unwrap_err();
+        assert!(format!("{err}").contains("phase") || format!("{err}").contains("variant"));
+    }
+
+    #[test]
+    fn pm_rejects_negative_hook_index() {
+        let pm = pm_with(Phase::Pre, None, Some(-1), vec![]);
         let err = RunQueryBuilder::new()
             .with_parameter_match(&pm)
             .unwrap_err();
-        assert!(format!("{err:?}").contains("phase"));
+        assert!(format!("{err:?}").contains("non-negative"));
     }
 
     #[test]
-    fn pm_rejects_invalid_parameter_name() {
-        let pm = ParameterMatch {
-            phase: "pre".into(),
-            file: None,
-            hook_index: None,
-            parameter: Some("x; DROP TABLE".into()),
-            operator: Some(ComparisonOp::Eq),
-            value: Some(serde_json::json!(1)),
-        };
-        let result = RunQueryBuilder::new().with_parameter_match(&pm);
-        assert!(result.is_err());
+    fn pm_rejects_bool_value_with_ordering_operator() {
+        for op in [
+            ComparisonOp::Gt,
+            ComparisonOp::Ge,
+            ComparisonOp::Lt,
+            ComparisonOp::Le,
+        ] {
+            let pm = pm_with(
+                Phase::Pre,
+                Some("flags.json"),
+                None,
+                vec![cond("enabled", op, serde_json::json!(true))],
+            );
+            let err = RunQueryBuilder::new()
+                .with_parameter_match(&pm)
+                .unwrap_err();
+            assert!(format!("{err:?}").contains("boolean value only supports"));
+        }
     }
 
     #[test]
-    fn pm_nested_dot_path_in_jsonpath() {
-        let pm = ParameterMatch {
-            phase: "post".into(),
-            file: Some("results.json".into()),
-            hook_index: None,
-            parameter: Some("metrics.max_temp".into()),
-            operator: Some(ComparisonOp::Le),
-            value: Some(serde_json::json!(85.0)),
+    fn pm_accepts_bool_value_with_eq_and_ne() {
+        for op in [ComparisonOp::Eq, ComparisonOp::Ne] {
+            let pm = pm_with(
+                Phase::Pre,
+                Some("flags.json"),
+                None,
+                vec![cond("enabled", op, serde_json::json!(true))],
+            );
+            assert!(RunQueryBuilder::new().with_parameter_match(&pm).is_ok());
+        }
+    }
+
+    #[test]
+    fn pm_rejects_too_many_parameter_matches() {
+        let matches: Vec<ParameterMatch> = (0..=MAX_PARAMETER_MATCHES)
+            .map(|_| pm_with(Phase::Pre, Some("c.json"), None, vec![]))
+            .collect();
+        let request = SearchRunsRequest {
+            vault: None,
+            from: None,
+            to: None,
+            exit_code: None,
+            success: None,
+            hook_filters: Vec::new(),
+            parameter_matches: matches,
+            include: Vec::new(),
+            order: SortOrder::LatestFirst,
+            limit: None,
+            offset: None,
         };
+        let err = RunQueryBuilder::from_request(&request).unwrap_err();
+        assert!(format!("{err:?}").contains("at most"));
+    }
+
+    // ---- multi-condition (Issue 2 fix) -----------------------------
+
+    #[test]
+    fn pm_multi_condition_range_on_same_field_compiles_to_single_predicate() {
+        // The whole point of `conditions` being a list: both bounds
+        // apply to the *same* row, unlike two separate `parameter_matches`.
+        let pm = pm_with(
+            Phase::Pre,
+            Some("train.json"),
+            None,
+            vec![
+                cond("lr", ComparisonOp::Ge, serde_json::json!(0.005)),
+                cond("lr", ComparisonOp::Le, serde_json::json!(0.05)),
+            ],
+        );
         let builder = RunQueryBuilder::new()
             .with_parameter_match(&pm)
-            .expect("nested dot path");
+            .expect("valid multi-condition");
         let bound = bound_strings(&builder);
         assert!(
             bound
                 .iter()
-                .any(|s| s == "$.content.metrics.max_temp ? (@ <= 85.0)"),
-            "expected nested dot path in JSONPath, got: {bound:?}"
+                .any(|s| s == "$ ? (@.content.lr >= 0.005 && @.content.lr <= 0.05)"),
+            "expected composable multi-condition form, got: {bound:?}"
         );
     }
 
     #[test]
-    fn pm_build_jsonpath_string_value_quoted() {
-        let expr = build_parameter_jsonpath("orbit", &ComparisonOp::Eq, &serde_json::json!("LEO"))
-            .expect("valid string match");
-        assert_eq!(expr, r#"$.content.orbit ? (@ == "LEO")"#);
+    fn pm_multi_condition_different_fields_compose() {
+        let pm = pm_with(
+            Phase::Pre,
+            Some("train.json"),
+            None,
+            vec![
+                cond("lr", ComparisonOp::Ge, serde_json::json!(0.005)),
+                cond("epoch", ComparisonOp::Eq, serde_json::json!(10)),
+            ],
+        );
+        let builder = RunQueryBuilder::new()
+            .with_parameter_match(&pm)
+            .expect("valid multi-condition");
+        let bound = bound_strings(&builder);
+        assert!(
+            bound
+                .iter()
+                .any(|s| s == "$ ? (@.content.lr >= 0.005 && @.content.epoch == 10)"),
+            "expected multi-field compose form, got: {bound:?}"
+        );
+    }
+
+    // ---- parameter path validation & quoting (Issue 4 fix) ---------
+
+    #[test]
+    fn pm_accepts_hyphenated_parameter_via_quoting() {
+        let expr = build_conditions_jsonpath(&[cond(
+            "learning-rate",
+            ComparisonOp::Eq,
+            serde_json::json!(0.1),
+        )])
+        .expect("hyphens must be quoted, not rejected");
+        assert_eq!(expr, r#"$.content."learning-rate" ? (@ == 0.1)"#);
+        JsonPath::new(&expr).expect("quoted-segment path must be valid JSONPath");
     }
 
     #[test]
+    fn pm_accepts_non_ascii_parameter_via_quoting() {
+        let expr = build_conditions_jsonpath(&[cond(
+            "温度",
+            ComparisonOp::Eq,
+            serde_json::json!(25),
+        )])
+        .expect("non-ASCII keys must be quoted, not rejected");
+        assert_eq!(expr, r#"$.content."温度" ? (@ == 25)"#);
+        JsonPath::new(&expr).expect("quoted-segment path must be valid JSONPath");
+    }
+
+    #[test]
+    fn pm_nested_path_mixes_bare_and_quoted_segments() {
+        let expr = build_conditions_jsonpath(&[cond(
+            "sat1.learning-rate.value",
+            ComparisonOp::Le,
+            serde_json::json!(0.5),
+        )])
+        .expect("mixed-segment path");
+        assert_eq!(
+            expr,
+            r#"$.content.sat1."learning-rate".value ? (@ <= 0.5)"#
+        );
+    }
+
+    #[test]
+    fn pm_rejects_empty_parameter() {
+        let err =
+            build_conditions_jsonpath(&[cond("", ComparisonOp::Eq, serde_json::json!(1))])
+                .unwrap_err();
+        assert!(format!("{err:?}").contains("must not be empty"));
+    }
+
+    #[test]
+    fn pm_rejects_empty_parameter_segment() {
+        for bad in ["a..b", ".a", "a."] {
+            let err = build_conditions_jsonpath(&[cond(
+                bad,
+                ComparisonOp::Eq,
+                serde_json::json!(1),
+            )])
+            .unwrap_err();
+            assert!(format!("{err:?}").contains("empty segment"), "for {bad}");
+        }
+    }
+
+    #[test]
+    fn pm_rejects_control_char_in_parameter() {
+        let err = build_conditions_jsonpath(&[cond(
+            "a\nb",
+            ComparisonOp::Eq,
+            serde_json::json!(1),
+        )])
+        .unwrap_err();
+        assert!(format!("{err:?}").contains("control character"));
+    }
+
+    #[test]
+    fn pm_rejects_oversize_parameter() {
+        let long = "a".repeat(201);
+        let err = build_conditions_jsonpath(&[cond(
+            &long,
+            ComparisonOp::Eq,
+            serde_json::json!(1),
+        )])
+        .unwrap_err();
+        assert!(format!("{err:?}").contains("200 bytes"));
+    }
+
+    #[test]
+    fn pm_quoted_segment_escapes_backslash_and_quote() {
+        // A parameter segment containing both `"` and `\` must round-trip
+        // through the parser rather than break the JSONPath syntax.
+        let expr = build_conditions_jsonpath(&[cond(
+            r#"a"b\c"#,
+            ComparisonOp::Eq,
+            serde_json::json!(1),
+        )])
+        .expect("segment with quotes must be quoted, not rejected");
+        assert_eq!(expr, r#"$.content."a\"b\\c" ? (@ == 1)"#);
+        JsonPath::new(&expr).expect("escaped quoted segment must be valid JSONPath");
+    }
+
+    // ---- value validation ------------------------------------------
+
+    #[test]
+    fn pm_string_value_is_quoted_and_escaped() {
+        let expr = build_conditions_jsonpath(&[cond(
+            "name",
+            ComparisonOp::Eq,
+            serde_json::json!(r#"a"b\c"#),
+        )])
+        .expect("escape should succeed");
+        assert_eq!(expr, r#"$.content.name ? (@ == "a\"b\\c")"#);
+        JsonPath::new(&expr).expect("emitted expression must be valid JSONPath");
+    }
+
+    #[test]
+    fn pm_rejects_null_value() {
+        let err = build_conditions_jsonpath(&[cond(
+            "x",
+            ComparisonOp::Eq,
+            serde_json::Value::Null,
+        )])
+        .unwrap_err();
+        assert!(format!("{err:?}").contains("must be number, string, or boolean"));
+    }
+
+    #[test]
+    fn pm_rejects_array_value() {
+        let err = build_conditions_jsonpath(&[cond(
+            "x",
+            ComparisonOp::Eq,
+            serde_json::json!([1, 2]),
+        )])
+        .unwrap_err();
+        assert!(format!("{err:?}").contains("must be number, string, or boolean"));
+    }
+
+    // ---- hook_index composition ------------------------------------
+
+    #[test]
     fn pm_hook_index_only_generates_hook_index_clause() {
-        let pm = ParameterMatch {
-            phase: "pre".into(),
-            file: None,
-            hook_index: Some(2),
-            parameter: None,
-            operator: None,
-            value: None,
-        };
+        let pm = pm_with(Phase::Pre, None, Some(2), vec![]);
         let builder = RunQueryBuilder::new()
             .with_parameter_match(&pm)
             .expect("hook_index-only parameter match");
@@ -687,26 +921,20 @@ mod tests {
         assert!(query.contains("ro.hook_index = $"));
         assert!(!query.contains("ro.config->>'path'"));
         assert!(!query.contains("jsonb_path_exists"));
-        let has_hook_index = builder.bind_values().iter().any(|v| match v {
-            BindValue::I32(i) => *i == 2,
-            _ => false,
-        });
-        assert!(has_hook_index, "expected hook_index=2 in bind values");
+        assert!(builder.bind_values().iter().any(|v| matches!(v, BindValue::I32(2))));
     }
 
     #[test]
-    fn pm_hook_index_with_file_and_parameter_composes_all_clauses() {
-        let pm = ParameterMatch {
-            phase: "post".into(),
-            file: Some("config.json".into()),
-            hook_index: Some(1),
-            parameter: Some("lr".into()),
-            operator: Some(ComparisonOp::Eq),
-            value: Some(serde_json::json!(0.01)),
-        };
+    fn pm_hook_index_with_file_and_conditions_composes_all_clauses() {
+        let pm = pm_with(
+            Phase::Post,
+            Some("config.json"),
+            Some(1),
+            vec![cond("lr", ComparisonOp::Eq, serde_json::json!(0.01))],
+        );
         let builder = RunQueryBuilder::new()
             .with_parameter_match(&pm)
-            .expect("hook_index + file + parameter compose");
+            .expect("hook_index + file + conditions compose");
         let query = builder.build_query();
         assert!(query.contains("ro.output ? 'content'"));
         assert!(query.contains("ro.config->>'path'"));
@@ -716,18 +944,7 @@ mod tests {
 
     #[test]
     fn pm_hook_index_alone_satisfies_at_least_one_rule() {
-        let pm = ParameterMatch {
-            phase: "pre".into(),
-            file: None,
-            hook_index: Some(0),
-            parameter: None,
-            operator: None,
-            value: None,
-        };
-        let result = RunQueryBuilder::new().with_parameter_match(&pm);
-        assert!(
-            result.is_ok(),
-            "hook_index alone should satisfy the at-least-one rule"
-        );
+        let pm = pm_with(Phase::Pre, None, Some(0), vec![]);
+        assert!(RunQueryBuilder::new().with_parameter_match(&pm).is_ok());
     }
 }

--- a/crates/capsula-server/src/query.rs
+++ b/crates/capsula-server/src/query.rs
@@ -563,7 +563,11 @@ mod tests {
             .collect()
     }
 
-    fn cond(parameter: &str, operator: ComparisonOp, value: serde_json::Value) -> ParameterCondition {
+    fn cond(
+        parameter: &str,
+        operator: ComparisonOp,
+        value: serde_json::Value,
+    ) -> ParameterCondition {
         ParameterCondition {
             parameter: parameter.to_string(),
             operator,
@@ -790,12 +794,9 @@ mod tests {
 
     #[test]
     fn pm_accepts_non_ascii_parameter_via_quoting() {
-        let expr = build_conditions_jsonpath(&[cond(
-            "温度",
-            ComparisonOp::Eq,
-            serde_json::json!(25),
-        )])
-        .expect("non-ASCII keys must be quoted, not rejected");
+        let expr =
+            build_conditions_jsonpath(&[cond("温度", ComparisonOp::Eq, serde_json::json!(25))])
+                .expect("non-ASCII keys must be quoted, not rejected");
         assert_eq!(expr, r#"$.content."温度" ? (@ == 25)"#);
         JsonPath::new(&expr).expect("quoted-segment path must be valid JSONPath");
     }
@@ -808,53 +809,39 @@ mod tests {
             serde_json::json!(0.5),
         )])
         .expect("mixed-segment path");
-        assert_eq!(
-            expr,
-            r#"$.content.sat1."learning-rate".value ? (@ <= 0.5)"#
-        );
+        assert_eq!(expr, r#"$.content.sat1."learning-rate".value ? (@ <= 0.5)"#);
     }
 
     #[test]
     fn pm_rejects_empty_parameter() {
-        let err =
-            build_conditions_jsonpath(&[cond("", ComparisonOp::Eq, serde_json::json!(1))])
-                .unwrap_err();
+        let err = build_conditions_jsonpath(&[cond("", ComparisonOp::Eq, serde_json::json!(1))])
+            .unwrap_err();
         assert!(format!("{err:?}").contains("must not be empty"));
     }
 
     #[test]
     fn pm_rejects_empty_parameter_segment() {
         for bad in ["a..b", ".a", "a."] {
-            let err = build_conditions_jsonpath(&[cond(
-                bad,
-                ComparisonOp::Eq,
-                serde_json::json!(1),
-            )])
-            .unwrap_err();
+            let err =
+                build_conditions_jsonpath(&[cond(bad, ComparisonOp::Eq, serde_json::json!(1))])
+                    .unwrap_err();
             assert!(format!("{err:?}").contains("empty segment"), "for {bad}");
         }
     }
 
     #[test]
     fn pm_rejects_control_char_in_parameter() {
-        let err = build_conditions_jsonpath(&[cond(
-            "a\nb",
-            ComparisonOp::Eq,
-            serde_json::json!(1),
-        )])
-        .unwrap_err();
+        let err =
+            build_conditions_jsonpath(&[cond("a\nb", ComparisonOp::Eq, serde_json::json!(1))])
+                .unwrap_err();
         assert!(format!("{err:?}").contains("control character"));
     }
 
     #[test]
     fn pm_rejects_oversize_parameter() {
         let long = "a".repeat(201);
-        let err = build_conditions_jsonpath(&[cond(
-            &long,
-            ComparisonOp::Eq,
-            serde_json::json!(1),
-        )])
-        .unwrap_err();
+        let err = build_conditions_jsonpath(&[cond(&long, ComparisonOp::Eq, serde_json::json!(1))])
+            .unwrap_err();
         assert!(format!("{err:?}").contains("200 bytes"));
     }
 
@@ -862,12 +849,9 @@ mod tests {
     fn pm_quoted_segment_escapes_backslash_and_quote() {
         // A parameter segment containing both `"` and `\` must round-trip
         // through the parser rather than break the JSONPath syntax.
-        let expr = build_conditions_jsonpath(&[cond(
-            r#"a"b\c"#,
-            ComparisonOp::Eq,
-            serde_json::json!(1),
-        )])
-        .expect("segment with quotes must be quoted, not rejected");
+        let expr =
+            build_conditions_jsonpath(&[cond(r#"a"b\c"#, ComparisonOp::Eq, serde_json::json!(1))])
+                .expect("segment with quotes must be quoted, not rejected");
         assert_eq!(expr, r#"$.content."a\"b\\c" ? (@ == 1)"#);
         JsonPath::new(&expr).expect("escaped quoted segment must be valid JSONPath");
     }
@@ -888,23 +872,17 @@ mod tests {
 
     #[test]
     fn pm_rejects_null_value() {
-        let err = build_conditions_jsonpath(&[cond(
-            "x",
-            ComparisonOp::Eq,
-            serde_json::Value::Null,
-        )])
-        .unwrap_err();
+        let err =
+            build_conditions_jsonpath(&[cond("x", ComparisonOp::Eq, serde_json::Value::Null)])
+                .unwrap_err();
         assert!(format!("{err:?}").contains("must be number, string, or boolean"));
     }
 
     #[test]
     fn pm_rejects_array_value() {
-        let err = build_conditions_jsonpath(&[cond(
-            "x",
-            ComparisonOp::Eq,
-            serde_json::json!([1, 2]),
-        )])
-        .unwrap_err();
+        let err =
+            build_conditions_jsonpath(&[cond("x", ComparisonOp::Eq, serde_json::json!([1, 2]))])
+                .unwrap_err();
         assert!(format!("{err:?}").contains("must be number, string, or boolean"));
     }
 
@@ -921,7 +899,12 @@ mod tests {
         assert!(query.contains("ro.hook_index = $"));
         assert!(!query.contains("ro.config->>'path'"));
         assert!(!query.contains("jsonb_path_exists"));
-        assert!(builder.bind_values().iter().any(|v| matches!(v, BindValue::I32(2))));
+        assert!(
+            builder
+                .bind_values()
+                .iter()
+                .any(|v| matches!(v, BindValue::I32(2)))
+        );
     }
 
     #[test]

--- a/crates/capsula-server/tests/api_tests.rs
+++ b/crates/capsula-server/tests/api_tests.rs
@@ -1090,6 +1090,25 @@ async fn pm_search(ctx: &TestContext, body: serde_json::Value) -> serde_json::Va
     response.json().await.expect("parse body")
 }
 
+/// For payloads rejected before the handler runs — invalid `Phase`,
+/// unknown fields, missing required condition fields, etc. Axum's `Json`
+/// extractor emits HTTP 422 in those cases without a JSON body, so we
+/// can't use `pm_search`.
+async fn pm_search_expects_serde_error(ctx: &TestContext, body: serde_json::Value) {
+    let client = reqwest::Client::new();
+    let response = client
+        .post(format!("{}/api/v1/runs/search", ctx.base_url()))
+        .json(&body)
+        .send()
+        .await
+        .expect("search request");
+    assert!(
+        response.status().is_client_error(),
+        "expected 4xx client error, got {}",
+        response.status()
+    );
+}
+
 fn pm_run_ids(body: &serde_json::Value) -> Vec<String> {
     body["runs"]
         .as_array()
@@ -1475,7 +1494,7 @@ async fn pm_file_only_matches_when_file_present() {
 async fn pm_invalid_phase_returns_error() {
     let ctx = TestContext::new().await;
 
-    let body = pm_search(
+    pm_search_expects_serde_error(
         &ctx,
         json!({
             "vault": "v1",
@@ -1486,8 +1505,6 @@ async fn pm_invalid_phase_returns_error() {
         }),
     )
     .await;
-
-    assert_eq!(body["status"], "error", "body: {body}");
 }
 
 #[tokio::test]
@@ -1516,7 +1533,7 @@ async fn pm_outer_parameter_operator_value_rejected_as_unknown_fields() {
     // treating the payload as a file-only match.
     let ctx = TestContext::new().await;
 
-    let body = pm_search(
+    pm_search_expects_serde_error(
         &ctx,
         json!({
             "vault": "v1",
@@ -1530,8 +1547,6 @@ async fn pm_outer_parameter_operator_value_rejected_as_unknown_fields() {
         }),
     )
     .await;
-
-    assert_eq!(body["status"], "error", "body: {body}");
 }
 
 #[tokio::test]
@@ -1540,7 +1555,7 @@ async fn pm_condition_missing_value_is_rejected() {
     // Option wrapping, so serde rejects the payload at deserialize time.
     let ctx = TestContext::new().await;
 
-    let body = pm_search(
+    pm_search_expects_serde_error(
         &ctx,
         json!({
             "vault": "v1",
@@ -1556,8 +1571,6 @@ async fn pm_condition_missing_value_is_rejected() {
         }),
     )
     .await;
-
-    assert_eq!(body["status"], "error", "body: {body}");
 }
 
 #[tokio::test]

--- a/crates/capsula-server/tests/api_tests.rs
+++ b/crates/capsula-server/tests/api_tests.rs
@@ -1129,9 +1129,7 @@ async fn pm_finds_run_by_file_and_parameter() {
             "parameter_matches": [{
                 "phase": "pre",
                 "file": "config.json",
-                "parameter": "lr",
-                "operator": "ge",
-                "value": 0.01,
+                "conditions": [{ "parameter": "lr", "operator": "ge", "value": 0.01 }],
             }]
         }),
     )
@@ -1175,9 +1173,7 @@ async fn pm_string_eq() {
             "parameter_matches": [{
                 "phase": "pre",
                 "file": "model.json",
-                "parameter": "architecture",
-                "operator": "eq",
-                "value": "transformer",
+                "conditions": [{ "parameter": "architecture", "operator": "eq", "value": "transformer" }],
             }]
         }),
     )
@@ -1220,9 +1216,7 @@ async fn pm_nested_dot_path() {
             "parameter_matches": [{
                 "phase": "pre",
                 "file": "sat1/orbit.json",
-                "parameter": "orbit.a",
-                "operator": "ge",
-                "value": 1.0,
+                "conditions": [{ "parameter": "orbit.a", "operator": "ge", "value": 1.0 }],
             }]
         }),
     )
@@ -1296,10 +1290,12 @@ async fn pm_multiple_matches_are_anded_across_files() {
         json!({
             "vault": "v1",
             "parameter_matches": [
-                { "phase": "pre", "file": "train.json", "parameter": "lr",
-                  "operator": "ge", "value": 0.001 },
-                { "phase": "pre", "file": "data.json", "parameter": "batch_size",
-                  "operator": "eq", "value": 32 }
+                { "phase": "pre", "file": "train.json",
+                  "conditions": [{ "parameter": "lr", "operator": "ge", "value": 0.001 }],
+              },
+                { "phase": "pre", "file": "data.json",
+                  "conditions": [{ "parameter": "batch_size", "operator": "eq", "value": 32 }],
+              }
             ]
         }),
     )
@@ -1344,16 +1340,22 @@ async fn pm_range_query_on_same_file() {
     )
     .await;
 
+    // Both bounds go in a single ParameterMatch's `conditions` list so
+    // they are evaluated as a per-row AND, not as two independent
+    // `EXISTS`. See `ParameterMatch::conditions` for the false positive
+    // this shape avoids.
     let body = pm_search(
         &ctx,
         json!({
             "vault": "v1",
-            "parameter_matches": [
-                { "phase": "pre", "file": "train.json", "parameter": "lr",
-                  "operator": "ge", "value": 0.005 },
-                { "phase": "pre", "file": "train.json", "parameter": "lr",
-                  "operator": "le", "value": 0.05 }
-            ]
+            "parameter_matches": [{
+                "phase": "pre",
+                "file": "train.json",
+                "conditions": [
+                    { "parameter": "lr", "operator": "ge", "value": 0.005 },
+                    { "parameter": "lr", "operator": "le", "value": 0.05 }
+                ]
+            }]
         }),
     )
     .await;
@@ -1386,9 +1388,7 @@ async fn pm_phase_pre_does_not_match_post_outputs() {
             "parameter_matches": [{
                 "phase": "pre",
                 "file": "config.json",
-                "parameter": "lr",
-                "operator": "eq",
-                "value": 0.01,
+                "conditions": [{ "parameter": "lr", "operator": "eq", "value": 0.01 }],
             }]
         }),
     )
@@ -1420,9 +1420,7 @@ async fn pm_does_not_match_non_parameter_hooks() {
             "vault": "v1",
             "parameter_matches": [{
                 "phase": "pre",
-                "parameter": "value",
-                "operator": "eq",
-                "value": "/usr/bin",
+                "conditions": [{ "parameter": "value", "operator": "eq", "value": "/usr/bin" }],
             }]
         }),
     )
@@ -1511,7 +1509,11 @@ async fn pm_empty_match_returns_error() {
 }
 
 #[tokio::test]
-async fn pm_partial_triple_returns_error() {
+async fn pm_outer_parameter_operator_value_rejected_as_unknown_fields() {
+    // Old API took a flat `parameter`/`operator`/`value` triple on
+    // ParameterMatch itself. `deny_unknown_fields` on the new shape
+    // rejects any client still sending that form instead of silently
+    // treating the payload as a file-only match.
     let ctx = TestContext::new().await;
 
     let body = pm_search(
@@ -1522,14 +1524,109 @@ async fn pm_partial_triple_returns_error() {
                 "phase": "pre",
                 "file": "config.json",
                 "parameter": "lr",
-                "operator": "ge"
-                // value missing
+                "operator": "ge",
+                "value": 0.01,
             }]
         }),
     )
     .await;
 
     assert_eq!(body["status"], "error", "body: {body}");
+}
+
+#[tokio::test]
+async fn pm_condition_missing_value_is_rejected() {
+    // Inside a ParameterCondition, `value` has no default and no
+    // Option wrapping, so serde rejects the payload at deserialize time.
+    let ctx = TestContext::new().await;
+
+    let body = pm_search(
+        &ctx,
+        json!({
+            "vault": "v1",
+            "parameter_matches": [{
+                "phase": "pre",
+                "file": "config.json",
+                "conditions": [{
+                    "parameter": "lr",
+                    "operator": "ge"
+                    // value missing
+                }]
+            }]
+        }),
+    )
+    .await;
+
+    assert_eq!(body["status"], "error", "body: {body}");
+}
+
+#[tokio::test]
+async fn pm_range_on_same_field_uses_per_row_semantics() {
+    // Adversarial fixture: one run with two rows on the same file
+    // (disambiguated by hook_index), lr=0.001 and lr=0.1. Under the
+    // old "one condition per entry" API, sending `lr >= 0.005` and
+    // `lr <= 0.05` as two `parameter_matches` entries would satisfy
+    // both `EXISTS` clauses via different rows and falsely match the
+    // run. Wrapping both bounds in one entry's `conditions` list
+    // compiles them into a single per-row predicate, so no row
+    // satisfies both bounds and the run does not match.
+    let ctx = TestContext::new().await;
+    let run_id = "01PMI005ADVEROWRANGEROW";
+
+    pm_create_run(&ctx, run_id, "v1").await;
+    let pre_run_hooks = json!([
+        {
+            "__meta": {
+                "id": "capture-json",
+                "config": { "path": "train.json" },
+                "success": true,
+                "error": null
+            },
+            "content": { "lr": 0.001 }
+        },
+        {
+            "__meta": {
+                "id": "capture-json",
+                "config": { "path": "train.json" },
+                "success": true,
+                "error": null
+            },
+            "content": { "lr": 0.1 }
+        }
+    ]);
+    let form = reqwest::multipart::Form::new()
+        .text("run_id", run_id.to_string())
+        .text("pre_run", pre_run_hooks.to_string());
+    let client = reqwest::Client::new();
+    let response = client
+        .post(format!("{}/api/v1/upload", ctx.base_url()))
+        .multipart(form)
+        .send()
+        .await
+        .expect("upload two rows same file");
+    assert_eq!(response.status(), 200);
+
+    let body = pm_search(
+        &ctx,
+        json!({
+            "vault": "v1",
+            "parameter_matches": [{
+                "phase": "pre",
+                "file": "train.json",
+                "conditions": [
+                    { "parameter": "lr", "operator": "ge", "value": 0.005 },
+                    { "parameter": "lr", "operator": "le", "value": 0.05 }
+                ]
+            }]
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        body["total"], 0,
+        "per-row AND must not match a run whose two rows separately \
+         satisfy each bound; body: {body}"
+    );
 }
 
 // Uploads a phase whose array contains multiple parameter-capturing hooks
@@ -1616,9 +1713,7 @@ async fn pm_hook_index_pins_to_specific_row() {
             "parameter_matches": [{
                 "phase": "pre",
                 "hook_index": 1,
-                "parameter": "lr",
-                "operator": "eq",
-                "value": 0.1,
+                "conditions": [{ "parameter": "lr", "operator": "eq", "value": 0.1 }],
             }]
         }),
     )
@@ -1673,9 +1768,7 @@ async fn pm_hook_index_out_of_range_returns_no_match() {
             "parameter_matches": [{
                 "phase": "pre",
                 "hook_index": 5,
-                "parameter": "lr",
-                "operator": "eq",
-                "value": 0.01,
+                "conditions": [{ "parameter": "lr", "operator": "eq", "value": 0.01 }],
             }]
         }),
     )

--- a/crates/capsula-server/tests/api_tests.rs
+++ b/crates/capsula-server/tests/api_tests.rs
@@ -974,3 +974,560 @@ async fn response_exposes_hook_index_and_preserves_array_order() {
     assert_eq!(pre[2]["__meta"]["id"], "capture-command");
     assert_eq!(pre[2]["stdout"], "second");
 }
+// =============================================================================
+// ParameterMatch integration tests
+// =============================================================================
+//
+// Exercises POST /api/v1/runs/search with `parameter_matches`. The filter
+// targets rows produced by parameter-capturing hooks (capture-json,
+// capture-toml), which all share the shape:
+//
+//   __meta.config = { "path": "<configured-path>" }
+//   output        = { "content": <parsed JSON> }
+//
+// The server selects rows structurally (`output ? 'content'`), pins by
+// `config->>'path'` when `file` is set, and adds a JSONPath predicate
+// rooted at `$.content` when `parameter`+`operator`+`value` is set.
+
+async fn pm_create_run(ctx: &TestContext, run_id: &str, vault: &str) {
+    let run_data = json!({
+        "id": run_id,
+        "name": format!("test-{run_id}"),
+        "timestamp": "2026-01-08T10:00:00Z",
+        "command": "test",
+        "vault": vault,
+        "project_root": "/tmp/test",
+        "exit_code": 0,
+        "duration_ms": 100,
+        "stdout": null,
+        "stderr": null,
+    });
+    let client = reqwest::Client::new();
+    let response = client
+        .post(format!("{}/api/v1/runs", ctx.base_url()))
+        .json(&run_data)
+        .send()
+        .await
+        .expect("create run");
+    assert_eq!(response.status(), 201, "create_run for {run_id} failed");
+}
+
+async fn pm_upload_hook(
+    ctx: &TestContext,
+    run_id: &str,
+    phase: &str,
+    hook_id: &str,
+    config: serde_json::Value,
+    payload: serde_json::Value,
+) {
+    let mut combined = serde_json::Map::new();
+    combined.insert(
+        "__meta".to_string(),
+        json!({
+            "id": hook_id,
+            "config": config,
+            "success": true,
+            "error": null,
+        }),
+    );
+    if let Some(obj) = payload.as_object() {
+        for (k, v) in obj {
+            combined.insert(k.clone(), v.clone());
+        }
+    }
+    let hooks_array = serde_json::Value::Array(vec![serde_json::Value::Object(combined)]);
+    let field = match phase {
+        "pre" => "pre_run",
+        "post" => "post_run",
+        other => panic!("phase must be 'pre' or 'post', got: {other}"),
+    };
+    let form = reqwest::multipart::Form::new()
+        .text("run_id", run_id.to_string())
+        .text(field, hooks_array.to_string());
+    let client = reqwest::Client::new();
+    let response = client
+        .post(format!("{}/api/v1/upload", ctx.base_url()))
+        .multipart(form)
+        .send()
+        .await
+        .expect("upload hook");
+    assert_eq!(
+        response.status(),
+        200,
+        "upload {phase} hook for {run_id} failed"
+    );
+}
+
+async fn pm_seed_capture_json(
+    ctx: &TestContext,
+    run_id: &str,
+    vault: &str,
+    phase: &str,
+    file: &str,
+    content: serde_json::Value,
+) {
+    pm_create_run(ctx, run_id, vault).await;
+    pm_upload_hook(
+        ctx,
+        run_id,
+        phase,
+        "capture-json",
+        json!({ "path": file }),
+        json!({ "content": content }),
+    )
+    .await;
+}
+
+async fn pm_search(ctx: &TestContext, body: serde_json::Value) -> serde_json::Value {
+    let client = reqwest::Client::new();
+    let response = client
+        .post(format!("{}/api/v1/runs/search", ctx.base_url()))
+        .json(&body)
+        .send()
+        .await
+        .expect("search request");
+    assert_eq!(response.status(), 200);
+    response.json().await.expect("parse body")
+}
+
+fn pm_run_ids(body: &serde_json::Value) -> Vec<String> {
+    body["runs"]
+        .as_array()
+        .expect("runs array")
+        .iter()
+        .map(|r| r["id"].as_str().expect("id").to_string())
+        .collect()
+}
+
+#[tokio::test]
+async fn pm_finds_run_by_file_and_parameter() {
+    let ctx = TestContext::new().await;
+
+    pm_seed_capture_json(
+        &ctx,
+        "01PMI001AAAAAAAAAAAAAAA",
+        "v1",
+        "pre",
+        "config.json",
+        json!({ "lr": 0.01 }),
+    )
+    .await;
+    pm_seed_capture_json(
+        &ctx,
+        "01PMI001BBBBBBBBBBBBBBB",
+        "v1",
+        "pre",
+        "config.json",
+        json!({ "lr": 0.001 }),
+    )
+    .await;
+
+    let body = pm_search(
+        &ctx,
+        json!({
+            "vault": "v1",
+            "parameter_matches": [{
+                "phase": "pre",
+                "file": "config.json",
+                "parameter": "lr",
+                "operator": "ge",
+                "value": 0.01,
+            }]
+        }),
+    )
+    .await;
+
+    assert_eq!(body["status"], "ok");
+    assert_eq!(body["total"], 1);
+    assert_eq!(
+        pm_run_ids(&body),
+        vec!["01PMI001AAAAAAAAAAAAAAA".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn pm_string_eq() {
+    let ctx = TestContext::new().await;
+
+    pm_seed_capture_json(
+        &ctx,
+        "01PMI002STRAAAAAAAAAAAA",
+        "v1",
+        "pre",
+        "model.json",
+        json!({ "architecture": "transformer" }),
+    )
+    .await;
+    pm_seed_capture_json(
+        &ctx,
+        "01PMI002STRBBBBBBBBBBBB",
+        "v1",
+        "pre",
+        "model.json",
+        json!({ "architecture": "lstm" }),
+    )
+    .await;
+
+    let body = pm_search(
+        &ctx,
+        json!({
+            "vault": "v1",
+            "parameter_matches": [{
+                "phase": "pre",
+                "file": "model.json",
+                "parameter": "architecture",
+                "operator": "eq",
+                "value": "transformer",
+            }]
+        }),
+    )
+    .await;
+
+    assert_eq!(body["total"], 1);
+    assert_eq!(
+        pm_run_ids(&body),
+        vec!["01PMI002STRAAAAAAAAAAAA".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn pm_nested_dot_path() {
+    let ctx = TestContext::new().await;
+
+    pm_seed_capture_json(
+        &ctx,
+        "01PMI003NESTAAAAAAAAAAA",
+        "v1",
+        "pre",
+        "sat1/orbit.json",
+        json!({ "orbit": { "a": 1.42 } }),
+    )
+    .await;
+    pm_seed_capture_json(
+        &ctx,
+        "01PMI003NESTBBBBBBBBBBB",
+        "v1",
+        "pre",
+        "sat1/orbit.json",
+        json!({ "orbit": { "a": 0.5 } }),
+    )
+    .await;
+
+    let body = pm_search(
+        &ctx,
+        json!({
+            "vault": "v1",
+            "parameter_matches": [{
+                "phase": "pre",
+                "file": "sat1/orbit.json",
+                "parameter": "orbit.a",
+                "operator": "ge",
+                "value": 1.0,
+            }]
+        }),
+    )
+    .await;
+
+    assert_eq!(body["total"], 1);
+    assert_eq!(
+        pm_run_ids(&body),
+        vec!["01PMI003NESTAAAAAAAAAAA".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn pm_multiple_matches_are_anded_across_files() {
+    let ctx = TestContext::new().await;
+
+    // Run A: two capture-json hooks with the same hook_id but distinct
+    // config.path. With the hook_index widening of the run_outputs unique
+    // index (#1017 / #1036), they coexist as separate rows.
+    //
+    // NOTE: capsula's `/api/v1/upload` enumerates each phase's array with
+    // `.enumerate()` and uses the position as hook_index. Calling
+    // `pm_upload_hook` twice in a row each sends a 1-element array, so
+    // both rows would receive hook_index=0 and the second upload would
+    // ON CONFLICT UPSERT the first. Send both hooks in a single multipart
+    // POST instead — that mirrors how the real CLI uploads pre-run.json.
+    pm_create_run(&ctx, "01PMI004ANDOKAAAAAAAAAA", "v1").await;
+    let pre_run_hooks = json!([
+        {
+            "__meta": {
+                "id": "capture-json",
+                "config": { "path": "train.json" },
+                "success": true,
+                "error": null
+            },
+            "content": { "lr": 0.01 }
+        },
+        {
+            "__meta": {
+                "id": "capture-json",
+                "config": { "path": "data.json" },
+                "success": true,
+                "error": null
+            },
+            "content": { "batch_size": 32 }
+        }
+    ]);
+    let form = reqwest::multipart::Form::new()
+        .text("run_id", "01PMI004ANDOKAAAAAAAAAA".to_string())
+        .text("pre_run", pre_run_hooks.to_string());
+    let response = reqwest::Client::new()
+        .post(format!("{}/api/v1/upload", ctx.base_url()))
+        .multipart(form)
+        .send()
+        .await
+        .expect("batch upload");
+    assert_eq!(response.status(), 200);
+
+    pm_seed_capture_json(
+        &ctx,
+        "01PMI004ANDNOBBBBBBBBBB",
+        "v1",
+        "pre",
+        "train.json",
+        json!({ "lr": 0.01 }),
+    )
+    .await;
+
+    let body = pm_search(
+        &ctx,
+        json!({
+            "vault": "v1",
+            "parameter_matches": [
+                { "phase": "pre", "file": "train.json", "parameter": "lr",
+                  "operator": "ge", "value": 0.001 },
+                { "phase": "pre", "file": "data.json", "parameter": "batch_size",
+                  "operator": "eq", "value": 32 }
+            ]
+        }),
+    )
+    .await;
+
+    assert_eq!(body["total"], 1);
+    assert_eq!(
+        pm_run_ids(&body),
+        vec!["01PMI004ANDOKAAAAAAAAAA".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn pm_range_query_on_same_file() {
+    let ctx = TestContext::new().await;
+
+    pm_seed_capture_json(
+        &ctx,
+        "01PMI005RNG001AAAAAAAAA",
+        "v1",
+        "pre",
+        "train.json",
+        json!({ "lr": 0.001 }),
+    )
+    .await;
+    pm_seed_capture_json(
+        &ctx,
+        "01PMI005RNG010BBBBBBBBB",
+        "v1",
+        "pre",
+        "train.json",
+        json!({ "lr": 0.01 }),
+    )
+    .await;
+    pm_seed_capture_json(
+        &ctx,
+        "01PMI005RNG100CCCCCCCCC",
+        "v1",
+        "pre",
+        "train.json",
+        json!({ "lr": 0.1 }),
+    )
+    .await;
+
+    let body = pm_search(
+        &ctx,
+        json!({
+            "vault": "v1",
+            "parameter_matches": [
+                { "phase": "pre", "file": "train.json", "parameter": "lr",
+                  "operator": "ge", "value": 0.005 },
+                { "phase": "pre", "file": "train.json", "parameter": "lr",
+                  "operator": "le", "value": 0.05 }
+            ]
+        }),
+    )
+    .await;
+
+    assert_eq!(body["total"], 1);
+    assert_eq!(
+        pm_run_ids(&body),
+        vec!["01PMI005RNG010BBBBBBBBB".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn pm_phase_pre_does_not_match_post_outputs() {
+    let ctx = TestContext::new().await;
+
+    pm_seed_capture_json(
+        &ctx,
+        "01PMI006PHASEAAAAAAAAAA",
+        "v1",
+        "post",
+        "config.json",
+        json!({ "lr": 0.01 }),
+    )
+    .await;
+
+    let body = pm_search(
+        &ctx,
+        json!({
+            "vault": "v1",
+            "parameter_matches": [{
+                "phase": "pre",
+                "file": "config.json",
+                "parameter": "lr",
+                "operator": "eq",
+                "value": 0.01,
+            }]
+        }),
+    )
+    .await;
+
+    assert_eq!(body["total"], 0);
+}
+
+#[tokio::test]
+async fn pm_does_not_match_non_parameter_hooks() {
+    let ctx = TestContext::new().await;
+
+    // capture-env style: no `content` field. ParameterMatch's structural
+    // filter (`output ? 'content'`) must skip it.
+    pm_create_run(&ctx, "01PMI007OTHRAAAAAAAAAAA", "v1").await;
+    pm_upload_hook(
+        &ctx,
+        "01PMI007OTHRAAAAAAAAAAA",
+        "pre",
+        "capture-env",
+        json!({ "name": "PATH" }),
+        json!({ "value": "/usr/bin" }),
+    )
+    .await;
+
+    let body = pm_search(
+        &ctx,
+        json!({
+            "vault": "v1",
+            "parameter_matches": [{
+                "phase": "pre",
+                "parameter": "value",
+                "operator": "eq",
+                "value": "/usr/bin",
+            }]
+        }),
+    )
+    .await;
+
+    assert_eq!(body["total"], 0);
+}
+
+#[tokio::test]
+async fn pm_file_only_matches_when_file_present() {
+    let ctx = TestContext::new().await;
+
+    pm_seed_capture_json(
+        &ctx,
+        "01PMI008FOAAAAAAAAAAAAA",
+        "v1",
+        "pre",
+        "orbit.json",
+        json!({ "a": 1 }),
+    )
+    .await;
+    pm_seed_capture_json(
+        &ctx,
+        "01PMI008FOBBBBBBBBBBBBB",
+        "v1",
+        "pre",
+        "other.json",
+        json!({ "a": 1 }),
+    )
+    .await;
+
+    let body = pm_search(
+        &ctx,
+        json!({
+            "vault": "v1",
+            "parameter_matches": [{
+                "phase": "pre",
+                "file": "orbit.json",
+            }]
+        }),
+    )
+    .await;
+
+    assert_eq!(body["total"], 1);
+    assert_eq!(
+        pm_run_ids(&body),
+        vec!["01PMI008FOAAAAAAAAAAAAA".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn pm_invalid_phase_returns_error() {
+    let ctx = TestContext::new().await;
+
+    let body = pm_search(
+        &ctx,
+        json!({
+            "vault": "v1",
+            "parameter_matches": [{
+                "phase": "during",
+                "file": "config.json",
+            }]
+        }),
+    )
+    .await;
+
+    assert_eq!(body["status"], "error", "body: {body}");
+}
+
+#[tokio::test]
+async fn pm_empty_match_returns_error() {
+    let ctx = TestContext::new().await;
+
+    let body = pm_search(
+        &ctx,
+        json!({
+            "vault": "v1",
+            "parameter_matches": [{
+                "phase": "pre",
+            }]
+        }),
+    )
+    .await;
+
+    assert_eq!(body["status"], "error", "body: {body}");
+}
+
+#[tokio::test]
+async fn pm_partial_triple_returns_error() {
+    let ctx = TestContext::new().await;
+
+    let body = pm_search(
+        &ctx,
+        json!({
+            "vault": "v1",
+            "parameter_matches": [{
+                "phase": "pre",
+                "file": "config.json",
+                "parameter": "lr",
+                "operator": "ge"
+                // value missing
+            }]
+        }),
+    )
+    .await;
+
+    assert_eq!(body["status"], "error", "body: {body}");
+}

--- a/crates/capsula-server/tests/api_tests.rs
+++ b/crates/capsula-server/tests/api_tests.rs
@@ -1531,3 +1531,215 @@ async fn pm_partial_triple_returns_error() {
 
     assert_eq!(body["status"], "error", "body: {body}");
 }
+
+// Uploads a phase whose array contains multiple parameter-capturing hooks
+// so `hook_index` (server-assigned via `.enumerate()`) is the only way to
+// disambiguate individual rows. Used by the `hook_index`-focused tests.
+async fn pm_upload_two_hook_array(ctx: &TestContext, run_id: &str, vault: &str) {
+    pm_create_run(ctx, run_id, vault).await;
+    let pre_run_hooks = json!([
+        {
+            "__meta": {
+                "id": "capture-json",
+                "config": { "path": "first.json" },
+                "success": true,
+                "error": null
+            },
+            "content": { "lr": 0.01 }
+        },
+        {
+            "__meta": {
+                "id": "capture-json",
+                "config": { "path": "second.json" },
+                "success": true,
+                "error": null
+            },
+            "content": { "lr": 0.1 }
+        }
+    ]);
+    let form = reqwest::multipart::Form::new()
+        .text("run_id", run_id.to_string())
+        .text("pre_run", pre_run_hooks.to_string());
+    let response = reqwest::Client::new()
+        .post(format!("{}/api/v1/upload", ctx.base_url()))
+        .multipart(form)
+        .send()
+        .await
+        .expect("batch upload");
+    assert_eq!(response.status(), 200, "two-hook batch upload failed");
+}
+
+#[tokio::test]
+async fn pm_hook_index_pins_to_specific_row() {
+    let ctx = TestContext::new().await;
+
+    // Match run whose hook at index 1 has lr == 0.1.
+    pm_upload_two_hook_array(&ctx, "01PMI010HIDXOKAAAAAAAAA", "v1").await;
+
+    // Decoy: a run whose hook at index 0 has lr == 0.1 (but not at 1).
+    pm_create_run(&ctx, "01PMI010HIDXNOBBBBBBBBB", "v1").await;
+    let decoy = json!([
+        {
+            "__meta": {
+                "id": "capture-json",
+                "config": { "path": "first.json" },
+                "success": true,
+                "error": null
+            },
+            "content": { "lr": 0.1 }
+        },
+        {
+            "__meta": {
+                "id": "capture-json",
+                "config": { "path": "second.json" },
+                "success": true,
+                "error": null
+            },
+            "content": { "lr": 0.01 }
+        }
+    ]);
+    let form = reqwest::multipart::Form::new()
+        .text("run_id", "01PMI010HIDXNOBBBBBBBBB".to_string())
+        .text("pre_run", decoy.to_string());
+    let response = reqwest::Client::new()
+        .post(format!("{}/api/v1/upload", ctx.base_url()))
+        .multipart(form)
+        .send()
+        .await
+        .expect("decoy upload");
+    assert_eq!(response.status(), 200);
+
+    let body = pm_search(
+        &ctx,
+        json!({
+            "vault": "v1",
+            "parameter_matches": [{
+                "phase": "pre",
+                "hook_index": 1,
+                "parameter": "lr",
+                "operator": "eq",
+                "value": 0.1,
+            }]
+        }),
+    )
+    .await;
+
+    assert_eq!(body["total"], 1);
+    assert_eq!(
+        pm_run_ids(&body),
+        vec!["01PMI010HIDXOKAAAAAAAAA".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn pm_hook_index_alone_matches_row_at_position() {
+    let ctx = TestContext::new().await;
+
+    pm_upload_two_hook_array(&ctx, "01PMI011HIDXALONEAAAAAA", "v1").await;
+
+    // hook_index=0 alone (no file, no parameter): should match the row at
+    // position 0 in the phase's array — succeeds because our fixture has
+    // exactly two parameter-capturing rows.
+    let body = pm_search(
+        &ctx,
+        json!({
+            "vault": "v1",
+            "parameter_matches": [{
+                "phase": "pre",
+                "hook_index": 0,
+            }]
+        }),
+    )
+    .await;
+
+    assert_eq!(body["total"], 1);
+    assert_eq!(
+        pm_run_ids(&body),
+        vec!["01PMI011HIDXALONEAAAAAA".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn pm_hook_index_out_of_range_returns_no_match() {
+    let ctx = TestContext::new().await;
+
+    pm_upload_two_hook_array(&ctx, "01PMI012HIDXOOBAAAAAAAA", "v1").await;
+
+    // No hook at index 5 in the phase's array.
+    let body = pm_search(
+        &ctx,
+        json!({
+            "vault": "v1",
+            "parameter_matches": [{
+                "phase": "pre",
+                "hook_index": 5,
+                "parameter": "lr",
+                "operator": "eq",
+                "value": 0.01,
+            }]
+        }),
+    )
+    .await;
+
+    assert_eq!(body["total"], 0);
+}
+
+#[tokio::test]
+async fn pm_hook_index_composes_with_file() {
+    let ctx = TestContext::new().await;
+
+    // Match: hook at position 1 whose config.path is "second.json".
+    pm_upload_two_hook_array(&ctx, "01PMI013HIDXCMPOKAAAAAA", "v1").await;
+
+    // Mismatch: hook at position 1 exists but its file is "different.json".
+    pm_create_run(&ctx, "01PMI013HIDXCMPNOBBBBBB", "v1").await;
+    let mismatch = json!([
+        {
+            "__meta": {
+                "id": "capture-json",
+                "config": { "path": "first.json" },
+                "success": true,
+                "error": null
+            },
+            "content": { "lr": 0.01 }
+        },
+        {
+            "__meta": {
+                "id": "capture-json",
+                "config": { "path": "different.json" },
+                "success": true,
+                "error": null
+            },
+            "content": { "lr": 0.1 }
+        }
+    ]);
+    let form = reqwest::multipart::Form::new()
+        .text("run_id", "01PMI013HIDXCMPNOBBBBBB".to_string())
+        .text("pre_run", mismatch.to_string());
+    let response = reqwest::Client::new()
+        .post(format!("{}/api/v1/upload", ctx.base_url()))
+        .multipart(form)
+        .send()
+        .await
+        .expect("mismatch upload");
+    assert_eq!(response.status(), 200);
+
+    let body = pm_search(
+        &ctx,
+        json!({
+            "vault": "v1",
+            "parameter_matches": [{
+                "phase": "pre",
+                "hook_index": 1,
+                "file": "second.json",
+            }]
+        }),
+    )
+    .await;
+
+    assert_eq!(body["total"], 1);
+    assert_eq!(
+        pm_run_ids(&body),
+        vec!["01PMI013HIDXCMPOKAAAAAA".to_string()]
+    );
+}


### PR DESCRIPTION
## Summary

Adds `ParameterMatch` to `POST /api/v1/runs/search` for structured filtering over parameter-capturing hooks (`capture-json`, `capture-toml`, ...). Each entry selects `run_outputs` rows structurally (by the presence of a top-level `content` field, decoupled from `hook_id`), then narrows by any of:

- `file` — exact match on `run_outputs.config->>'path'`
- `hook_index` — 0-based position in `capsula.toml`'s phase array (disambiguates repeated `hook_id` / file combinations)
- `conditions` — one or more `<parameter> <operator> <value>` predicates, compiled into a single JSONPath and applied per row

`conditions` is a list so a range like `lr >= 0.005 && lr <= 0.05` compiles to one predicate on the same row. Two separate `parameter_matches` entries would AND across rows and can falsely match a run whose rows separately satisfy each bound.

## Example — range on the same field

```json
POST /api/v1/runs/search
{
  "vault": "training",
  "parameter_matches": [{
    "phase": "pre",
    "file": "train.json",
    "conditions": [
      { "parameter": "lr", "operator": "ge", "value": 0.005 },
      { "parameter": "lr", "operator": "le", "value": 0.05 }
    ]
  }]
}
```

compiles to `$ ? (@.content.lr >= 0.005 && @.content.lr <= 0.05)` inside a single `EXISTS` subquery.

## Changes

**`capsula-api-types`** — public wire types
- `ComparisonOp` (`eq` / `ne` / `gt` / `ge` / `lt` / `le`)
- `Phase` (`pre` / `post`), replaces raw `String`
- `ParameterCondition { parameter, operator, value }`
- `ParameterMatch { phase, file?, hook_index?, conditions[] }` — `deny_unknown_fields`
- `SearchRunsRequest.parameter_matches: Vec<ParameterMatch>`

**`capsula-server`**
- `models.rs`: `Deserialize`-only mirrors with `deny_unknown_fields`
- `query.rs`:
  - `with_parameter_match` — assembles the `EXISTS` clause and per-condition JSONPath
  - `build_conditions_jsonpath` — single condition emits the compact `$.content.<path> ? (@ <op> <val>)`; two or more emit the composable `$ ? (@.content.<p1> <op1> <v1> && ...)`
  - `build_path` — splits the parameter on `.`, quotes any segment outside bare ASCII `[A-Za-z0-9_]`, escapes `"` and `\` inside quoted segments — so keys like `learning-rate` and `温度` are addressable without opening injection
  - `QueryError::InvalidParameterMatch(String)` for structured-match errors
  - Validation: `phase` at serde level; `hook_index >= 0`; `Bool` value only with `eq`/`ne`; `MAX_PARAMETER_MATCHES = 32`; per-condition `parameter` length + empty-segment + control-char rejection; `value` restricted to number / string / boolean

## Validation semantics

| Constraint | Enforced by | Behaviour |
|---|---|---|
| Unknown `phase` string | serde | 4xx via handler |
| Outer `parameter` / `operator` typo | `deny_unknown_fields` | 4xx via handler |
| Missing at least one of `file` / `hook_index` / `conditions` | `with_parameter_match` | `InvalidParameterMatch` |
| Negative `hook_index` | `with_parameter_match` | `InvalidParameterMatch` |
| Bool value + ordering operator | `with_parameter_match` | `InvalidParameterMatch` |
| `parameter_matches.len() > 32` | `from_request` | `InvalidParameterMatch` |
| Empty / oversized / control-char in `parameter` | `build_path` | `InvalidParameterMatch` |
| Non-number/string/bool `value` | `value_to_jsonpath` | `InvalidParameterMatch` |

## Tests

Unit tests in `crates/capsula-server/src/query.rs` (25 for `pm_*`):
- shape / composition: `pm_file_and_single_condition_generate_full_query`, `pm_file_only_omits_jsonpath`, `pm_condition_only_omits_file_clause`, `pm_hook_index_only_generates_hook_index_clause`, `pm_hook_index_with_file_and_conditions_composes_all_clauses`, `pm_hook_index_alone_satisfies_at_least_one_rule`
- multi-condition: `pm_multi_condition_range_on_same_field_compiles_to_single_predicate`, `pm_multi_condition_different_fields_compose`
- path quoting: `pm_accepts_hyphenated_parameter_via_quoting`, `pm_accepts_non_ascii_parameter_via_quoting`, `pm_nested_path_mixes_bare_and_quoted_segments`, `pm_quoted_segment_escapes_backslash_and_quote`
- path rejection: `pm_rejects_empty_parameter`, `pm_rejects_empty_parameter_segment`, `pm_rejects_control_char_in_parameter`, `pm_rejects_oversize_parameter`
- value validation: `pm_string_value_is_quoted_and_escaped`, `pm_rejects_null_value`, `pm_rejects_array_value`, `pm_rejects_bool_value_with_ordering_operator`, `pm_accepts_bool_value_with_eq_and_ne`
- shape rejection: `pm_rejects_empty_match`, `pm_rejects_invalid_phase`, `pm_rejects_negative_hook_index`, `pm_rejects_too_many_parameter_matches`

Integration tests in `crates/capsula-server/tests/api_tests.rs` (22 `pm_*` tests) exercise the endpoint end-to-end against a testcontainer Postgres. Highlights:
- `pm_range_on_same_field_uses_per_row_semantics` — adversarial: one run with two rows on the same file (`lr = 0.001`, `lr = 0.1`), range `[0.005, 0.05]` must not match under the new per-row semantics
- `pm_range_query_on_same_file` — normal range on distinct-row fixtures
- `pm_outer_parameter_operator_value_rejected_as_unknown_fields` — locks in the `deny_unknown_fields` guard against the old flat-triple wire form
- `pm_condition_missing_value_is_rejected` — locks in serde-level rejection of an incomplete `ParameterCondition`

## Follow-ups (not in this PR)

- `jsonb_path_exists()` is not GIN-indexable; switching this call site and the pre-existing `with_hook_filter` call to the `@?` operator would restore index usage. Tracked separately.
- `hook_filters` has no per-request count cap; adding a parallel `MAX_HOOK_FILTERS` was scoped out.
- `SearchRunsRequest` is duplicated between `capsula-api-types` and `capsula-server::models` (pre-existing structural point).

Closes #971