### PR TITLE
feat(capture-parameter): add hook for queryable structured parameter capture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,7 +521,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "capsula"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-api-types"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-capture-command"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "capsula-core",
  "serde",
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-capture-cwd"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "capsula-core",
  "serde",
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-capture-env"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "capsula-core",
  "serde",
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-capture-file"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "capsula-core",
  "glob",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-capture-git-repo"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "capsula-core",
  "git2",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-capture-machine"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "capsula-core",
  "serde",
@@ -627,8 +627,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "capsula-capture-parameter"
+version = "0.13.0"
+dependencies = [
+ "capsula-capture-file",
+ "capsula-core",
+ "glob",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tempfile",
+ "thiserror 2.0.18",
+ "toml",
+ "tracing",
+ "ulid",
+]
+
+[[package]]
 name = "capsula-client"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "capsula-api-types",
  "reqwest",
@@ -640,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-config"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "capsula-core",
  "capsula-registry",
@@ -653,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-core"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "clap",
@@ -667,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-notify-slack"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "capsula-core",
  "glob",
@@ -683,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-orchestration"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "capsula-client",
@@ -703,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-registry"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "capsula-capture-command",
  "capsula-capture-cwd",
@@ -711,6 +728,7 @@ dependencies = [
  "capsula-capture-file",
  "capsula-capture-git-repo",
  "capsula-capture-machine",
+ "capsula-capture-parameter",
  "capsula-core",
  "capsula-notify-slack",
  "serde",
@@ -721,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-server"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "askama",
  "askama_web",
@@ -749,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-tui"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "capsula-config",
@@ -3589,6 +3607,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4646,6 +4677,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/*"]
 default-members = ["crates/capsula-cli"]
 
 [workspace.package]
-version = "0.12.1"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.95"
 readme = "README.md"
@@ -16,20 +16,21 @@ anyhow = "1"
 askama = "0.16"
 askama_web = { version = "0.16", features = ["axum-0.8"] }
 axum = { version = "0.8", features = ["multipart"] }
-capsula-api-types = { path = "crates/capsula-api-types", version = "0.12.1" }
-capsula-capture-command = { path = "crates/capsula-capture-command", version = "0.12.1" }
-capsula-capture-cwd = { path = "crates/capsula-capture-cwd", version = "0.12.1" }
-capsula-capture-env = { path = "crates/capsula-capture-env", version = "0.12.1" }
-capsula-capture-file = { path = "crates/capsula-capture-file", version = "0.12.1" }
-capsula-capture-git-repo = { path = "crates/capsula-capture-git-repo", version = "0.12.1" }
-capsula-capture-machine = { path = "crates/capsula-capture-machine", version = "0.12.1" }
-capsula-client = { path = "crates/capsula-client", version = "0.12.1" }
-capsula-config = { path = "crates/capsula-config", version = "0.12.1" }
-capsula-core = { path = "crates/capsula-core", version = "0.12.1" }
-capsula-notify-slack = { path = "crates/capsula-notify-slack", version = "0.12.1" }
-capsula-orchestration = { path = "crates/capsula-orchestration", version = "0.12.1" }
-capsula-registry = { path = "crates/capsula-registry", version = "0.12.1" }
-capsula-tui = { path = "crates/capsula-tui", version = "0.12.1" }
+capsula-api-types = { path = "crates/capsula-api-types", version = "0.13.0" }
+capsula-capture-command = { path = "crates/capsula-capture-command", version = "0.13.0" }
+capsula-capture-cwd = { path = "crates/capsula-capture-cwd", version = "0.13.0" }
+capsula-capture-env = { path = "crates/capsula-capture-env", version = "0.13.0" }
+capsula-capture-file = { path = "crates/capsula-capture-file", version = "0.13.0" }
+capsula-capture-git-repo = { path = "crates/capsula-capture-git-repo", version = "0.13.0" }
+capsula-capture-machine = { path = "crates/capsula-capture-machine", version = "0.13.0" }
+capsula-capture-parameter = { path = "crates/capsula-capture-parameter", version = "0.13.0" }
+capsula-client = { path = "crates/capsula-client", version = "0.13.0" }
+capsula-config = { path = "crates/capsula-config", version = "0.13.0" }
+capsula-core = { path = "crates/capsula-core", version = "0.13.0" }
+capsula-notify-slack = { path = "crates/capsula-notify-slack", version = "0.13.0" }
+capsula-orchestration = { path = "crates/capsula-orchestration", version = "0.13.0" }
+capsula-registry = { path = "crates/capsula-registry", version = "0.13.0" }
+capsula-tui = { path = "crates/capsula-tui", version = "0.13.0" }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive", "env"] }
 crossterm = "0.29"
@@ -43,6 +44,7 @@ ratatui = "0.30"
 reqwest = { version = "0.13", features = ["blocking", "json", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 sha2 = "0.11"
 shlex = "2"
 sql-json-path = "0.1"

--- a/crates/capsula-capture-file/src/lib.rs
+++ b/crates/capsula-capture-file/src/lib.rs
@@ -1,4 +1,4 @@
-mod error;
+pub mod error;
 mod hash;
 
 use crate::error::FileHookError;

--- a/crates/capsula-capture-parameter/Cargo.toml
+++ b/crates/capsula-capture-parameter/Cargo.toml
@@ -1,29 +1,29 @@
 [package]
-name = "capsula-registry"
+name = "capsula-capture-parameter"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-description = "A Capsula hooks registry."
-keywords = ["capsula", "registry"]
+description = "A Capsula hook that captures a parameter value."
 readme.workspace = true
 repository.workspace = true
 license.workspace = true
+keywords = ["capsula", "capsula-hook"]
 categories = ["development-tools"]
 
 [dependencies]
-capsula-capture-command = { workspace = true }
-capsula-capture-cwd = { workspace = true }
-capsula-capture-env = { workspace = true }
 capsula-capture-file = { workspace = true }
-capsula-capture-git-repo = { workspace = true }
-capsula-capture-machine = { workspace = true }
-capsula-capture-parameter = { workspace = true }
 capsula-core = { workspace = true }
-capsula-notify-slack = { workspace = true }
+glob = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+toml = { workspace = true }
+serde_yaml = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+ulid = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/capsula-capture-parameter/src/error.rs
+++ b/crates/capsula-capture-parameter/src/error.rs
@@ -24,7 +24,7 @@ pub enum ParameterHookError {
     #[error("Parameter conflict at key path '{0}'")]
     ParameterConflict(String),
 
-    /// strip_prefix is not a literal prefix of a matched file's relative path
+    /// `strip_prefix` is not a literal prefix of a matched file's relative path
     #[error("strip_prefix '{prefix}' is not a prefix of matched path '{path}'")]
     StripPrefixMismatch { prefix: String, path: String },
 

--- a/crates/capsula-capture-parameter/src/error.rs
+++ b/crates/capsula-capture-parameter/src/error.rs
@@ -1,0 +1,43 @@
+use capsula_core::error::CapsulaError;
+use thiserror::Error;
+
+/// Parameter hook specific errors
+#[derive(Debug, Error)]
+pub enum ParameterHookError {
+    /// Failed to deserialize json parameter
+    #[error("Failed to deserialize json parameter: {0}")]
+    JsonDeserializationFailed(#[from] serde_json::Error),
+
+    /// Failed to deserialize toml parameter
+    #[error("Failed to deserialize toml parameter: {0}")]
+    TomlDeserializationFailed(#[from] toml::de::Error),
+
+    /// Failed to deserialize yaml parameter
+    #[error("Failed to deserialize yaml parameter: {0}")]
+    YamlDeserializationFailed(#[from] serde_yaml::Error),
+
+    /// Unsupported file type for parameter capture
+    #[error("Unsupported file type for parameter capture: {0}")]
+    UnsupportedFileType(String),
+
+    /// Two files contribute conflicting values at the same nested key path
+    #[error("Parameter conflict at key path '{0}'")]
+    ParameterConflict(String),
+
+    /// strip_prefix is not a literal prefix of a matched file's relative path
+    #[error("strip_prefix '{prefix}' is not a prefix of matched path '{path}'")]
+    StripPrefixMismatch { prefix: String, path: String },
+
+    /// Failed to capture file for parameter
+    #[error(transparent)]
+    FileCapture(#[from] capsula_capture_file::error::FileHookError),
+}
+
+impl From<ParameterHookError> for CapsulaError {
+    fn from(err: ParameterHookError) -> Self {
+        Self::HookFailed {
+            hook: "capture-parameter".to_string(),
+            source: Box::new(err),
+        }
+    }
+}

--- a/crates/capsula-capture-parameter/src/lib.rs
+++ b/crates/capsula-capture-parameter/src/lib.rs
@@ -1,0 +1,416 @@
+mod error;
+
+use std::path::{Path, PathBuf};
+
+use capsula_capture_file::error::FileHookError;
+use capsula_core::captured::Captured;
+use capsula_core::error::CapsulaResult;
+use capsula_core::hook::{Hook, PhaseMarker, RuntimeParams};
+use capsula_core::run::PreparedRun;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use tracing::debug;
+
+use crate::error::ParameterHookError;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ParameterHookConfig {
+    /// Glob pattern (relative to `project_root`) selecting parameter files.
+    /// Only `.json` / `.toml` / `.yaml` / `.yml` are parsed.
+    glob: String,
+
+    /// Optional literal path prefix to strip from each matched file's
+    /// relative path before constructing the nested key path. If specified,
+    /// every matched file must start with this prefix or the hook fails with
+    /// `StripPrefixMismatch`.
+    #[serde(default)]
+    strip_prefix: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct ParameterHook {
+    config: ParameterHookConfig,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ParameterCaptured {
+    /// Nested parameter map keyed by directory components and file stems.
+    /// Multiple files contributing to the same key path are deep-merged;
+    /// conflicting leaf values fail with `ParameterConflict`.
+    parameters: Map<String, Value>,
+}
+
+impl<P> Hook<P> for ParameterHook
+where
+    P: PhaseMarker,
+{
+    const ID: &'static str = "capture-parameter";
+
+    type Config = ParameterHookConfig;
+    type Output = ParameterCaptured;
+
+    fn from_config(
+        config: &serde_json::Value,
+        _project_root: &Path,
+    ) -> CapsulaResult<Self> {
+        let config: ParameterHookConfig = serde_json::from_value(config.clone())
+            .map_err(ParameterHookError::from)?;
+        Ok(Self { config })
+    }
+
+    fn config(&self) -> &Self::Config {
+        &self.config
+    }
+
+    fn run(
+        &self,
+        metadata: &PreparedRun,
+        _params: &RuntimeParams<P>,
+    ) -> CapsulaResult<Self::Output> {
+        let pattern = build_glob_pattern(&metadata.project_root, &self.config.glob);
+        debug!("ParameterHook: searching pattern: {pattern}");
+
+        let mut files = collect_files(&pattern).map_err(ParameterHookError::from)?;
+        files.sort();
+        debug!("ParameterHook: matched {} files", files.len());
+
+        let mut parameters: Map<String, Value> = Map::new();
+        let strip = self.config.strip_prefix.as_deref();
+        let mut path_stack: Vec<String> = Vec::new();
+
+        for file_path in files {
+            let rel = file_path
+                .strip_prefix(&metadata.project_root)
+                .unwrap_or(&file_path);
+            let keys = compute_keys(rel, strip)?;
+            let parsed = parse_file(&file_path)?;
+            merge_at_keys(&mut parameters, &keys, parsed, &mut path_stack)?;
+        }
+
+        Ok(ParameterCaptured { parameters })
+    }
+}
+
+impl Captured for ParameterCaptured {
+    fn serialize_json(&self) -> Result<serde_json::Value, serde_json::Error> {
+        serde_json::to_value(self)
+    }
+}
+
+fn build_glob_pattern(base: &Path, pattern: &str) -> String {
+    base.join(pattern).to_string_lossy().replace('\\', "/")
+}
+
+fn collect_files(pattern: &str) -> Result<Vec<PathBuf>, FileHookError> {
+    let paths = glob::glob(pattern)?
+        .filter_map(Result::ok)
+        .filter(|p| p.is_file())
+        .collect();
+    Ok(paths)
+}
+
+/// Build the nested key sequence for a matched file: optional `strip_prefix`
+/// is removed, then the remaining directory components plus the file stem
+/// become the keys.
+fn compute_keys(
+    rel_path: &Path,
+    strip_prefix: Option<&str>,
+) -> Result<Vec<String>, ParameterHookError> {
+    let trimmed = if let Some(prefix) = strip_prefix {
+        rel_path
+            .strip_prefix(Path::new(prefix))
+            .map_err(|_| ParameterHookError::StripPrefixMismatch {
+                prefix: prefix.to_string(),
+                path: rel_path.to_string_lossy().into_owned(),
+            })?
+    } else {
+        rel_path
+    };
+
+    let mut keys: Vec<String> = trimmed
+        .parent()
+        .into_iter()
+        .flat_map(Path::components)
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .collect();
+
+    if let Some(stem) = trimmed.file_stem() {
+        keys.push(stem.to_string_lossy().into_owned());
+    }
+
+    Ok(keys)
+}
+
+/// Merge `leaf` into `target` at the nested key path `keys`. Existing objects
+/// are deep-merged; conflicting non-object values produce `ParameterConflict`.
+fn merge_at_keys(
+    target: &mut Map<String, Value>,
+    keys: &[String],
+    leaf: Value,
+    path_stack: &mut Vec<String>,
+) -> Result<(), ParameterHookError> {
+    let Some((first, rest)) = keys.split_first() else {
+        return Ok(());
+    };
+
+    path_stack.push(first.clone());
+
+    if rest.is_empty() {
+        match target.get_mut(first) {
+            Some(existing) => merge_value(existing, leaf, path_stack)?,
+            None => {
+                target.insert(first.clone(), leaf);
+            }
+        }
+    } else {
+        let entry = target
+            .entry(first.clone())
+            .or_insert_with(|| Value::Object(Map::new()));
+        let Value::Object(inner) = entry else {
+            return Err(ParameterHookError::ParameterConflict(path_stack.join(".")));
+        };
+        merge_at_keys(inner, rest, leaf, path_stack)?;
+    }
+
+    path_stack.pop();
+    Ok(())
+}
+
+/// Recursively merge `b` into `a`. Objects are merged key-by-key; scalars,
+/// arrays, and nulls must be equal or the merge fails with `ParameterConflict`.
+fn merge_value(
+    a: &mut Value,
+    b: Value,
+    path_stack: &mut Vec<String>,
+) -> Result<(), ParameterHookError> {
+    match b {
+        Value::Object(mb) => {
+            let Value::Object(ma) = a else {
+                return Err(ParameterHookError::ParameterConflict(path_stack.join(".")));
+            };
+            for (k, v) in mb {
+                path_stack.push(k.clone());
+                match ma.get_mut(&k) {
+                    Some(existing) => merge_value(existing, v, path_stack)?,
+                    None => {
+                        ma.insert(k, v);
+                    }
+                }
+                path_stack.pop();
+            }
+            Ok(())
+        }
+        b_val => {
+            if *a == b_val {
+                Ok(())
+            } else {
+                Err(ParameterHookError::ParameterConflict(path_stack.join(".")))
+            }
+        }
+    }
+}
+
+fn parse_file(path: &Path) -> Result<serde_json::Value, ParameterHookError> {
+    let content = std::fs::read_to_string(path).map_err(|source| FileHookError::ReadError {
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(str::to_ascii_lowercase)
+        .unwrap_or_default();
+
+    match ext.as_str() {
+        "json" => Ok(serde_json::from_str(&content)?),
+        "toml" => {
+            let v: toml::Value = toml::from_str(&content)?;
+            Ok(serde_json::to_value(v)?)
+        }
+        "yaml" | "yml" => {
+            let v: serde_yaml::Value = serde_yaml::from_str(&content)?;
+            Ok(serde_json::to_value(v)?)
+        }
+        _ => Err(ParameterHookError::UnsupportedFileType(ext)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        reason = "Tests use unwrap/expect/panic for clarity"
+    )]
+
+    use super::*;
+    use serde_json::json;
+
+    // ---- compute_keys -----------------------------------------------------
+
+    #[test]
+    fn compute_keys_simple_file_no_prefix() {
+        let keys = compute_keys(Path::new("foo.json"), None).unwrap();
+        assert_eq!(keys, vec!["foo".to_string()]);
+    }
+
+    #[test]
+    fn compute_keys_nested_no_prefix() {
+        let keys = compute_keys(Path::new("sat1/orbit.json"), None).unwrap();
+        assert_eq!(keys, vec!["sat1".to_string(), "orbit".to_string()]);
+    }
+
+    #[test]
+    fn compute_keys_with_strip_prefix_removes_layer() {
+        let keys = compute_keys(Path::new("config/sat1/orbit.json"), Some("config")).unwrap();
+        assert_eq!(keys, vec!["sat1".to_string(), "orbit".to_string()]);
+    }
+
+    #[test]
+    fn compute_keys_strip_prefix_mismatch_errors() {
+        let err = compute_keys(Path::new("etc/foo.json"), Some("config")).unwrap_err();
+        assert!(matches!(err, ParameterHookError::StripPrefixMismatch { .. }));
+    }
+
+    // ---- merge_value ------------------------------------------------------
+
+    #[test]
+    fn merge_value_disjoint_objects() {
+        let mut a = json!({ "x": 1 });
+        merge_value(&mut a, json!({ "y": 2 }), &mut Vec::new()).unwrap();
+        assert_eq!(a, json!({ "x": 1, "y": 2 }));
+    }
+
+    #[test]
+    fn merge_value_equal_scalars_ok() {
+        let mut a = json!(42);
+        merge_value(&mut a, json!(42), &mut Vec::new()).unwrap();
+        assert_eq!(a, json!(42));
+    }
+
+    #[test]
+    fn merge_value_conflicting_scalars_error() {
+        let mut a = json!(1);
+        let err = merge_value(&mut a, json!(2), &mut vec!["root".into()]).unwrap_err();
+        assert!(matches!(err, ParameterHookError::ParameterConflict(ref p) if p == "root"));
+    }
+
+    #[test]
+    fn merge_value_type_mismatch_error() {
+        let mut a = json!({ "x": 1 });
+        let err = merge_value(&mut a, json!(42), &mut vec!["k".into()]).unwrap_err();
+        assert!(matches!(err, ParameterHookError::ParameterConflict(_)));
+    }
+
+    #[test]
+    fn merge_value_equal_arrays_ok() {
+        let mut a = json!([1, 2, 3]);
+        merge_value(&mut a, json!([1, 2, 3]), &mut Vec::new()).unwrap();
+        assert_eq!(a, json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn merge_value_different_arrays_error() {
+        let mut a = json!([1, 2]);
+        let err = merge_value(&mut a, json!([1, 3]), &mut vec!["arr".into()]).unwrap_err();
+        assert!(matches!(err, ParameterHookError::ParameterConflict(ref p) if p == "arr"));
+    }
+
+    #[test]
+    fn merge_value_deep_object_merge() {
+        let mut a = json!({ "inner": { "x": 1 } });
+        merge_value(&mut a, json!({ "inner": { "y": 2 } }), &mut Vec::new()).unwrap();
+        assert_eq!(a, json!({ "inner": { "x": 1, "y": 2 } }));
+    }
+
+    // ---- merge_at_keys ----------------------------------------------------
+
+    #[test]
+    fn merge_at_keys_inserts_at_leaf() {
+        let mut target = Map::new();
+        merge_at_keys(&mut target, &["foo".into()], json!(1), &mut Vec::new()).unwrap();
+        assert_eq!(Value::Object(target), json!({ "foo": 1 }));
+    }
+
+    #[test]
+    fn merge_at_keys_creates_nested_objects() {
+        let mut target: Map<String, Value> = Map::new();
+        merge_at_keys(
+            &mut target,
+            &["sat1".into(), "orbit".into()],
+            json!({ "a": 1 }),
+            &mut Vec::new(),
+        )
+        .unwrap();
+        merge_at_keys(
+            &mut target,
+            &["sat1".into(), "attitude".into()],
+            json!({ "q": [0, 0, 0, 1] }),
+            &mut Vec::new(),
+        )
+        .unwrap();
+        assert_eq!(
+            Value::Object(target),
+            json!({
+                "sat1": {
+                    "attitude": { "q": [0, 0, 0, 1] },
+                    "orbit":    { "a": 1 }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn merge_at_keys_unifies_leaf_and_intermediate() {
+        let mut target: Map<String, Value> = Map::new();
+        merge_at_keys(
+            &mut target,
+            &["sat1".into()],
+            json!({ "x": 1 }),
+            &mut Vec::new(),
+        )
+        .unwrap();
+        merge_at_keys(
+            &mut target,
+            &["sat1".into(), "orbit".into()],
+            json!({ "a": 1 }),
+            &mut Vec::new(),
+        )
+        .unwrap();
+        assert_eq!(
+            Value::Object(target),
+            json!({
+                "sat1": {
+                    "x": 1,
+                    "orbit": { "a": 1 }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn merge_at_keys_conflict_reports_full_path() {
+        let mut target: Map<String, Value> = Map::new();
+        merge_at_keys(
+            &mut target,
+            &["sat1".into(), "orbit".into()],
+            json!({ "a": 1 }),
+            &mut Vec::new(),
+        )
+        .unwrap();
+        let err = merge_at_keys(
+            &mut target,
+            &["sat1".into(), "orbit".into()],
+            json!({ "a": 2 }),
+            &mut Vec::new(),
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, ParameterHookError::ParameterConflict(ref p) if p == "sat1.orbit.a"),
+            "expected conflict at 'sat1.orbit.a', got: {err:?}"
+        );
+    }
+}
+

--- a/crates/capsula-capture-parameter/src/lib.rs
+++ b/crates/capsula-capture-parameter/src/lib.rs
@@ -49,12 +49,9 @@ where
     type Config = ParameterHookConfig;
     type Output = ParameterCaptured;
 
-    fn from_config(
-        config: &serde_json::Value,
-        _project_root: &Path,
-    ) -> CapsulaResult<Self> {
-        let config: ParameterHookConfig = serde_json::from_value(config.clone())
-            .map_err(ParameterHookError::from)?;
+    fn from_config(config: &serde_json::Value, _project_root: &Path) -> CapsulaResult<Self> {
+        let config: ParameterHookConfig =
+            serde_json::from_value(config.clone()).map_err(ParameterHookError::from)?;
         Ok(Self { config })
     }
 
@@ -117,12 +114,12 @@ fn compute_keys(
     strip_prefix: Option<&str>,
 ) -> Result<Vec<String>, ParameterHookError> {
     let trimmed = if let Some(prefix) = strip_prefix {
-        rel_path
-            .strip_prefix(Path::new(prefix))
-            .map_err(|_| ParameterHookError::StripPrefixMismatch {
+        rel_path.strip_prefix(Path::new(prefix)).map_err(|_| {
+            ParameterHookError::StripPrefixMismatch {
                 prefix: prefix.to_string(),
                 path: rel_path.to_string_lossy().into_owned(),
-            })?
+            }
+        })?
     } else {
         rel_path
     };
@@ -271,7 +268,10 @@ mod tests {
     #[test]
     fn compute_keys_strip_prefix_mismatch_errors() {
         let err = compute_keys(Path::new("etc/foo.json"), Some("config")).unwrap_err();
-        assert!(matches!(err, ParameterHookError::StripPrefixMismatch { .. }));
+        assert!(matches!(
+            err,
+            ParameterHookError::StripPrefixMismatch { .. }
+        ));
     }
 
     // ---- merge_value ------------------------------------------------------
@@ -413,4 +413,3 @@ mod tests {
         );
     }
 }
-

--- a/crates/capsula-capture-parameter/tests/integration.rs
+++ b/crates/capsula-capture-parameter/tests/integration.rs
@@ -31,9 +31,9 @@ fn make_run(project_root: &Path) -> PreparedRun {
 
 fn run_hook(
     project_root: &Path,
-    config: serde_json::Value,
+    config: &serde_json::Value,
 ) -> capsula_core::error::CapsulaResult<serde_json::Value> {
-    let hook = <ParameterHook as Hook<PreRun>>::from_config(&config, project_root)?;
+    let hook = <ParameterHook as Hook<PreRun>>::from_config(config, project_root)?;
     let run = make_run(project_root);
     let params = RuntimeParams::<PreRun>::default();
     let captured = <ParameterHook as Hook<PreRun>>::run(&hook, &run, &params)?;
@@ -59,7 +59,7 @@ fn parses_single_json_file() {
     let tmp = TempDir::new().unwrap();
     fs::write(tmp.path().join("params.json"), r#"{"a": 1, "b": "x"}"#).unwrap();
 
-    let out = run_hook(tmp.path(), json!({ "glob": "*.json" })).unwrap();
+    let out = run_hook(tmp.path(), &json!({ "glob": "*.json" })).unwrap();
     assert_eq!(
         out,
         json!({
@@ -77,7 +77,7 @@ fn parses_toml_file() {
     )
     .unwrap();
 
-    let out = run_hook(tmp.path(), json!({ "glob": "*.toml" })).unwrap();
+    let out = run_hook(tmp.path(), &json!({ "glob": "*.toml" })).unwrap();
     assert_eq!(
         out,
         json!({
@@ -92,7 +92,7 @@ fn merges_json_and_yaml_with_same_stem() {
     fs::write(tmp.path().join("orbit.json"), r#"{"a": 1}"#).unwrap();
     fs::write(tmp.path().join("orbit.yaml"), "b: 2\n").unwrap();
 
-    let out = run_hook(tmp.path(), json!({ "glob": "orbit.*" })).unwrap();
+    let out = run_hook(tmp.path(), &json!({ "glob": "orbit.*" })).unwrap();
     assert_eq!(
         out,
         json!({
@@ -111,7 +111,7 @@ fn nested_directories_with_strip_prefix() {
 
     let out = run_hook(
         tmp.path(),
-        json!({
+        &json!({
             "glob": "config/**/*.json",
             "strip_prefix": "config"
         }),
