### PR TITLE
Replace git2 with gix in git repo capture

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,2 +1,3 @@
 [default.extend-words]
 consts = "consts"
+rela = "rela"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "askama"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,7 +620,7 @@ name = "capsula-capture-git-repo"
 version = "0.12.1"
 dependencies = [
  "capsula-core",
- "git2",
+ "gix",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -868,6 +877,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clru"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,6 +1014,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,6 +1125,20 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1338,6 +1379,16 @@ checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
  "bit-set",
  "regex",
+]
+
+[[package]]
+name = "faster-hex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
+dependencies = [
+ "heapless",
+ "serde",
 ]
 
 [[package]]
@@ -1600,18 +1651,869 @@ dependencies = [
 ]
 
 [[package]]
-name = "git2"
-version = "0.20.4"
+name = "gix"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "6ce52001b946a6249d5d0d3011df0a042ac3f8a4d013460db6476577b0b9c567"
+dependencies = [
+ "gix-actor",
+ "gix-archive",
+ "gix-attributes",
+ "gix-blame",
+ "gix-command",
+ "gix-commitgraph",
+ "gix-config",
+ "gix-date",
+ "gix-diff",
+ "gix-dir",
+ "gix-discover",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-ignore",
+ "gix-index",
+ "gix-lock",
+ "gix-merge",
+ "gix-negotiate",
+ "gix-object",
+ "gix-odb",
+ "gix-pack",
+ "gix-path",
+ "gix-pathspec",
+ "gix-protocol",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-sec",
+ "gix-shallow",
+ "gix-status",
+ "gix-submodule",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-url",
+ "gix-utils",
+ "gix-validate",
+ "gix-worktree",
+ "gix-worktree-state",
+ "gix-worktree-stream",
+ "nonempty",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "272916673b83714734b15d4ef3c8b5f1ccddb15fea8ff548430b97c1ab7b7ed8"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-error",
+]
+
+[[package]]
+name = "gix-archive"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a20ec244b733338d4cb60e5e05eac700dab7fcc689647b1d1daa9396b119342"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-error",
+ "gix-object",
+ "gix-worktree-stream",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe17c5a1c0b6f2ef1476aa1d3222ea50cdff67608016613a58bfc3e078046000"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "kstring",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-bitmap"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecbfc77ec6852294e341ecc305a490b59f2813e6ca42d79efda5099dcab1894"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-blame"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dab9a942ab54a9661ded7397c3bf927274e7afa94494db0d75cfcbde02ca0a"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-diff",
+ "gix-error",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-chunk"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edf288be9b60fe7231de03771faa292be1493d84786f68727e33ad1f91764320"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-command"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86335306511abe43d75c866d4b1f3d90932fe202edcd43e1314036333e7384d8"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "shell-words",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe3b5aa0f24e19028c261d229aeeedafcaaa52ebd71021cc15184620fc9d32eb"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-error",
+ "gix-hash",
+ "memmap2",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c01848aebd21c67f6ba41f1de8efd46ae96df21f001954a3c9e1517e514d410"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-config-value"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b39ed39ee4c10a3b157f9fb94bac8098d9f8e56201f0cf7dee6c187416c4b2"
 dependencies = [
  "bitflags 2.11.1",
+ "bstr",
+ "gix-path",
  "libc",
- "libgit2-sys",
- "log",
- "openssl-probe 0.1.6",
- "openssl-sys",
- "url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-date"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94cdae4eb4b0f4136e3d9b3aa2d2cd03cfb5bb9b636b31263aea2df86d41543"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "itoa",
+ "jiff",
+ "smallvec",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc08e0fa1a91ff5f24affeab052f198056645e1de004910bde7b82b50ea5982a"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-command",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-imara-diff",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-dir"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a0fc06e9e1e430cbf0a313666976d90f822f461a6525320427aa9b8af5236c"
+dependencies = [
+ "bstr",
+ "gix-discover",
+ "gix-fs",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-trace",
+ "gix-utils",
+ "gix-worktree",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17852e6a501e688a1702b24ebe5b3761d4719455bc869fd29f38b0b859bcad34"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-fs",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-error"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e207b971746ab724fccdfced2e4e19e854744611904a0195d3aa8fda8a110613"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af375693ad5333d0a2c66b4c5b2cbe9ccc38e34f8e8bf24e4ae42c12307fdc4f"
+dependencies = [
+ "bytes",
+ "crc32fast",
+ "gix-path",
+ "gix-trace",
+ "gix-utils",
+ "libc",
+ "once_cell",
+ "prodash",
+ "thiserror 2.0.18",
+ "walkdir",
+ "zlib-rs",
+]
+
+[[package]]
+name = "gix-filter"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac917dbe9653c9b615d248db91907a365bd779750c9e1b457a9d9fdeece3a08"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes",
+ "gix-command",
+ "gix-hash",
+ "gix-object",
+ "gix-packetline",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "gix-utils",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e1967daac9848757c47c2aef0c57bcadc1a897347f559778249bf286a536c86"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "gix-features",
+ "gix-path",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08bf29249a069bf2507f5964f80997f37b134d320ea348d66527726b9be2c38c"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-features",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf70d1e252337eed16360f8b8ebb71865ece58eab7954b39ce38b420de703d2"
+dependencies = [
+ "faster-hex",
+ "gix-features",
+ "sha1-checked",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d33b455e07b3c16d3b2eeebc7b38d2dafcbf8a653de1138ef55d4c2a1fd0b08b"
+dependencies = [
+ "gix-hash",
+ "hashbrown 0.16.1",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-ignore"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb13fbbeeafee943e52b61fcc88dfddf6a452fcaf0c4d0cdc8f218fa25bbec5"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-trace",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-imara-diff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39eb0623e15e4cb83c02ce6a959e48fadd1ae3b715b36b5acc01816e01388c82"
+dependencies = [
+ "bstr",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54c3ef97ad08121e4327a6226bd63fed6b9e3c6b976d48bddd4356d9d41191db"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "filetime",
+ "fnv",
+ "gix-bitmap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-traverse",
+ "gix-utils",
+ "gix-validate",
+ "hashbrown 0.16.1",
+ "itoa",
+ "libc",
+ "memmap2",
+ "rustix",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-lock"
+version = "23.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b3bc074e5723027b482dcd9ab99d95804a53742f6de812d0172fbba4a186c1"
+dependencies = [
+ "gix-tempfile",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-merge"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74bbcdcc52b70a32f0a151b024dff9d0fcf56ee48f00d9503e735af9d99ea881"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-diff",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-imara-diff",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-quote",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-worktree",
+ "nonempty",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-negotiate"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "103d42bfade1b8a96ca5005933127bdad461ce588d92422b2c2daa3ff20d780c"
+dependencies = [
+ "bitflags 2.11.1",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a38075a95d7cc5df8afd38e72c617026c1456952207a4120a7f55a3fbf93b4d7"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-utils",
+ "gix-validate",
+ "itoa",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.80.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeeda12a9663120418735ecdc1250d06eeab0be75700e47b3402a981331716ba"
+dependencies = [
+ "arc-swap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-pack",
+ "gix-path",
+ "gix-quote",
+ "memmap2",
+ "parking_lot",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf02e6f5c8f07a069c9ea5245f40d9b14856ada4086091dc99941b49002b4fa"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-error",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-path",
+ "memmap2",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-packetline"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "362246df440ee691699f0664cbf7006a6ece477db6734222be95e4198e5656e6"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671a6059e8a4c1b7f406e24716499cefa3926e060876fb1959ef225efeee346e"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "gix-validate",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-pathspec"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a84a4f083dd70fb49f4377e13afa6d90df2daaa1c705c49d6ff1331fc7e8855"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-attributes",
+ "gix-config-value",
+ "gix-glob",
+ "gix-path",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-protocol"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4bee82db63ec635996b96efae71cf467c155fa3f34a556184373224a26c4fd"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-ref",
+ "gix-shallow",
+ "gix-transport",
+ "gix-utils",
+ "maybe-async",
+ "nonempty",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-quote"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e97b73791a64bc0fa7dd2c5b3e551136115f97750b876ed1c952c7a7dbaf8be"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-utils",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8ba9cc15f558b274c99349b83130f5ec83459660828fde9718bbbb43a726167"
+dependencies = [
+ "gix-actor",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-utils",
+ "gix-validate",
+ "memmap2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61755b27d57edc8940a1b1593c8c61548ca8e4c02da1ed8d5bfeda9eb2a6b761"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-glob",
+ "gix-hash",
+ "gix-revision",
+ "gix-validate",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb5288fac706d3ea3e4e2ba9ec38b78743b8c02f422e18cb342299cfd6ab7e8"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "313813706b073a12ff7f9b2896bf3e6504cdac7cfbc97b1920114724705069f0"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3a2d3e504a238136751e646a6c028252286a0ea64ea9974bf0498633407c6"
+dependencies = [
+ "bitflags 2.11.1",
+ "gix-path",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "gix-shallow"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29187305521bfacf4aefd284ab28dbfa9fb74abd39a5e63dd313b1baa5808c27"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-lock",
+ "nonempty",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-status"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c6d2a8c521ffa205fe7e268c82e6d1378ba37cd826ca10ab6129fdc29a4b65"
+dependencies = [
+ "bstr",
+ "filetime",
+ "gix-diff",
+ "gix-dir",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-worktree",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-submodule"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fd5fc8692890bd71a596e540fd4c364f8460eaa82c4eaaedebde6e1e3eb4d91"
+dependencies = [
+ "bstr",
+ "gix-config",
+ "gix-path",
+ "gix-pathspec",
+ "gix-refspec",
+ "gix-url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "23.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "691ea1e31435c7e7d4d04705ec9d1c0d9482c46b2acf512bc723939d8f0af7fb"
+dependencies = [
+ "dashmap",
+ "gix-fs",
+ "libc",
+ "parking_lot",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f23569e55f2ffaf958617353b9734a7d52a7c19c439eeaa5e3efc217fd2270e"
+
+[[package]]
+name = "gix-transport"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd6a5c676b92d4ead5f5a2b2935024415dec69edc997b6090ca9cac010a3018"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-features",
+ "gix-packetline",
+ "gix-quote",
+ "gix-sec",
+ "gix-url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a14b7052c0786676c03e71fcfde7d7f0f8e8316e642b5cec6bb3998719b2ce5c"
+dependencies = [
+ "bitflags 2.11.1",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35842d099e813f6f6bba529e88d4670572149c3df79b7a412952259887721ece"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "percent-encoding",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-utils"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e477b4f07a6e8da4ba791c53c858102959703c60d70f199932010d5b94adb2c"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26ac2602b43eadfdca0560b81d3341944162a3c9f64ccdeef8fc501ad80dad5"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69955eb5e2910832f88d041964b809eee01dadd579237e0b55efec58fd406fd"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-validate",
+]
+
+[[package]]
+name = "gix-worktree-state"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a96dccbcf9e8fe0291c55f06e08da93ebb2e691c1311276f541eefcc6d70800"
+dependencies = [
+ "bstr",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-worktree",
+ "io-close",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-worktree-stream"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8444b8ed4662e1a0c97f3eceda29630001a1bbb2632201e50312623e594213"
+dependencies = [
+ "gix-attributes",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-object",
+ "gix-path",
+ "gix-traverse",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1640,10 +2542,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1680,6 +2597,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2071,6 +2998,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-close"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2096,6 +3033,47 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6835eea34fb6321b9b3aa7b685c2b433948c09447e389dc017fdf687d5d11e65"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c22e04db9c58f5136eb1757f3d5c49a7b187f49e52185228cbd2f5acdfcc08c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jni"
@@ -2180,6 +3158,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "lab"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2207,20 +3194,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.18.4+1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
-dependencies = [
- "cc",
- "libc",
- "libssh2-sys",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2244,32 +3217,6 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
-dependencies = [
- "cc",
- "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -2357,6 +3304,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "maybe-async"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2371,6 +3329,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memmem"
@@ -2469,6 +3436,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonempty"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
 
 [[package]]
 name = "normalize-line-endings"
@@ -2691,27 +3664,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.116"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "ordered-float"
@@ -2952,6 +3907,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3022,6 +3986,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prodash"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]
@@ -3488,7 +4461,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -3762,6 +4735,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest 0.10.7",
+ "sha1",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3791,6 +4774,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -4795,6 +5784,12 @@ name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bom"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
 
 [[package]]
 name = "unicode-ident"
@@ -5843,6 +6838,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,11 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive", "env"] }
 crossterm = "0.29"
 dotenvy = "0.15.7"
-git2 = "0.20"
+gix = { version = "0.83.0", default-features = false, features = [
+  "revision",
+  "sha1",
+  "status"
+] }
 glob = "0.3"
 mime_guess = "2"
 names = { version = "0.14", default-features = false }

--- a/crates/capsula-capture-git-repo/Cargo.toml
+++ b/crates/capsula-capture-git-repo/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools"]
 
 [dependencies]
 capsula-core = { workspace = true }
-git2 = { workspace = true }
+gix = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/capsula-capture-git-repo/src/error.rs
+++ b/crates/capsula-capture-git-repo/src/error.rs
@@ -12,9 +12,35 @@ pub enum GitHookError {
     #[error("Failed to get repository HEAD: {message}")]
     HeadNotFound { message: String },
 
-    /// Git operation failed
-    #[error("Git operation failed: {0}")]
-    GitOperation(#[from] git2::Error),
+    #[error("Failed to discover git repository: {0}")]
+    Discover(#[from] gix::discover::Error),
+
+    #[error("Failed to create git tag: {0}")]
+    TagReference(#[from] gix::reference::edit::Error),
+
+    #[error("Failed to create git status platform: {0}")]
+    Status(#[from] gix::status::Error),
+
+    #[error("Failed to create git status iterator: {0}")]
+    StatusIterator(#[from] gix::status::into_iter::Error),
+
+    #[error("Failed to read git status item: {0}")]
+    StatusItem(#[from] gix::status::iter::Error),
+
+    #[error("Failed to read git references: {0}")]
+    References(#[from] gix::reference::iter::Error),
+
+    #[error("Failed to initialize git reference iterator: {0}")]
+    ReferenceIterator(#[from] gix::reference::iter::init::Error),
+
+    #[error("Failed to read git reference: {message}")]
+    ReferenceItem { message: String },
+
+    #[error("Failed to calculate git merge base: {0}")]
+    MergeBase(#[from] gix::repository::merge_base::Error),
+
+    #[error("Failed to read git blob: {0}")]
+    FindBlob(#[from] gix::object::find::existing::with_conversion::Error),
 
     /// Serialization failed
     #[error("Failed to serialize git hook: {0}")]
@@ -25,6 +51,9 @@ pub enum GitHookError {
 
     #[error("capture-git-repo hook requires an artifact directory but none was provided")]
     ArtifactDirMissing,
+
+    #[error("Git repository has no worktree")]
+    WorktreeMissing,
 
     #[error("I/O error: {0}")]
     IoError(#[from] std::io::Error),

--- a/crates/capsula-capture-git-repo/src/lib.rs
+++ b/crates/capsula-capture-git-repo/src/lib.rs
@@ -5,10 +5,10 @@ use capsula_core::captured::Captured;
 use capsula_core::error::CapsulaResult;
 use capsula_core::hook::{Hook, PhaseMarker, RuntimeParams};
 use capsula_core::run::PreparedRun;
-use git2::Repository;
+use gix::Repository;
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
-use std::path::PathBuf;
+use std::fmt::{Debug, Write as _};
+use std::path::{Path, PathBuf};
 use tracing::{debug, warn};
 
 fn default_remote() -> String {
@@ -106,29 +106,27 @@ where
             "GitHook: Discovering repository at: {}",
             repo_path.display()
         );
-        let repo = Repository::discover(&repo_path).map_err(|e| {
-            if e.code() == git2::ErrorCode::NotFound {
-                GitHookError::NotARepository
-            } else {
-                GitHookError::GitOperation(e)
-            }
+        let repo = gix::discover(&repo_path).map_err(|error| match &error {
+            gix::discover::Error::Discover(
+                gix::discover::upwards::Error::NoGitRepository { .. }
+                | gix::discover::upwards::Error::NoGitRepositoryWithinCeiling { .. }
+                | gix::discover::upwards::Error::NoGitRepositoryWithinFs { .. },
+            ) => GitHookError::NotARepository,
+            _ => GitHookError::Discover(error),
         })?;
 
         debug!("GitHook: Getting HEAD commit");
-        let head = repo.head().map_err(GitHookError::from)?;
-        let oid = head.target().ok_or_else(|| GitHookError::HeadNotFound {
-            message: "HEAD does not point to a valid commit".to_string(),
-        })?;
+        let oid = repo
+            .head_id()
+            .map_err(|error| GitHookError::HeadNotFound {
+                message: error.to_string(),
+            })?
+            .detach();
         debug!("GitHook: HEAD commit SHA: {}", oid);
 
         // Check if repository is dirty (excluding ignored files to match git status behavior)
         debug!("GitHook: Checking repository status");
-        let mut status_opts = git2::StatusOptions::new();
-        status_opts.include_untracked(true).include_ignored(false);
-        let statuses = repo
-            .statuses(Some(&mut status_opts))
-            .map_err(GitHookError::from)?;
-        let is_dirty = !statuses.is_empty();
+        let is_dirty = Self::is_dirty(&repo)?;
         debug!("GitHook: Repository is dirty: {}", is_dirty);
 
         // If dirty and not allowed, we'll signal abort through the Captured trait
@@ -170,11 +168,12 @@ where
         let tag = if self.config.tag_head {
             let tag_name = format!("capsula/{}", metadata.name);
             debug!("GitHook: Creating lightweight tag '{}'", tag_name);
-            let commit = repo
-                .find_object(oid, Some(git2::ObjectType::Commit))
-                .map_err(GitHookError::from)?;
-            repo.tag_lightweight(&tag_name, &commit, false)
-                .map_err(GitHookError::from)?;
+            repo.tag_reference(
+                &tag_name,
+                oid,
+                gix::refs::transaction::PreviousValue::MustNotExist,
+            )
+            .map_err(GitHookError::TagReference)?;
             debug!("GitHook: Tag '{}' created successfully", tag_name);
             Some(tag_name)
         } else {
@@ -194,19 +193,45 @@ where
 }
 
 impl GitHook {
-    fn check_pushed(repo: &Repository, head_oid: git2::Oid, remote: &str) -> CapsulaResult<bool> {
+    fn is_dirty(repo: &Repository) -> CapsulaResult<bool> {
+        let mut status = repo
+            .status(gix::progress::Discard)
+            .map_err(GitHookError::Status)?
+            .untracked_files(gix::status::UntrackedFiles::Files)
+            .into_iter(Vec::<gix::bstr::BString>::new())
+            .map_err(GitHookError::StatusIterator)?;
+
+        status
+            .next()
+            .transpose()
+            .map(|item| item.is_some())
+            .map_err(GitHookError::StatusItem)
+            .map_err(Into::into)
+    }
+
+    fn check_pushed(
+        repo: &Repository,
+        head_oid: gix::ObjectId,
+        remote: &str,
+    ) -> CapsulaResult<bool> {
         let remote_branch_prefix = format!("refs/remotes/{remote}/");
 
         // Check remote branches: HEAD is at tip or ancestor of a remote branch
-        for reference in repo.references().map_err(GitHookError::from)? {
-            let reference = reference.map_err(GitHookError::from)?;
-            if let Some(name) = reference.name()
+        for reference in repo
+            .references()
+            .map_err(GitHookError::References)?
+            .prefixed(remote_branch_prefix.as_str())
+            .map_err(GitHookError::ReferenceIterator)?
+        {
+            let reference = reference.map_err(|source| GitHookError::ReferenceItem {
+                message: source.to_string(),
+            })?;
+            let name = reference.name().as_bstr().to_string();
+            let Some(remote_oid) = reference.target().try_id().map(ToOwned::to_owned) else {
+                continue;
+            };
+            if (remote_oid == head_oid || Self::is_ancestor(repo, head_oid, remote_oid)?)
                 && name.starts_with(&remote_branch_prefix)
-                && let Ok(remote_commit) = reference.peel_to_commit()
-                && (remote_commit.id() == head_oid
-                    || repo
-                        .graph_descendant_of(remote_commit.id(), head_oid)
-                        .map_err(GitHookError::from)?)
             {
                 debug!("HEAD ({head_oid}) found in remote branch: {name}");
                 return Ok(true);
@@ -216,22 +241,277 @@ impl GitHook {
         Ok(false)
     }
 
+    fn is_ancestor(
+        repo: &Repository,
+        ancestor: gix::ObjectId,
+        descendant: gix::ObjectId,
+    ) -> CapsulaResult<bool> {
+        match repo.merge_base(ancestor, descendant) {
+            Ok(merge_base) => Ok(merge_base.detach() == ancestor),
+            Err(gix::repository::merge_base::Error::NotFound { .. }) => Ok(false),
+            Err(error) => Err(GitHookError::MergeBase(error).into()),
+        }
+    }
+
     fn diff_content(repo: &Repository) -> CapsulaResult<String> {
-        let mut diff_opts = git2::DiffOptions::new();
-        diff_opts.include_untracked(true);
-        let diff = repo
-            .diff_index_to_workdir(None, Some(&mut diff_opts))
-            .map_err(GitHookError::from)?;
+        let workdir = repo.workdir().ok_or(GitHookError::WorktreeMissing)?;
+        let mut status = repo
+            .status(gix::progress::Discard)
+            .map_err(GitHookError::Status)?
+            .untracked_files(gix::status::UntrackedFiles::Files)
+            .into_iter(Vec::<gix::bstr::BString>::new())
+            .map_err(GitHookError::StatusIterator)?;
 
         let mut diff_content = String::new();
-        diff.print(git2::DiffFormat::Patch, |_, _, line| {
-            // Non-UTF-8 bytes (e.g. binary blobs in a diff) become
-            // replacement characters rather than being silently dropped.
-            diff_content.push_str(&String::from_utf8_lossy(line.content()));
-            true
-        })
-        .map_err(GitHookError::from)?;
+        for item in &mut status {
+            Self::append_status_patch(
+                repo,
+                workdir,
+                item.map_err(GitHookError::StatusItem)?,
+                &mut diff_content,
+            )?;
+        }
 
         Ok(diff_content)
+    }
+
+    fn append_status_patch(
+        repo: &Repository,
+        workdir: &Path,
+        item: gix::status::Item,
+        diff_content: &mut String,
+    ) -> CapsulaResult<()> {
+        use gix::status::plumbing::index_as_worktree::{Change, EntryStatus};
+
+        match item {
+            gix::status::Item::IndexWorktree(gix::status::index_worktree::Item::Modification {
+                entry,
+                rela_path: path,
+                status,
+                ..
+            }) => match status {
+                EntryStatus::Change(Change::Removed) => {
+                    let old = Self::blob_content(repo, entry.id)?;
+                    Self::append_file_patch(diff_content, &path, Some(&old), None);
+                }
+                EntryStatus::Change(
+                    Change::Modification { .. }
+                    | Change::Type { .. }
+                    | Change::SubmoduleModification(_),
+                ) => {
+                    let old = Self::blob_content(repo, entry.id)?;
+                    let new = Self::worktree_content(workdir, &path)?;
+                    Self::append_file_patch(diff_content, &path, Some(&old), Some(&new));
+                }
+                EntryStatus::IntentToAdd => {
+                    let new = Self::worktree_content(workdir, &path)?;
+                    Self::append_file_patch(diff_content, &path, None, Some(&new));
+                }
+                EntryStatus::Conflict { .. } | EntryStatus::NeedsUpdate(_) => {}
+            },
+            gix::status::Item::IndexWorktree(
+                gix::status::index_worktree::Item::DirectoryContents { entry, .. },
+            ) => {
+                let new = Self::worktree_content(workdir, &entry.rela_path)?;
+                Self::append_file_patch(diff_content, &entry.rela_path, None, Some(&new));
+            }
+            gix::status::Item::IndexWorktree(gix::status::index_worktree::Item::Rewrite {
+                source,
+                dirwalk_entry,
+                ..
+            }) => {
+                let old = match source {
+                    gix::status::index_worktree::RewriteSource::RewriteFromIndex {
+                        source_entry,
+                        ..
+                    } => Some(Self::blob_content(repo, source_entry.id)?),
+                    gix::status::index_worktree::RewriteSource::CopyFromDirectoryEntry {
+                        ..
+                    } => None,
+                };
+                let new = Self::worktree_content(workdir, &dirwalk_entry.rela_path)?;
+                Self::append_file_patch(
+                    diff_content,
+                    &dirwalk_entry.rela_path,
+                    old.as_deref(),
+                    Some(&new),
+                );
+            }
+            gix::status::Item::TreeIndex(change) => {
+                Self::append_index_patch(repo, diff_content, change)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn append_index_patch(
+        repo: &Repository,
+        diff_content: &mut String,
+        change: gix::diff::index::Change,
+    ) -> CapsulaResult<()> {
+        match change {
+            gix::diff::index::Change::Addition { location, id, .. } => {
+                let new = Self::blob_content(repo, id.into_owned())?;
+                Self::append_file_patch(diff_content, &location.into_owned(), None, Some(&new));
+            }
+            gix::diff::index::Change::Deletion { location, id, .. } => {
+                let old = Self::blob_content(repo, id.into_owned())?;
+                Self::append_file_patch(diff_content, &location.into_owned(), Some(&old), None);
+            }
+            gix::diff::index::Change::Modification {
+                location,
+                previous_id,
+                id,
+                ..
+            } => {
+                let old = Self::blob_content(repo, previous_id.into_owned())?;
+                let new = Self::blob_content(repo, id.into_owned())?;
+                Self::append_file_patch(
+                    diff_content,
+                    &location.into_owned(),
+                    Some(&old),
+                    Some(&new),
+                );
+            }
+            gix::diff::index::Change::Rewrite {
+                location,
+                source_id,
+                id,
+                ..
+            } => {
+                let old = Self::blob_content(repo, source_id.into_owned())?;
+                let new = Self::blob_content(repo, id.into_owned())?;
+                Self::append_file_patch(
+                    diff_content,
+                    &location.into_owned(),
+                    Some(&old),
+                    Some(&new),
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn blob_content(repo: &Repository, id: gix::ObjectId) -> CapsulaResult<Vec<u8>> {
+        repo.find_blob(id)
+            .map(|mut blob| blob.take_data())
+            .map_err(GitHookError::FindBlob)
+            .map_err(Into::into)
+    }
+
+    fn worktree_content(workdir: &Path, repo_path: &[u8]) -> CapsulaResult<Vec<u8>> {
+        let path = workdir.join(Self::path_for_filesystem(repo_path));
+        std::fs::read(path)
+            .map_err(GitHookError::IoError)
+            .map_err(Into::into)
+    }
+
+    fn append_file_patch(
+        diff_content: &mut String,
+        repo_path: &[u8],
+        old: Option<&[u8]>,
+        new: Option<&[u8]>,
+    ) {
+        if old == new {
+            return;
+        }
+
+        let path = Self::path_for_patch(repo_path);
+        let _ = writeln!(diff_content, "diff --git a/{path} b/{path}");
+        match (old, new) {
+            (None, Some(new)) => {
+                diff_content.push_str("new file mode 100644\n");
+                Self::append_unified_hunk(
+                    diff_content,
+                    "/dev/null",
+                    &format!("b/{path}"),
+                    &[],
+                    new,
+                );
+            }
+            (Some(old), None) => {
+                diff_content.push_str("deleted file mode 100644\n");
+                Self::append_unified_hunk(
+                    diff_content,
+                    &format!("a/{path}"),
+                    "/dev/null",
+                    old,
+                    &[],
+                );
+            }
+            (Some(old), Some(new)) if Self::is_binary(old) || Self::is_binary(new) => {
+                let _ = writeln!(diff_content, "Binary files a/{path} and b/{path} differ");
+            }
+            (Some(old), Some(new)) => {
+                Self::append_unified_hunk(
+                    diff_content,
+                    &format!("a/{path}"),
+                    &format!("b/{path}"),
+                    old,
+                    new,
+                );
+            }
+            (None, None) => {}
+        }
+    }
+
+    fn append_unified_hunk(
+        diff_content: &mut String,
+        old_path: &str,
+        new_path: &str,
+        old: &[u8],
+        new: &[u8],
+    ) {
+        let _ = writeln!(diff_content, "--- {old_path}");
+        let _ = writeln!(diff_content, "+++ {new_path}");
+        let _ = writeln!(
+            diff_content,
+            "@@ -{} +{} @@",
+            Self::hunk_range(old),
+            Self::hunk_range(new)
+        );
+        Self::append_prefixed_lines(diff_content, '-', old);
+        Self::append_prefixed_lines(diff_content, '+', new);
+    }
+
+    fn append_prefixed_lines(diff_content: &mut String, prefix: char, content: &[u8]) {
+        if content.is_empty() {
+            return;
+        }
+
+        for line in content.split_inclusive(|byte| *byte == b'\n') {
+            diff_content.push(prefix);
+            diff_content.push_str(&String::from_utf8_lossy(line));
+            if !line.ends_with(b"\n") {
+                diff_content.push('\n');
+            }
+        }
+
+        if !content.ends_with(b"\n") {
+            diff_content.push_str("\\ No newline at end of file\n");
+        }
+    }
+
+    fn hunk_range(content: &[u8]) -> String {
+        if content.is_empty() {
+            return "0,0".to_string();
+        }
+        format!(
+            "1,{}",
+            content.split_inclusive(|byte| *byte == b'\n').count()
+        )
+    }
+
+    fn path_for_patch(repo_path: &[u8]) -> String {
+        String::from_utf8_lossy(repo_path).into_owned()
+    }
+
+    fn path_for_filesystem(repo_path: &[u8]) -> PathBuf {
+        PathBuf::from(Self::path_for_patch(repo_path))
+    }
+
+    fn is_binary(content: &[u8]) -> bool {
+        content.contains(&0)
     }
 }


### PR DESCRIPTION
## Summary

- Replace the `git2` dependency in `capsula-capture-git-repo` with `gix`.
- Reimplement repository discovery, status inspection, reference iteration, merge-base checks, tag creation, and blob reads with `gix` APIs.
- Remove the previous `git diff` process invocation so capturing dirty repository state no longer invokes the user-provided `git` binary.
- Replace the temporary boxed git operation error with concrete `thiserror` variants.

## Discussion and tradeoffs

This PR is intentionally opened as a draft because the migration has pros and cons.

The main upside is security and dependency simplification: we remove `git2`/`libgit2` and avoid shelling out to `git diff`, which could otherwise execute a user-controlled `git` binary from `PATH`.

The main downside is that `gix` does not currently expose a high-level API equivalent to generating a full Git patch file for the current repository state. It has lower-level diff/status machinery and unified-diff rendering support, but not a native one-shot replacement for the old behavior of preserving the local dirty diff as a Git-compatible patch.

To preserve behavior without invoking `git`, this branch generates patch-like content from structured `gix` status items. That is safer, but it is not a full `git diff` clone. In particular, it should be treated as a best-effort human-readable artifact rather than a canonical reproducibility format. It may not exactly preserve rename headers, mode-only changes, optimized hunk placement, all binary details, textconv/filter behavior, or every subtle index/worktree distinction.

Longer term, using a Git patch as the canonical reproducibility artifact is probably fragile. A more robust direction would be a structured local-diff artifact containing the base commit/tree, changed paths, status kinds, modes/object IDs where available, and content-addressed snapshots of post-change file contents. A patch can still be generated as a derived review aid.

## Verification

- `just lint` passed.
- `cargo test -p capsula-capture-git-repo` passed.
- `cargo fmt --check --all` passed.
- `just test` was attempted, but workspace server integration tests failed while creating Docker containers: `Client(CreateContainer(DockerResponseServerError { status_code: 500, message: "" }))` in `crates/capsula-server/tests/api_tests.rs`. The failure was uniform across those tests and appears environment/Docker related rather than specific to this crate.