### PR TITLE
feat: add Python client package for Capsula server API

### DIFF
--- a/clients/python/.gitignore
+++ b/clients/python/.gitignore
@@ -1,0 +1,3 @@
+.venv/
+.pytest_cache/
+__pycache__/

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "capsula-client"
+version = "0.1.0"
+description = "Python client for the Capsula server API"
+requires-python = ">=3.12"
+dependencies = [
+    "httpx>=0.28",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-httpx>=0.35",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/capsula_client"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/clients/python/src/capsula_client/__init__.py
+++ b/clients/python/src/capsula_client/__init__.py
@@ -1,0 +1,29 @@
+"""Python client for the Capsula server API."""
+
+from capsula_client._client import CapsulaClient
+from capsula_client._models import (
+    ComparisonOp,
+    FileInfo,
+    HookFilter,
+    HookOutput,
+    ParameterMatch,
+    SearchRunsRequest,
+    SearchRunsResponse,
+    SearchRunResult,
+    SortOrder,
+    VaultInfo,
+)
+
+__all__ = [
+    "CapsulaClient",
+    "ComparisonOp",
+    "FileInfo",
+    "HookFilter",
+    "HookOutput",
+    "ParameterMatch",
+    "SearchRunsRequest",
+    "SearchRunsResponse",
+    "SearchRunResult",
+    "SortOrder",
+    "VaultInfo",
+]

--- a/clients/python/src/capsula_client/_client.py
+++ b/clients/python/src/capsula_client/_client.py
@@ -1,0 +1,141 @@
+"""Capsula server HTTP client."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from capsula_client._models import (
+    FileInfo,
+    HookOutput,
+    SearchRunResult,
+    SearchRunsRequest,
+    SearchRunsResponse,
+    VaultInfo,
+)
+
+
+class CapsulaClientError(Exception):
+    """Error communicating with the Capsula server."""
+
+
+class CapsulaClient:
+    """Python client for the Capsula server API.
+
+    Usage::
+
+        client = CapsulaClient("https://capsula.example.com")
+        vaults = client.list_vaults()
+        results = client.search_runs(SearchRunsRequest(vault="my-vault"))
+    """
+
+    def __init__(self, base_url: str, *, timeout: float = 30.0) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._client = httpx.Client(base_url=self._base_url, timeout=timeout)
+
+    def close(self) -> None:
+        """Close the underlying HTTP client."""
+        self._client.close()
+
+    def __enter__(self) -> CapsulaClient:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+    # --- Vaults ---
+
+    def list_vaults(self) -> list[VaultInfo]:
+        """List all vaults on the server."""
+        resp = self._request("GET", "/api/v1/vaults")
+        return [VaultInfo(name=v["name"], run_count=v["run_count"]) for v in resp["vaults"]]
+
+    def vault_exists(self, vault_name: str) -> VaultInfo | None:
+        """Check if a vault exists. Returns VaultInfo or None."""
+        resp = self._request("GET", f"/api/v1/vaults/{vault_name}")
+        if resp.get("exists"):
+            v = resp["vault"]
+            return VaultInfo(name=v["name"], run_count=v["run_count"])
+        return None
+
+    # --- Runs ---
+
+    def search_runs(self, request: SearchRunsRequest) -> SearchRunsResponse:
+        """Search for runs matching the given criteria."""
+        resp = self._request("POST", "/api/v1/runs/search", json=request.to_dict())
+        runs = [_parse_run(r) for r in resp.get("runs", [])]
+        return SearchRunsResponse(
+            status=resp.get("status", "ok"),
+            total=resp.get("total", len(runs)),
+            runs=runs,
+        )
+
+    def get_run(self, run_id: str) -> dict[str, Any]:
+        """Get details of a specific run."""
+        return self._request("GET", f"/api/v1/runs/{run_id}")
+
+    # --- Internal ---
+
+    def _request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+        """Make an HTTP request and return the parsed JSON response."""
+        try:
+            resp = self._client.request(method, path, **kwargs)
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            raise CapsulaClientError(
+                f"Server returned {e.response.status_code}: {e.response.text}"
+            ) from e
+        except httpx.HTTPError as e:
+            raise CapsulaClientError(f"HTTP request failed: {e}") from e
+        return resp.json()
+
+
+def _parse_run(data: dict[str, Any]) -> SearchRunResult:
+    """Parse a run from the server response."""
+    return SearchRunResult(
+        id=data["id"],
+        name=data["name"],
+        timestamp=data["timestamp"],
+        vault=data["vault"],
+        command=data["command"],
+        project_root=data["project_root"],
+        exit_code=data.get("exit_code"),
+        duration_ms=data.get("duration_ms"),
+        stdout=data.get("stdout"),
+        stderr=data.get("stderr"),
+        files=_parse_files(data.get("files")) if data.get("files") is not None else None,
+        pre_run_hooks=_parse_hooks(data.get("pre_run_hooks")) if data.get("pre_run_hooks") is not None else None,
+        post_run_hooks=_parse_hooks(data.get("post_run_hooks")) if data.get("post_run_hooks") is not None else None,
+    )
+
+
+def _parse_hooks(hooks: list[dict[str, Any]]) -> list[HookOutput]:
+    """Parse hook outputs from the server response."""
+    result = []
+    for h in hooks:
+        meta = h.get("__meta", {})
+        output = {k: v for k, v in h.items() if k != "__meta"}
+        result.append(
+            HookOutput(
+                hook_id=meta.get("id", ""),
+                output=output,
+                success=meta.get("success", True),
+                config=meta.get("config"),
+                error=meta.get("error"),
+            )
+        )
+    return result
+
+
+def _parse_files(files: list[dict[str, Any]]) -> list[FileInfo]:
+    """Parse file info from the server response."""
+    return [
+        FileInfo(
+            path=f["path"],
+            size=f["size"],
+            url=f["url"],
+            hash=f.get("hash"),
+        )
+        for f in files
+    ]

--- a/clients/python/src/capsula_client/_client.py
+++ b/clients/python/src/capsula_client/_client.py
@@ -123,6 +123,7 @@ def _parse_hooks(hooks: list[dict[str, Any]]) -> list[HookOutput]:
                 success=meta.get("success", True),
                 config=meta.get("config"),
                 error=meta.get("error"),
+                hook_index=meta.get("hook_index"),
             )
         )
     return result

--- a/clients/python/src/capsula_client/_models.py
+++ b/clients/python/src/capsula_client/_models.py
@@ -1,0 +1,189 @@
+"""Data models mirroring capsula-api-types (Rust) for the Python client."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class ComparisonOp(str, Enum):
+    """Comparison operator for parameter matching."""
+
+    EQ = "eq"
+    NE = "ne"
+    GT = "gt"
+    GE = "ge"
+    LT = "lt"
+    LE = "le"
+
+
+class SortOrder(str, Enum):
+    """Sort order for search results."""
+
+    LATEST_FIRST = "latest_first"
+    OLDEST_FIRST = "oldest_first"
+
+
+@dataclass(frozen=True, slots=True)
+class VaultInfo:
+    """Information about a vault."""
+
+    name: str
+    run_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class HookFilter:
+    """A filter condition on a hook's output using JSONPath."""
+
+    hook_id: str
+    output_filter: str
+    config_filter: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ParameterMatch:
+    """Structured filter for parameter-capturing hooks (``capture-json``, ``capture-toml``, ...).
+
+    Targets ``run_outputs`` rows whose ``output`` JSON has the shape
+    ``{"content": <parsed JSON>}`` and whose ``__meta.config.path`` carries
+    the source file path. The server picks matching rows structurally (by
+    the presence of the ``content`` field), so the filter is decoupled from
+    any specific ``hook_id``.
+
+    Constraints (validated server-side; the client does not raise):
+
+    - At least one of ``file`` / ``parameter`` must be specified.
+    - ``parameter``, ``operator``, and ``value`` are an all-or-nothing
+      triple — supply all three or none.
+    - Specifying ``parameter`` without ``file`` causes the server to log
+      a warning, since the match will scan every parameter-capturing row
+      of the run.
+
+    Example:
+        ``ParameterMatch("pre", file="config/sat1/orbit.json",
+        parameter="a", operator=ComparisonOp.GE, value=1.0)``
+        generates ``$.content.a ? (@ >= 1.0)`` against the row whose
+        ``config.path == "config/sat1/orbit.json"``.
+
+    For querying outputs of non-parameter hooks (``capture-env``,
+    ``capture-command``, ...), use :class:`HookFilter` with a raw JSONPath
+    expression instead.
+    """
+
+    phase: str
+    file: str | None = None
+    parameter: str | None = None
+    operator: ComparisonOp | None = None
+    value: Any | None = None  # number, string, or bool
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {"phase": self.phase}
+        if self.file is not None:
+            d["file"] = self.file
+        if self.parameter is not None:
+            d["parameter"] = self.parameter
+        if self.operator is not None:
+            d["operator"] = self.operator.value
+        if self.value is not None:
+            d["value"] = self.value
+        return d
+
+
+@dataclass(slots=True)
+class SearchRunsRequest:
+    """Request body for POST /api/v1/runs/search."""
+
+    vault: str | None = None
+    from_: str | None = None
+    to: str | None = None
+    exit_code: int | None = None
+    success: bool | None = None
+    hook_filters: list[HookFilter] = field(default_factory=list)
+    parameter_matches: list[ParameterMatch] = field(default_factory=list)
+    include: list[str] = field(default_factory=list)
+    order: SortOrder = SortOrder.LATEST_FIRST
+    limit: int | None = None
+    offset: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {}
+        if self.vault is not None:
+            d["vault"] = self.vault
+        if self.from_ is not None:
+            d["from"] = self.from_
+        if self.to is not None:
+            d["to"] = self.to
+        if self.exit_code is not None:
+            d["exit_code"] = self.exit_code
+        if self.success is not None:
+            d["success"] = self.success
+        if self.hook_filters:
+            d["hook_filters"] = [
+                {
+                    "hook_id": f.hook_id,
+                    "output_filter": f.output_filter,
+                    **({"config_filter": f.config_filter} if f.config_filter else {}),
+                }
+                for f in self.hook_filters
+            ]
+        if self.parameter_matches:
+            d["parameter_matches"] = [pm.to_dict() for pm in self.parameter_matches]
+        if self.include:
+            d["include"] = self.include
+        d["order"] = self.order.value
+        if self.limit is not None:
+            d["limit"] = self.limit
+        if self.offset is not None:
+            d["offset"] = self.offset
+        return d
+
+
+@dataclass(frozen=True, slots=True)
+class HookOutput:
+    """A hook's output from a run."""
+
+    hook_id: str
+    output: dict[str, Any]
+    success: bool
+    config: dict[str, Any] | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class FileInfo:
+    """File information in search results."""
+
+    path: str
+    size: int
+    url: str
+    hash: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SearchRunResult:
+    """A single run in search results."""
+
+    id: str
+    name: str
+    timestamp: str
+    vault: str
+    command: str
+    project_root: str
+    exit_code: int | None = None
+    duration_ms: int | None = None
+    stdout: str | None = None
+    stderr: str | None = None
+    files: list[FileInfo] | None = None
+    pre_run_hooks: list[HookOutput] | None = None
+    post_run_hooks: list[HookOutput] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SearchRunsResponse:
+    """Response from POST /api/v1/runs/search."""
+
+    status: str
+    total: int
+    runs: list[SearchRunResult]

--- a/clients/python/src/capsula_client/_models.py
+++ b/clients/python/src/capsula_client/_models.py
@@ -54,18 +54,24 @@ class ParameterMatch:
 
     Constraints (validated server-side; the client does not raise):
 
-    - At least one of ``file`` / ``parameter`` must be specified.
+    - At least one of ``file`` / ``hook_index`` / ``parameter`` must be
+      specified.
     - ``parameter``, ``operator``, and ``value`` are an all-or-nothing
       triple — supply all three or none.
-    - Specifying ``parameter`` without ``file`` causes the server to log
-      a warning, since the match will scan every parameter-capturing row
-      of the run.
+    - Specifying ``parameter`` without either ``file`` or ``hook_index``
+      causes the server to log a warning, since the match will scan every
+      parameter-capturing row of the run.
 
     Example:
         ``ParameterMatch("pre", file="config/sat1/orbit.json",
         parameter="a", operator=ComparisonOp.GE, value=1.0)``
         generates ``$.content.a ? (@ >= 1.0)`` against the row whose
         ``config.path == "config/sat1/orbit.json"``.
+
+    Use ``hook_index`` to pin the match to a specific 0-based position in
+    the phase's array — useful when several parameter-capturing hooks in
+    ``capsula.toml`` share the same ``file`` / ``hook_id`` and would
+    otherwise be indistinguishable.
 
     For querying outputs of non-parameter hooks (``capture-env``,
     ``capture-command``, ...), use :class:`HookFilter` with a raw JSONPath
@@ -74,6 +80,7 @@ class ParameterMatch:
 
     phase: str
     file: str | None = None
+    hook_index: int | None = None
     parameter: str | None = None
     operator: ComparisonOp | None = None
     value: Any | None = None  # number, string, or bool
@@ -82,6 +89,8 @@ class ParameterMatch:
         d: dict[str, Any] = {"phase": self.phase}
         if self.file is not None:
             d["file"] = self.file
+        if self.hook_index is not None:
+            d["hook_index"] = self.hook_index
         if self.parameter is not None:
             d["parameter"] = self.parameter
         if self.operator is not None:
@@ -142,13 +151,20 @@ class SearchRunsRequest:
 
 @dataclass(frozen=True, slots=True)
 class HookOutput:
-    """A hook's output from a run."""
+    """A hook's output from a run.
+
+    ``hook_index`` is the 0-based position of this hook in the phase's array
+    (``pre_run`` / ``post_run`` in ``capsula.toml``). It is populated from
+    ``__meta.hook_index`` in the server response; older server responses
+    that do not include it leave the field as ``None``.
+    """
 
     hook_id: str
     output: dict[str, Any]
     success: bool
     config: dict[str, Any] | None = None
     error: str | None = None
+    hook_index: int | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -84,6 +84,44 @@ class TestParameterMatch:
         assert d["phase"] == "post"
         assert d["file"] == "model.json"
 
+    def test_to_dict_hook_index_alone(self):
+        pm = ParameterMatch(phase="pre", hook_index=2)
+        d = pm.to_dict()
+        assert d == {"phase": "pre", "hook_index": 2}
+        assert "file" not in d
+        assert "parameter" not in d
+
+    def test_to_dict_hook_index_composed_with_file_and_parameter(self):
+        pm = ParameterMatch(
+            phase="pre",
+            file="config.json",
+            hook_index=1,
+            parameter="lr",
+            operator=ComparisonOp.EQ,
+            value=0.01,
+        )
+        d = pm.to_dict()
+        assert d == {
+            "phase": "pre",
+            "file": "config.json",
+            "hook_index": 1,
+            "parameter": "lr",
+            "operator": "eq",
+            "value": 0.01,
+        }
+
+    def test_to_dict_hook_index_zero_is_included(self):
+        # ``hook_index`` uses ``is not None`` (not a falsy check), so 0
+        # must still be serialized — it is a legitimate array position.
+        pm = ParameterMatch(phase="pre", hook_index=0)
+        d = pm.to_dict()
+        assert d["hook_index"] == 0
+
+    def test_to_dict_default_hook_index_omitted(self):
+        pm = ParameterMatch(phase="pre", file="c.json")
+        d = pm.to_dict()
+        assert "hook_index" not in d
+
 
 class TestSearchRunsRequest:
     def test_minimal(self):
@@ -198,13 +236,21 @@ class TestCapsulaClient:
                         "exit_code": 0,
                         "pre_run_hooks": [
                             {
-                                "__meta": {"id": "capture-command", "success": True},
+                                "__meta": {
+                                    "id": "capture-command",
+                                    "success": True,
+                                    "hook_index": 0,
+                                },
                                 "solar_flux": 1361.0,
                             }
                         ],
                         "post_run_hooks": [
                             {
-                                "__meta": {"id": "capture-file", "success": True},
+                                "__meta": {
+                                    "id": "capture-file",
+                                    "success": True,
+                                    "hook_index": 3,
+                                },
                                 "max_temperature": 85.3,
                             }
                         ],
@@ -240,8 +286,43 @@ class TestCapsulaClient:
         assert resp.runs[0].id == "abc123"
         assert resp.runs[0].pre_run_hooks is not None
         assert resp.runs[0].pre_run_hooks[0].output["solar_flux"] == 1361.0
+        assert resp.runs[0].pre_run_hooks[0].hook_index == 0
         assert resp.runs[0].post_run_hooks is not None
         assert resp.runs[0].post_run_hooks[0].output["max_temperature"] == 85.3
+        assert resp.runs[0].post_run_hooks[0].hook_index == 3
+
+    def test_search_runs_missing_hook_index_is_none(self, httpx_mock):
+        # Older server responses (before hook_index was exposed) omit the
+        # field in ``__meta``. The client should tolerate this by leaving
+        # ``HookOutput.hook_index`` as ``None`` rather than raising.
+        httpx_mock.add_response(
+            url="https://capsula.test/api/v1/runs/search",
+            json={
+                "status": "ok",
+                "total": 1,
+                "runs": [
+                    {
+                        "id": "legacy001",
+                        "name": "legacy-response",
+                        "timestamp": "2026-05-15T12:00:00Z",
+                        "vault": "v1",
+                        "command": "true",
+                        "project_root": "/tmp/p",
+                        "exit_code": 0,
+                        "pre_run_hooks": [
+                            {
+                                "__meta": {"id": "capture-command", "success": True},
+                                "solar_flux": 1361.0,
+                            }
+                        ],
+                    }
+                ],
+            },
+        )
+        with CapsulaClient("https://capsula.test") as client:
+            resp = client.search_runs(SearchRunsRequest(vault="v1"))
+        assert resp.runs[0].pre_run_hooks is not None
+        assert resp.runs[0].pre_run_hooks[0].hook_index is None
 
     def test_search_runs_empty(self, httpx_mock):
         httpx_mock.add_response(

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -1,0 +1,264 @@
+"""Tests for capsula_client."""
+
+from __future__ import annotations
+
+import pytest
+
+from capsula_client import (
+    CapsulaClient,
+    ComparisonOp,
+    HookFilter,
+    ParameterMatch,
+    SearchRunsRequest,
+    SortOrder,
+)
+
+
+# --- Model tests ---
+
+
+class TestParameterMatch:
+    def test_to_dict_file_and_parameter(self):
+        pm = ParameterMatch(
+            phase="pre",
+            file="config/sat1/orbit.json",
+            parameter="a",
+            operator=ComparisonOp.GE,
+            value=1.0,
+        )
+        assert pm.to_dict() == {
+            "phase": "pre",
+            "file": "config/sat1/orbit.json",
+            "parameter": "a",
+            "operator": "ge",
+            "value": 1.0,
+        }
+
+    def test_to_dict_file_only_omits_triple(self):
+        pm = ParameterMatch(phase="pre", file="config.json")
+        d = pm.to_dict()
+        assert d == {"phase": "pre", "file": "config.json"}
+        assert "parameter" not in d
+        assert "operator" not in d
+        assert "value" not in d
+
+    def test_to_dict_parameter_only_omits_file(self):
+        pm = ParameterMatch(
+            phase="pre",
+            parameter="lr",
+            operator=ComparisonOp.GE,
+            value=0.01,
+        )
+        d = pm.to_dict()
+        assert d == {
+            "phase": "pre",
+            "parameter": "lr",
+            "operator": "ge",
+            "value": 0.01,
+        }
+        assert "file" not in d
+
+    def test_to_dict_nested_dot_path(self):
+        pm = ParameterMatch(
+            phase="pre",
+            file="sat1/orbit.json",
+            parameter="orbit.a",
+            operator=ComparisonOp.GE,
+            value=1.0,
+        )
+        d = pm.to_dict()
+        assert d["file"] == "sat1/orbit.json"
+        assert d["parameter"] == "orbit.a"
+        assert d["operator"] == "ge"
+
+    def test_to_dict_string_value(self):
+        pm = ParameterMatch(
+            phase="post",
+            file="model.json",
+            parameter="architecture",
+            operator=ComparisonOp.EQ,
+            value="transformer",
+        )
+        d = pm.to_dict()
+        assert d["value"] == "transformer"
+        assert d["phase"] == "post"
+        assert d["file"] == "model.json"
+
+
+class TestSearchRunsRequest:
+    def test_minimal(self):
+        req = SearchRunsRequest(vault="my-vault")
+        d = req.to_dict()
+        assert d["vault"] == "my-vault"
+        assert d["order"] == "latest_first"
+        assert "hook_filters" not in d
+        assert "parameter_matches" not in d
+
+    def test_with_parameter_matches(self):
+        req = SearchRunsRequest(
+            vault="thermal-sim",
+            parameter_matches=[
+                ParameterMatch(
+                    phase="pre",
+                    file="env.json",
+                    parameter="solar_flux",
+                    operator=ComparisonOp.GE,
+                    value=1347.39,
+                ),
+                ParameterMatch(
+                    phase="pre",
+                    file="env.json",
+                    parameter="solar_flux",
+                    operator=ComparisonOp.LE,
+                    value=1374.61,
+                ),
+            ],
+            include=["hooks"],
+            limit=1,
+        )
+        d = req.to_dict()
+        assert len(d["parameter_matches"]) == 2
+        assert d["parameter_matches"][0]["operator"] == "ge"
+        assert d["parameter_matches"][0]["file"] == "env.json"
+        assert d["parameter_matches"][1]["operator"] == "le"
+        assert d["include"] == ["hooks"]
+        assert d["limit"] == 1
+
+    def test_with_hook_filter(self):
+        req = SearchRunsRequest(
+            hook_filters=[
+                HookFilter("capture-git-repo", '$.sha ? (@ starts with "abc")'),
+            ],
+        )
+        d = req.to_dict()
+        assert len(d["hook_filters"]) == 1
+        assert d["hook_filters"][0]["hook_id"] == "capture-git-repo"
+
+    def test_omits_none_fields(self):
+        req = SearchRunsRequest()
+        d = req.to_dict()
+        assert "vault" not in d
+        assert "exit_code" not in d
+        assert "from" not in d
+
+    def test_order(self):
+        req = SearchRunsRequest(order=SortOrder.OLDEST_FIRST)
+        d = req.to_dict()
+        assert d["order"] == "oldest_first"
+
+
+# --- Client tests (with mocked HTTP) ---
+
+
+class TestCapsulaClient:
+    def test_list_vaults(self, httpx_mock):
+        httpx_mock.add_response(
+            url="https://capsula.test/api/v1/vaults",
+            json={"status": "ok", "vaults": [{"name": "my-vault", "run_count": 5}]},
+        )
+        with CapsulaClient("https://capsula.test") as client:
+            vaults = client.list_vaults()
+        assert len(vaults) == 1
+        assert vaults[0].name == "my-vault"
+        assert vaults[0].run_count == 5
+
+    def test_vault_exists(self, httpx_mock):
+        httpx_mock.add_response(
+            url="https://capsula.test/api/v1/vaults/my-vault",
+            json={"status": "ok", "exists": True, "vault": {"name": "my-vault", "run_count": 3}},
+        )
+        with CapsulaClient("https://capsula.test") as client:
+            vault = client.vault_exists("my-vault")
+        assert vault is not None
+        assert vault.name == "my-vault"
+
+    def test_vault_not_exists(self, httpx_mock):
+        httpx_mock.add_response(
+            url="https://capsula.test/api/v1/vaults/nonexistent",
+            json={"status": "ok", "exists": False, "vault": None},
+        )
+        with CapsulaClient("https://capsula.test") as client:
+            vault = client.vault_exists("nonexistent")
+        assert vault is None
+
+    def test_search_runs(self, httpx_mock):
+        httpx_mock.add_response(
+            url="https://capsula.test/api/v1/runs/search",
+            json={
+                "status": "ok",
+                "total": 1,
+                "runs": [
+                    {
+                        "id": "abc123",
+                        "name": "happy-river",
+                        "timestamp": "2026-05-15T12:00:00Z",
+                        "vault": "thermal-sim",
+                        "command": "python sim.py",
+                        "project_root": "/home/user/project",
+                        "exit_code": 0,
+                        "pre_run_hooks": [
+                            {
+                                "__meta": {"id": "capture-command", "success": True},
+                                "solar_flux": 1361.0,
+                            }
+                        ],
+                        "post_run_hooks": [
+                            {
+                                "__meta": {"id": "capture-file", "success": True},
+                                "max_temperature": 85.3,
+                            }
+                        ],
+                    }
+                ],
+            },
+        )
+        with CapsulaClient("https://capsula.test") as client:
+            resp = client.search_runs(
+                SearchRunsRequest(
+                    vault="thermal-sim",
+                    parameter_matches=[
+                        ParameterMatch(
+                            phase="pre",
+                            file="env.json",
+                            parameter="solar_flux",
+                            operator=ComparisonOp.GE,
+                            value=1347.39,
+                        ),
+                        ParameterMatch(
+                            phase="pre",
+                            file="env.json",
+                            parameter="solar_flux",
+                            operator=ComparisonOp.LE,
+                            value=1374.61,
+                        ),
+                    ],
+                    include=["hooks"],
+                    limit=1,
+                )
+            )
+        assert resp.total == 1
+        assert resp.runs[0].id == "abc123"
+        assert resp.runs[0].pre_run_hooks is not None
+        assert resp.runs[0].pre_run_hooks[0].output["solar_flux"] == 1361.0
+        assert resp.runs[0].post_run_hooks is not None
+        assert resp.runs[0].post_run_hooks[0].output["max_temperature"] == 85.3
+
+    def test_search_runs_empty(self, httpx_mock):
+        httpx_mock.add_response(
+            url="https://capsula.test/api/v1/runs/search",
+            json={"status": "ok", "total": 0, "runs": []},
+        )
+        with CapsulaClient("https://capsula.test") as client:
+            resp = client.search_runs(SearchRunsRequest(vault="nonexistent"))
+        assert resp.total == 0
+        assert resp.runs == []
+
+    def test_server_error(self, httpx_mock):
+        httpx_mock.add_response(
+            url="https://capsula.test/api/v1/vaults",
+            status_code=500,
+            json={"status": "error", "error": "internal server error"},
+        )
+        with CapsulaClient("https://capsula.test") as client:
+            with pytest.raises(Exception, match="500"):
+                client.list_vaults()

--- a/clients/python/uv.lock
+++ b/clients/python/uv.lock
@@ -1,0 +1,176 @@
+version = 1
+revision = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353 },
+]
+
+[[package]]
+name = "capsula-client"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "httpx" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-httpx" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.28" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-httpx", marker = "extra == 'dev'", specifier = ">=0.35" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134 },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515 },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784 },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
+]
+
+[[package]]
+name = "idna"
+version = "3.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340 },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484 },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195 },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151 },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249 },
+]
+
+[[package]]
+name = "pytest-httpx"
+version = "0.36.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/42/f53c58570e80d503ade9dd42ce57f2915d14bcbe25f6308138143950d1d6/pytest_httpx-0.36.2.tar.gz", hash = "sha256:05a56527484f7f4e8c856419ea379b8dc359c36801c4992fdb330f294c690356", size = 57683 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/55/1fa65f8e4fceb19dd6daa867c162ad845d547f6058cd92b4b02384a44777/pytest_httpx-0.36.2-py3-none-any.whl", hash = "sha256:d42ebd5679442dc7bfb0c48e0767b6562e9bc4534d805127b0084171886a5e22", size = 20315 },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614 },
+]