@@ -135,7 +135,7 @@ fn leaf_and_intermediate_node_merge() {
     fs::write(tmp.path().join("sat1.json"), r#"{"x": 1}"#).unwrap();
     fs::write(tmp.path().join("sat1/orbit.json"), r#"{"a": 1}"#).unwrap();
 
-    let out = run_hook(tmp.path(), json!({ "glob": "**/*.json" })).unwrap();
+    let out = run_hook(tmp.path(), &json!({ "glob": "**/*.json" })).unwrap();
     assert_eq!(
         out,
         json!({
@@ -155,7 +155,7 @@ fn conflict_when_two_files_disagree_on_value() {
     fs::write(tmp.path().join("p.json"), r#"{"x": 1}"#).unwrap();
     fs::write(tmp.path().join("p.yaml"), "x: 2\n").unwrap();
 
-    let result = run_hook(tmp.path(), json!({ "glob": "p.*" }));
+    let result = run_hook(tmp.path(), &json!({ "glob": "p.*" }));
     let err = result.unwrap_err();
     let msg = full_error_text(&err);
     assert!(
@@ -169,7 +169,7 @@ fn unsupported_extension_errors() {
     let tmp = TempDir::new().unwrap();
     fs::write(tmp.path().join("data.csv"), "a,b\n1,2\n").unwrap();
 
-    let result = run_hook(tmp.path(), json!({ "glob": "*.csv" }));
+    let result = run_hook(tmp.path(), &json!({ "glob": "*.csv" }));
     assert!(result.is_err());
 }
 
@@ -181,7 +181,7 @@ fn strip_prefix_mismatch_errors() {
 
     let result = run_hook(
         tmp.path(),
-        json!({
+        &json!({
             "glob": "etc/*.json",
             "strip_prefix": "config"
         }),

--- a/crates/capsula-capture-parameter/tests/integration.rs
+++ b/crates/capsula-capture-parameter/tests/integration.rs
@@ -1,0 +1,195 @@
+//! End-to-end tests for the `capture-parameter` hook against a real
+//! filesystem (temp dirs).
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "Tests use unwrap/expect/panic for clarity"
+)]
+
+use std::fs;
+use std::path::Path;
+
+use capsula_capture_parameter::ParameterHook;
+use capsula_core::captured::Captured;
+use capsula_core::hook::{Hook, PreRun, RuntimeParams};
+use capsula_core::run::{PreparedRun, Run};
+use serde_json::json;
+use tempfile::TempDir;
+use ulid::Ulid;
+
+fn make_run(project_root: &Path) -> PreparedRun {
+    Run {
+        id: Ulid::new(),
+        name: "test-run".into(),
+        command: vec![],
+        run_dir: project_root.to_path_buf(),
+        project_root: project_root.to_path_buf(),
+    }
+}
+
+fn run_hook(
+    project_root: &Path,
+    config: serde_json::Value,
+) -> capsula_core::error::CapsulaResult<serde_json::Value> {
+    let hook = <ParameterHook as Hook<PreRun>>::from_config(&config, project_root)?;
+    let run = make_run(project_root);
+    let params = RuntimeParams::<PreRun>::default();
+    let captured = <ParameterHook as Hook<PreRun>>::run(&hook, &run, &params)?;
+    Ok(captured.serialize_json().expect("serialize"))
+}
+
+/// Flatten an error chain into a single string by appending every
+/// `source()` along the way. Capsula's outer error only reports
+/// "Hook 'X' failed", so the actual cause lives in nested sources.
+fn full_error_text(err: &(dyn std::error::Error + 'static)) -> String {
+    let mut s = err.to_string();
+    let mut current = err.source();
+    while let Some(e) = current {
+        s.push_str(" :: ");
+        s.push_str(&e.to_string());
+        current = e.source();
+    }
+    s
+}
+
+#[test]
+fn parses_single_json_file() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(tmp.path().join("params.json"), r#"{"a": 1, "b": "x"}"#).unwrap();
+
+    let out = run_hook(tmp.path(), json!({ "glob": "*.json" })).unwrap();
+    assert_eq!(
+        out,
+        json!({
+            "parameters": { "params": { "a": 1, "b": "x" } }
+        })
+    );
+}
+
+#[test]
+fn parses_toml_file() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(
+        tmp.path().join("config.toml"),
+        "name = \"capsula\"\nport = 8080\n",
+    )
+    .unwrap();
+
+    let out = run_hook(tmp.path(), json!({ "glob": "*.toml" })).unwrap();
+    assert_eq!(
+        out,
+        json!({
+            "parameters": { "config": { "name": "capsula", "port": 8080 } }
+        })
+    );
+}
+
+#[test]
+fn merges_json_and_yaml_with_same_stem() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(tmp.path().join("orbit.json"), r#"{"a": 1}"#).unwrap();
+    fs::write(tmp.path().join("orbit.yaml"), "b: 2\n").unwrap();
+
+    let out = run_hook(tmp.path(), json!({ "glob": "orbit.*" })).unwrap();
+    assert_eq!(
+        out,
+        json!({
+            "parameters": { "orbit": { "a": 1, "b": 2 } }
+        })
+    );
+}
+
+#[test]
+fn nested_directories_with_strip_prefix() {
+    let tmp = TempDir::new().unwrap();
+    fs::create_dir_all(tmp.path().join("config/sat1")).unwrap();
+    fs::create_dir_all(tmp.path().join("config/sat2")).unwrap();
+    fs::write(tmp.path().join("config/sat1/orbit.json"), r#"{"a": 1}"#).unwrap();
+    fs::write(tmp.path().join("config/sat2/orbit.json"), r#"{"a": 3}"#).unwrap();
+
+    let out = run_hook(
+        tmp.path(),
+        json!({
+            "glob": "config/**/*.json",
+            "strip_prefix": "config"
+        }),
+    )
+    .unwrap();
+    assert_eq!(
+        out,
+        json!({
+            "parameters": {
+                "sat1": { "orbit": { "a": 1 } },
+                "sat2": { "orbit": { "a": 3 } }
+            }
+        })
+    );
+}
+
+#[test]
+fn leaf_and_intermediate_node_merge() {
+    let tmp = TempDir::new().unwrap();
+    fs::create_dir_all(tmp.path().join("sat1")).unwrap();
+    fs::write(tmp.path().join("sat1.json"), r#"{"x": 1}"#).unwrap();
+    fs::write(tmp.path().join("sat1/orbit.json"), r#"{"a": 1}"#).unwrap();
+
+    let out = run_hook(tmp.path(), json!({ "glob": "**/*.json" })).unwrap();
+    assert_eq!(
+        out,
+        json!({
+            "parameters": {
+                "sat1": {
+                    "x": 1,
+                    "orbit": { "a": 1 }
+                }
+            }
+        })
+    );
+}
+
+#[test]
+fn conflict_when_two_files_disagree_on_value() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(tmp.path().join("p.json"), r#"{"x": 1}"#).unwrap();
+    fs::write(tmp.path().join("p.yaml"), "x: 2\n").unwrap();
+
+    let result = run_hook(tmp.path(), json!({ "glob": "p.*" }));
+    let err = result.unwrap_err();
+    let msg = full_error_text(&err);
+    assert!(
+        msg.to_lowercase().contains("conflict"),
+        "expected conflict error, got: {msg}"
+    );
+}
+
+#[test]
+fn unsupported_extension_errors() {
+    let tmp = TempDir::new().unwrap();
+    fs::write(tmp.path().join("data.csv"), "a,b\n1,2\n").unwrap();
+
+    let result = run_hook(tmp.path(), json!({ "glob": "*.csv" }));
+    assert!(result.is_err());
+}
+
+#[test]
+fn strip_prefix_mismatch_errors() {
+    let tmp = TempDir::new().unwrap();
+    fs::create_dir_all(tmp.path().join("etc")).unwrap();
+    fs::write(tmp.path().join("etc/foo.json"), r#"{"a": 1}"#).unwrap();
+
+    let result = run_hook(
+        tmp.path(),
+        json!({
+            "glob": "etc/*.json",
+            "strip_prefix": "config"
+        }),
+    );
+    let err = result.unwrap_err();
+    let msg = full_error_text(&err);
+    assert!(
+        msg.contains("strip_prefix"),
+        "expected strip_prefix error, got: {msg}"
+    );
+}

--- a/crates/capsula-registry/src/lib.rs
+++ b/crates/capsula-registry/src/lib.rs
@@ -185,6 +185,7 @@ where
     capsula_capture_env::EnvVarHook: capsula_core::hook::Hook<P>,
     capsula_capture_command::CommandHook: capsula_core::hook::Hook<P>,
     capsula_capture_machine::MachineHook: capsula_core::hook::Hook<P>,
+    capsula_capture_parameter::ParameterHook: capsula_core::hook::Hook<P>,
     capsula_notify_slack::SlackNotifyHook: capsula_core::hook::Hook<P>,
 {
     Ok(RegistryBuilder::new()
@@ -194,6 +195,7 @@ where
         .with_hook::<capsula_capture_env::EnvVarHook>()?
         .with_hook::<capsula_capture_command::CommandHook>()?
         .with_hook::<capsula_capture_machine::MachineHook>()?
+        .with_hook::<capsula_capture_parameter::ParameterHook>()?
         .with_hook::<capsula_notify_slack::SlackNotifyHook>()?
         .build())
 }

--- a/docs/hooks/capture-parameter.md
+++ b/docs/hooks/capture-parameter.md
@@ -1,0 +1,226 @@
+---
+icon: material/hook
+---
+
+# capture-parameter
+
+Parses structured parameter files (TOML / JSON / YAML) into JSON and embeds the
+parsed values directly into `pre-run.json` / `post-run.json` so they can be
+queried by the server.
+
+## Use Cases
+
+- Make experiment hyperparameters queryable across runs
+- Power dashboards that show parameter values alongside metrics
+- Normalize configs written in different formats (TOML / JSON / YAML) into a
+  single queryable schema
+- Diff parameter sets between two runs without re-reading raw files
+
+## Configuration
+
+### Required Options
+
+| Option | Type   | Description                                                                  |
+| ------ | ------ | ---------------------------------------------------------------------------- |
+| `glob` | string | File pattern relative to project root (e.g., `"configs/*.yaml"`, `"*.toml"`) |
+
+### Optional Options
+
+| Option         | Type   | Default | Description                                                                                                                              |
+| -------------- | ------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `strip_prefix` | string | (none)  | Literal path prefix to remove from each matched file's relative path before constructing nested keys. Must be a prefix of every match.   |
+
+### Supported File Formats
+
+The hook detects the format by file extension (case-insensitive):
+
+| Extension       | Parser        |
+| --------------- | ------------- |
+| `.json`         | `serde_json`  |
+| `.toml`         | `toml`        |
+| `.yaml`, `.yml` | `serde_yaml`  |
+
+Files matching the glob whose extension is none of the above produce an
+`UnsupportedFileType` error and abort the hook.
+
+### Example
+
+```toml
+[[pre-run.hooks]]
+id = "capture-parameter"
+glob = "configs/*.yaml"
+```
+
+## Output Example
+
+Each matched file's path (relative to `project_root`, with `strip_prefix`
+removed if set) becomes a sequence of nested keys: directory components are
+intermediate keys, and the file stem is the final key. Sibling files merge
+into the same object naturally.
+
+Given:
+
+```text
+config/sat1/orbit.json     { "a": 1, "b": 2 }
+config/sat1/attitude.yaml  { "q": [0, 0, 0, 1] }
+config/sat2/orbit.json     { "a": 3 }
+```
+
+with config:
+
+```toml
+[[pre-run.hooks]]
+id = "capture-parameter"
+glob = "config/**/*.{json,yaml}"
+strip_prefix = "config"
+```
+
+the captured output is:
+
+```json
+{
+  "__meta": {
+    "id": "capture-parameter",
+    "config": {
+      "glob": "config/**/*.{json,yaml}",
+      "strip_prefix": "config"
+    },
+    "success": true
+  },
+  "parameters": {
+    "sat1": {
+      "attitude": { "q": [0, 0, 0, 1] },
+      "orbit":    { "a": 1, "b": 2 }
+    },
+    "sat2": {
+      "orbit": { "a": 3 }
+    }
+  }
+}
+```
+
+The server can then query the parsed values directly, e.g.,
+`WHERE parameters.sat1.orbit.a > 0`.
+
+## Merge & Conflict Semantics
+
+Files whose computed key paths collide are **deep-merged** into the same
+object. This unifies two situations that would otherwise need separate
+handling:
+
+1. **Same-stem cross-format files** — `orbit.json` and `orbit.yaml` in the
+   same directory both contribute to `parameters.<dir>.orbit`.
+2. **Leaf vs. intermediate node** — a file `sat1.json` at level N and any
+   files under `sat1/` at level N+1 both contribute to `parameters.sat1`.
+
+A `ParameterConflict` error is raised only when the merge cannot reconcile
+two values. The error message includes the dotted key path where the conflict
+occurred.
+
+| Situation                                                | Outcome                            |
+| -------------------------------------------------------- | ---------------------------------- |
+| Disjoint keys at the same level                          | Merged                             |
+| Same key, identical scalar / array value                 | Merged (idempotent)                |
+| Same key, **different** scalar / array values            | `ParameterConflict` at that path   |
+| Same key, one side object and the other scalar / array   | `ParameterConflict` at that path   |
+
+Arrays are treated as **opaque leaf values** — element-wise merging is not
+performed. Two arrays must be exactly equal to merge.
+
+!!! note "`strip_prefix` mismatch"
+    If `strip_prefix` is set but a matched file's relative path does not start
+    with it, the hook fails with `StripPrefixMismatch`. Either narrow the glob
+    so it cannot escape the prefix, or remove `strip_prefix`.
+
+## When to Use vs `capture-file`
+
+`capture-parameter` and [`capture-file`](capture-file.md) can both record the
+state of a configuration file at run time, but they answer different questions.
+Pick by what you intend to do with the captured data downstream.
+
+### Axis 1: Queryability vs Byte-exactness
+
+| Concern                                   | `capture-file`                   | `capture-parameter`                       |
+| ----------------------------------------- | -------------------------------- | ----------------------------------------- |
+| Stored content                            | Raw bytes (+ optional hash)      | Parsed JSON value                         |
+| Cross-run server query (sql-json-path)    | Hash / path only                 | Full structured query on parameter values |
+| Bit-exact reproduction of the input file  | Yes                              | No (formatting / comments lost)           |
+| Hash for content-addressable identity     | Yes                              | No                                        |
+| File format constraint                    | Any (binary OK)                  | TOML / JSON / YAML only                   |
+| Comments preserved                        | Yes                              | No                                        |
+| Format-specific types (TOML datetime)     | Preserved as written             | Coerced to JSON string                    |
+| Output location                           | Artifact directory + meta entry  | Inline `parameters` map in `pre-run.json` |
+
+### Axis 2: Use case decision matrix
+
+| Scenario                                                    | Recommended hook            |
+| ----------------------------------------------------------- | --------------------------- |
+| Hyperparameter sweep, want to query top runs by `lr` value  | `capture-parameter`         |
+| Leaderboard dashboard joining params with metrics           | `capture-parameter`         |
+| Reproduce a bug exactly from a tricky YAML formatting       | `capture-file`              |
+| Compliance archive of every config used in production       | `capture-file`              |
+| Save a model checkpoint (`.pth`) or dataset (`.csv`)        | `capture-file`              |
+| Preserve hand-written comments in a YAML config             | `capture-file`              |
+| Normalize configs across teams using different formats      | `capture-parameter`         |
+| Full audit + queryable params (production ML)               | **Both** (see below)        |
+
+### Combined pattern (recommended for production)
+
+For production-grade tracking, register both hooks against the same glob. You
+get a byte-exact archive **and** queryable structured values.
+
+```toml
+[[pre-run.hooks]]
+id = "capture-file"
+glob = "configs/*.yaml"
+mode = "copy"
+hash = "sha256"
+
+[[pre-run.hooks]]
+id = "capture-parameter"
+glob = "configs/*.yaml"
+```
+
+The two outputs serve different consumers:
+
+- `capture-file` → archival, replay, compliance audit
+- `capture-parameter` → server query, dashboards, cross-run analysis
+
+### Mental model
+
+- `capture-file` is `git add path/to/file` — it preserves bytes.
+- `capture-parameter` is `INSERT INTO params (...) VALUES (...)` — it gives
+  the server queryable data.
+
+If you only ever look at one run at a time, `capture-file` is usually enough.
+The moment you want to ask a question that **spans runs**
+(`WHERE learning_rate > 0.01`, `GROUP BY architecture`), you need
+`capture-parameter`.
+
+## Limitations
+
+The conversion to JSON is intentionally simple and drops several pieces of
+information that JSON cannot represent. If any of these matter for a given
+file, capture the raw bytes with `capture-file` instead (or in addition).
+
+- **Comments** in TOML / YAML are removed.
+- **TOML datetime types** are coerced to RFC 3339 strings; the original type
+  tag is not preserved.
+- **YAML anchors / aliases** (`&` / `*`) are resolved at parse time. References
+  become duplicated content.
+- **YAML merge keys** (`<<`) are resolved at parse time.
+- **YAML non-string mapping keys** are not supported and will fail
+  serialization to JSON.
+- **YAML special floats** (`.inf`, `.nan`) are not representable in JSON.
+- **Multi-document YAML streams** (`---` separators) are not supported.
+- **Conflicting parameter values** across matched files are rejected with
+  `ParameterConflict`. See [Merge & Conflict Semantics](#merge-conflict-semantics).
+  Disambiguate via a narrower glob, by renaming files / keys, or by splitting
+  into multiple `capture-parameter` entries.
+- **Element-wise array merge** is not supported. Arrays must be exactly equal
+  across files to coexist at the same key.
+
+## See Also
+
+- [`capture-file`](capture-file.md) — byte-exact file capture
+- [`capture-env`](capture-env.md) — single environment variable capture


### PR DESCRIPTION
## Summary

Adds a new hook `capture-parameter` that parses TOML / JSON / YAML configuration
files, normalizes them to JSON, and embeds the parsed values directly into
`pre-run.json` / `post-run.json` so that the capsula-server can query them with
sql-json-path. Whereas `capture-file` preserves bytes for archival / audit,
`capture-parameter` preserves structured values for cross-run query / analysis.

## Motivation

`capture-file` records the byte-exact state of a config file, but the server
can only index its `hash` and `path`. There is no way to answer queries like
"find every run with `learning_rate > 0.01`" across runs. With
`capture-parameter`:

- Hyperparameter sweeps become queryable from the server with SQL JSON path.
- Configs written in different formats (TOML / JSON / YAML) are normalized
  into a single queryable schema.
- Dashboards can join run-level parameters with metrics.

## Design

### Configuration

```toml
[[pre-run.hooks]]
id = "capture-parameter"
glob = "config/**/*.{json,yaml}"   # file selection
strip_prefix = "config"            # optional namespace prefix to strip
```

### Directory hierarchy → nested keys

`config/sat1/orbit.json` (containing `{"a": 1}`), with
`strip_prefix = "config"`, becomes queryable as `parameters.sat1.orbit.a`.
The intermediate directory components plus the file stem form the nested
key path.

### Merge & conflict semantics

When multiple files land at the same key path, their contents are
**deep-merged**. `ParameterConflict` is raised only when values genuinely
disagree. This unifies several situations that would otherwise need separate
handling:

| Situation | Outcome |
|---|---|
| `orbit.json` + `orbit.yaml` (disjoint keys) | merged |
| `orbit.json` + `orbit.yaml` (same key, same value) | OK (idempotent) |
| `orbit.json` + `orbit.yaml` (same key, different value) | `ParameterConflict` |
| `sat1.json` (leaf) and `sat1/orbit.json` (intermediate node) | merged |
| Differing arrays at the same key | `ParameterConflict` (no element-wise merge) |

### Output example

Input layout:

```
config/sat1/orbit.json     { "a": 1, "b": 2 }
config/sat1/attitude.yaml  { "q": [0, 0, 0, 1] }
config/sat2/orbit.json     { "a": 3 }
```

Captured output (excerpt of `pre-run.json`):

```json
{
  "__meta": { "id": "capture-parameter", "config": {...}, "success": true },
  "parameters": {
    "sat1": {
      "attitude": { "q": [0, 0, 0, 1] },
      "orbit":    { "a": 1, "b": 2 }
    },
    "sat2": {
      "orbit": { "a": 3 }
    }
  }
}
```

## Changes

### New crate

- `crates/capsula-capture-parameter/` — `ParameterHook`, `ParameterCaptured`,
  helper functions (`compute_keys`, `merge_value`, `merge_at_keys`),
  `ParameterHookError`.

### Existing crates

- `crates/capsula-registry/` — registers `ParameterHook` in both the pre-run
  and post-run registries.
- `crates/capsula-capture-file/src/lib.rs` — `mod error;` → `pub mod error;`
  so that `FileHookError` can be wrapped from `capture-parameter` via
  `#[error(transparent)]`.
- `Cargo.toml` (workspace) — adds `capsula-capture-parameter`; bumps the
  workspace version from `0.12.1` to **`0.13.0`** (minor bump for the new
  feature; backward compatible).

### Documentation

- `docs/hooks/capture-parameter.md` (new):
  - Configuration options (`glob`, `strip_prefix`)
  - Output example showing directory hierarchy → nested keys
  - **Merge & Conflict Semantics** section
  - When to use `capture-parameter` vs `capture-file` (two-axis comparison
    table, scenario decision matrix, combined-usage pattern)
  - Limitations covering JSON-incompatible information (TOML datetime, YAML
    anchors, etc.)

## Tests

`cargo test -p capsula-capture-parameter` — **23 tests, all green**.

### Unit tests (15) — `src/lib.rs` `#[cfg(test)] mod tests`
- `compute_keys`: simple / nested / strip_prefix / strip_prefix mismatch
- `merge_value`: disjoint objects, equal scalars, conflicting scalars, type
  mismatch, equal arrays, differing arrays, deep object merge
- `merge_at_keys`: leaf insertion, nested object creation, leaf↔intermediate
  unification, conflict path reporting

### Integration tests (8) — `tests/integration.rs`
- Single JSON / TOML file parsing
- Same-stem cross-format merge (`orbit.json` + `orbit.yaml`)
- Nested directories with `strip_prefix`
- Leaf and intermediate node merge (`sat1.json` + `sat1/orbit.json`)
- `ParameterConflict` on value disagreement
- Unsupported extensions (e.g., `.csv`) error
- `strip_prefix` mismatch error

## Limitations

Because the value is normalized to JSON, the following are lost. Use
`capture-file` alongside if these matter:

- Comments in TOML / YAML
- TOML datetime type tags (coerced to RFC 3339 strings)
- YAML anchors / aliases (resolved at parse time; references become duplicated)
- YAML non-string mapping keys (fails JSON serialization)
- YAML `.inf` / `.nan` (not representable in JSON)
- Element-wise array merge (arrays are treated as opaque leaves)

## Test Plan

- [x] `cargo test -p capsula-capture-parameter` — 23 tests pass
- [x] `cargo build --release -p capsula`
- [x] End-to-end demo in `/home/shimomura/capsula-demo` — a Monte Carlo Pi
      estimator with `capture-file` and `capture-parameter` applied to the
      same glob, output diff confirmed
- [x] CI green

## Breaking Changes

None. New hook only; existing capsula configurations are unaffected.