### PR DESCRIPTION
## Summary

Add a typed Python client package (`clients/python/capsula-client`) for the Capsula server HTTP API.

Mirrors the Rust `capsula-client` crate, providing Python tools with first-class access to the Capsula server.

## Changes

### `clients/python/capsula-client`

- `CapsulaClient`: HTTP client (`httpx`) with `list_vaults`, `vault_exists`, `search_runs`, `get_run`
- Model types mirroring `capsula-api-types`:
  - `SearchRunsRequest`, `SearchRunsResponse`, `SearchRunResult`
  - `ParameterMatch`, `ComparisonOp`, `HookFilter`, `SortOrder`
  - `VaultInfo`, `HookOutput`, `FileInfo`

## Usage

```python
from capsula_client import CapsulaClient, SearchRunsRequest, ParameterMatch, ComparisonOp

with CapsulaClient("https://capsula.example.com") as client:
    vaults = client.list_vaults()

    resp = client.search_runs(SearchRunsRequest(
        vault="thermal-sim",
        parameter_matches=[
            ParameterMatch("hook-id", "pre", "solar_flux", ComparisonOp.GE, 1347.39),
            ParameterMatch("hook-id", "pre", "solar_flux", ComparisonOp.LE, 1374.61),
        ],
        include=["hooks"],
        limit=1,
    ))
```

## Dependencies

- `httpx>=0.28`
- `pytest>=8.0` + `pytest-httpx>=0.35` (dev)

## Tests

12 tests: model serialization (6) + mocked HTTP client (6)

## Note

This PR includes the ParameterMatch server changes from #973 as a dependency. The `ParameterMatch` model type in the Python client mirrors the server-side type.

Closes #972