### PR TITLE
feat(capture-json): add hook that parses a single JSON file into queryable parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,6 +629,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "capsula-capture-json"
+version = "0.12.1"
+dependencies = [
+ "capsula-core",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "ulid",
+]
+
+[[package]]
 name = "capsula-capture-machine"
 version = "0.12.1"
 dependencies = [
@@ -739,6 +752,7 @@ dependencies = [
  "capsula-capture-env",
  "capsula-capture-file",
  "capsula-capture-git-repo",
+ "capsula-capture-json",
  "capsula-capture-machine",
  "capsula-capture-toml",
  "capsula-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ capsula-capture-cwd = { path = "crates/capsula-capture-cwd", version = "0.12.1" 
 capsula-capture-env = { path = "crates/capsula-capture-env", version = "0.12.1" }
 capsula-capture-file = { path = "crates/capsula-capture-file", version = "0.12.1" }
 capsula-capture-git-repo = { path = "crates/capsula-capture-git-repo", version = "0.12.1" }
+capsula-capture-json = { path = "crates/capsula-capture-json", version = "0.12.1" }
 capsula-capture-machine = { path = "crates/capsula-capture-machine", version = "0.12.1" }
 capsula-capture-toml = { path = "crates/capsula-capture-toml", version = "0.12.1" }
 capsula-client = { path = "crates/capsula-client", version = "0.12.1" }

--- a/crates/capsula-capture-json/Cargo.toml
+++ b/crates/capsula-capture-json/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "capsula-capture-json"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "A Capsula hook that parses a JSON file into queryable parameters."
+readme.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords = ["capsula", "capsula-hook"]
+categories = ["development-tools"]
+
+[dependencies]
+capsula-core = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+ulid = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/capsula-capture-json/src/error.rs
+++ b/crates/capsula-capture-json/src/error.rs
@@ -1,0 +1,29 @@
+use capsula_core::error::CapsulaError;
+use std::path::PathBuf;
+use thiserror::Error;
+
+/// `capture-json` hook specific errors
+#[derive(Debug, Error)]
+pub enum JsonHookError {
+    /// Failed to read the configured JSON file
+    #[error("Failed to read JSON file '{path}': {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// Failed to deserialize the file content as JSON, or failed to parse the
+    /// hook config from TOML.
+    #[error("Failed to deserialize JSON: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+impl From<JsonHookError> for CapsulaError {
+    fn from(err: JsonHookError) -> Self {
+        Self::HookFailed {
+            hook: "capture-json".to_string(),
+            source: Box::new(err),
+        }
+    }
+}

--- a/crates/capsula-capture-json/src/lib.rs
+++ b/crates/capsula-capture-json/src/lib.rs
@@ -1,9 +1,11 @@
 //! `capture-json` hook: parse a single JSON file and embed its parsed
-//! content in the run output under the `parameters` field.
+//! content in the run output under the `content` field.
 //!
 //! By design this hook captures exactly one file per instance. Compose
 //! multiple `capture-json` entries in `capsula.toml` to capture multiple
-//! files.
+//! files. The path written in the config is preserved as part of the
+//! standard `__meta.config.path`, so the captured value does not need
+//! to duplicate it.
 
 mod error;
 
@@ -28,17 +30,12 @@ pub struct JsonHookConfig {
 #[derive(Debug)]
 pub struct JsonHook {
     config: JsonHookConfig,
-    project_root: PathBuf,
 }
 
 #[derive(Debug, Serialize)]
 pub struct JsonCaptured {
-    /// The path as written in the configuration (verbatim, including any
-    /// directory components). Useful for distinguishing multiple
-    /// `capture-json` outputs that share the same basename.
-    file: String,
     /// The parsed content of the file as JSON.
-    parameters: serde_json::Value,
+    content: serde_json::Value,
 }
 
 impl<P> Hook<P> for JsonHook
@@ -50,13 +47,10 @@ where
     type Config = JsonHookConfig;
     type Output = JsonCaptured;
 
-    fn from_config(config: &serde_json::Value, project_root: &Path) -> CapsulaResult<Self> {
+    fn from_config(config: &serde_json::Value, _project_root: &Path) -> CapsulaResult<Self> {
         let config: JsonHookConfig =
             serde_json::from_value(config.clone()).map_err(JsonHookError::from)?;
-        Ok(Self {
-            config,
-            project_root: project_root.to_path_buf(),
-        })
+        Ok(Self { config })
     }
 
     fn config(&self) -> &Self::Config {
@@ -65,24 +59,20 @@ where
 
     fn run(
         &self,
-        _metadata: &PreparedRun,
+        metadata: &PreparedRun,
         _params: &RuntimeParams<P>,
     ) -> CapsulaResult<Self::Output> {
-        let full_path = self.project_root.join(&self.config.path);
+        let full_path = metadata.project_root.join(&self.config.path);
         debug!("JsonHook: reading {}", full_path.display());
 
-        let content = std::fs::read_to_string(&full_path).map_err(|source| JsonHookError::Io {
+        let raw = std::fs::read_to_string(&full_path).map_err(|source| JsonHookError::Io {
             path: full_path.clone(),
             source,
         })?;
 
-        let parameters: serde_json::Value =
-            serde_json::from_str(&content).map_err(JsonHookError::from)?;
+        let content: serde_json::Value = serde_json::from_str(&raw).map_err(JsonHookError::from)?;
 
-        Ok(JsonCaptured {
-            file: self.config.path.to_string_lossy().into_owned(),
-            parameters,
-        })
+        Ok(JsonCaptured { content })
     }
 }
 
@@ -128,27 +118,29 @@ mod tests {
     }
 
     #[test]
-    fn parses_valid_json_into_parameters_field() {
+    fn parses_valid_json_into_content_field() {
         let tmp = TempDir::new().unwrap();
         fs::write(tmp.path().join("p.json"), r#"{"a": 1, "b": "x"}"#).unwrap();
 
         let hook = make_hook(tmp.path(), "p.json");
         let captured = run_hook(&hook, tmp.path()).unwrap();
 
-        assert_eq!(captured.file, "p.json");
-        assert_eq!(captured.parameters, serde_json::json!({"a": 1, "b": "x"}));
+        assert_eq!(captured.content, serde_json::json!({"a": 1, "b": "x"}));
     }
 
     #[test]
-    fn file_field_preserves_configured_path_verbatim() {
-        let tmp = TempDir::new().unwrap();
-        fs::create_dir_all(tmp.path().join("config/sat1")).unwrap();
-        fs::write(tmp.path().join("config/sat1/orbit.json"), r#"{"a": 1}"#).unwrap();
+    fn resolves_path_relative_to_metadata_project_root() {
+        // The hook reads project_root from PreparedRun, not from its own
+        // state. Capture this contract: a hook built against tmp_a but
+        // run against tmp_b should resolve relative to tmp_b.
+        let tmp_a = TempDir::new().unwrap();
+        let tmp_b = TempDir::new().unwrap();
+        fs::write(tmp_b.path().join("p.json"), r#"{"x": 1}"#).unwrap();
 
-        let hook = make_hook(tmp.path(), "config/sat1/orbit.json");
-        let captured = run_hook(&hook, tmp.path()).unwrap();
+        let hook = make_hook(tmp_a.path(), "p.json");
+        let captured = run_hook(&hook, tmp_b.path()).unwrap();
 
-        assert_eq!(captured.file, "config/sat1/orbit.json");
+        assert_eq!(captured.content, serde_json::json!({"x": 1}));
     }
 
     #[test]
@@ -163,8 +155,8 @@ mod tests {
         let hook = make_hook(tmp.path(), "nested.json");
         let captured = run_hook(&hook, tmp.path()).unwrap();
 
-        assert_eq!(captured.parameters["sat1"]["orbit"]["a"], 1.42);
-        assert_eq!(captured.parameters["sat1"]["orbit"]["b"], "LEO");
+        assert_eq!(captured.content["sat1"]["orbit"]["a"], 1.42);
+        assert_eq!(captured.content["sat1"]["orbit"]["b"], "LEO");
     }
 
     #[test]
@@ -184,7 +176,7 @@ mod tests {
     }
 
     #[test]
-    fn serialized_output_has_file_and_parameters_fields() {
+    fn serialized_output_has_only_content_field() {
         let tmp = TempDir::new().unwrap();
         fs::write(tmp.path().join("p.json"), r#"{"x": 42}"#).unwrap();
 
@@ -192,8 +184,11 @@ mod tests {
         let captured = run_hook(&hook, tmp.path()).unwrap();
         let json = captured.serialize_json().unwrap();
 
-        assert_eq!(json["file"], "p.json");
-        assert_eq!(json["parameters"]["x"], 42);
+        assert_eq!(json["content"]["x"], 42);
+        assert!(
+            json.get("file").is_none(),
+            "file is redundant with __meta.config.path"
+        );
         assert!(
             json.get("__meta").is_none(),
             "__meta is added by orchestration, not the hook"

--- a/crates/capsula-capture-json/src/lib.rs
+++ b/crates/capsula-capture-json/src/lib.rs
@@ -1,0 +1,202 @@
+//! `capture-json` hook: parse a single JSON file and embed its parsed
+//! content in the run output under the `parameters` field.
+//!
+//! By design this hook captures exactly one file per instance. Compose
+//! multiple `capture-json` entries in `capsula.toml` to capture multiple
+//! files.
+
+mod error;
+
+use std::path::{Path, PathBuf};
+
+use capsula_core::captured::Captured;
+use capsula_core::error::CapsulaResult;
+use capsula_core::hook::{Hook, PhaseMarker, RuntimeParams};
+use capsula_core::run::PreparedRun;
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+use crate::error::JsonHookError;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct JsonHookConfig {
+    /// Path to the JSON file to parse, relative to `project_root`.
+    /// Absolute paths are also accepted.
+    path: PathBuf,
+}
+
+#[derive(Debug)]
+pub struct JsonHook {
+    config: JsonHookConfig,
+    project_root: PathBuf,
+}
+
+#[derive(Debug, Serialize)]
+pub struct JsonCaptured {
+    /// The path as written in the configuration (verbatim, including any
+    /// directory components). Useful for distinguishing multiple
+    /// `capture-json` outputs that share the same basename.
+    file: String,
+    /// The parsed content of the file as JSON.
+    parameters: serde_json::Value,
+}
+
+impl<P> Hook<P> for JsonHook
+where
+    P: PhaseMarker,
+{
+    const ID: &'static str = "capture-json";
+
+    type Config = JsonHookConfig;
+    type Output = JsonCaptured;
+
+    fn from_config(config: &serde_json::Value, project_root: &Path) -> CapsulaResult<Self> {
+        let config: JsonHookConfig =
+            serde_json::from_value(config.clone()).map_err(JsonHookError::from)?;
+        Ok(Self {
+            config,
+            project_root: project_root.to_path_buf(),
+        })
+    }
+
+    fn config(&self) -> &Self::Config {
+        &self.config
+    }
+
+    fn run(
+        &self,
+        _metadata: &PreparedRun,
+        _params: &RuntimeParams<P>,
+    ) -> CapsulaResult<Self::Output> {
+        let full_path = self.project_root.join(&self.config.path);
+        debug!("JsonHook: reading {}", full_path.display());
+
+        let content = std::fs::read_to_string(&full_path).map_err(|source| JsonHookError::Io {
+            path: full_path.clone(),
+            source,
+        })?;
+
+        let parameters: serde_json::Value =
+            serde_json::from_str(&content).map_err(JsonHookError::from)?;
+
+        Ok(JsonCaptured {
+            file: self.config.path.to_string_lossy().into_owned(),
+            parameters,
+        })
+    }
+}
+
+impl Captured for JsonCaptured {
+    fn serialize_json(&self) -> Result<serde_json::Value, serde_json::Error> {
+        serde_json::to_value(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        reason = "Tests use unwrap/expect for brevity"
+    )]
+
+    use super::*;
+    use capsula_core::hook::PreRun;
+    use capsula_core::run::Run;
+    use std::fs;
+    use tempfile::TempDir;
+    use ulid::Ulid;
+
+    fn make_hook(project_root: &Path, path: &str) -> JsonHook {
+        let cfg = serde_json::json!({ "path": path });
+        <JsonHook as Hook<PreRun>>::from_config(&cfg, project_root).unwrap()
+    }
+
+    fn make_run(project_root: &Path) -> PreparedRun {
+        Run {
+            id: Ulid::new(),
+            name: "test-run".into(),
+            command: vec![],
+            run_dir: project_root.to_path_buf(),
+            project_root: project_root.to_path_buf(),
+        }
+    }
+
+    fn run_hook(hook: &JsonHook, project_root: &Path) -> CapsulaResult<JsonCaptured> {
+        let run = make_run(project_root);
+        <JsonHook as Hook<PreRun>>::run(hook, &run, &RuntimeParams::default())
+    }
+
+    #[test]
+    fn parses_valid_json_into_parameters_field() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("p.json"), r#"{"a": 1, "b": "x"}"#).unwrap();
+
+        let hook = make_hook(tmp.path(), "p.json");
+        let captured = run_hook(&hook, tmp.path()).unwrap();
+
+        assert_eq!(captured.file, "p.json");
+        assert_eq!(captured.parameters, serde_json::json!({"a": 1, "b": "x"}));
+    }
+
+    #[test]
+    fn file_field_preserves_configured_path_verbatim() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("config/sat1")).unwrap();
+        fs::write(tmp.path().join("config/sat1/orbit.json"), r#"{"a": 1}"#).unwrap();
+
+        let hook = make_hook(tmp.path(), "config/sat1/orbit.json");
+        let captured = run_hook(&hook, tmp.path()).unwrap();
+
+        assert_eq!(captured.file, "config/sat1/orbit.json");
+    }
+
+    #[test]
+    fn supports_nested_json_objects() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("nested.json"),
+            r#"{"sat1": {"orbit": {"a": 1.42, "b": "LEO"}}}"#,
+        )
+        .unwrap();
+
+        let hook = make_hook(tmp.path(), "nested.json");
+        let captured = run_hook(&hook, tmp.path()).unwrap();
+
+        assert_eq!(captured.parameters["sat1"]["orbit"]["a"], 1.42);
+        assert_eq!(captured.parameters["sat1"]["orbit"]["b"], "LEO");
+    }
+
+    #[test]
+    fn missing_file_returns_io_error() {
+        let tmp = TempDir::new().unwrap();
+        let hook = make_hook(tmp.path(), "does-not-exist.json");
+        assert!(run_hook(&hook, tmp.path()).is_err());
+    }
+
+    #[test]
+    fn invalid_json_returns_parse_error() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("bad.json"), "not json{").unwrap();
+
+        let hook = make_hook(tmp.path(), "bad.json");
+        assert!(run_hook(&hook, tmp.path()).is_err());
+    }
+
+    #[test]
+    fn serialized_output_has_file_and_parameters_fields() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("p.json"), r#"{"x": 42}"#).unwrap();
+
+        let hook = make_hook(tmp.path(), "p.json");
+        let captured = run_hook(&hook, tmp.path()).unwrap();
+        let json = captured.serialize_json().unwrap();
+
+        assert_eq!(json["file"], "p.json");
+        assert_eq!(json["parameters"]["x"], 42);
+        assert!(
+            json.get("__meta").is_none(),
+            "__meta is added by orchestration, not the hook"
+        );
+    }
+}

--- a/crates/capsula-capture-json/src/lib.rs
+++ b/crates/capsula-capture-json/src/lib.rs
@@ -21,6 +21,7 @@ use tracing::debug;
 use crate::error::JsonHookError;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct JsonHookConfig {
     /// Path to the JSON file to parse, relative to `project_root`.
     /// Absolute paths are also accepted.
@@ -193,5 +194,17 @@ mod tests {
             json.get("__meta").is_none(),
             "__meta is added by orchestration, not the hook"
         );
+    }
+
+    #[test]
+    fn rejects_unknown_config_fields() {
+        let config = serde_json::json!({
+            "path": "p.json",
+            "unexpected": true,
+        });
+
+        let result = <JsonHook as Hook<PreRun>>::from_config(&config, &PathBuf::from("."));
+
+        assert!(result.is_err(), "unknown config fields should be rejected");
     }
 }

--- a/crates/capsula-registry/Cargo.toml
+++ b/crates/capsula-registry/Cargo.toml
@@ -16,6 +16,7 @@ capsula-capture-cwd = { workspace = true }
 capsula-capture-env = { workspace = true }
 capsula-capture-file = { workspace = true }
 capsula-capture-git-repo = { workspace = true }
+capsula-capture-json = { workspace = true }
 capsula-capture-machine = { workspace = true }
 capsula-capture-toml = { workspace = true }
 capsula-core = { workspace = true }

--- a/crates/capsula-registry/src/lib.rs
+++ b/crates/capsula-registry/src/lib.rs
@@ -185,6 +185,7 @@ where
     capsula_capture_env::EnvVarHook: capsula_core::hook::Hook<P>,
     capsula_capture_command::CommandHook: capsula_core::hook::Hook<P>,
     capsula_capture_machine::MachineHook: capsula_core::hook::Hook<P>,
+    capsula_capture_json::JsonHook: capsula_core::hook::Hook<P>,
     capsula_capture_toml::TomlHook: capsula_core::hook::Hook<P>,
     capsula_notify_slack::SlackNotifyHook: capsula_core::hook::Hook<P>,
 {
@@ -195,6 +196,7 @@ where
         .with_hook::<capsula_capture_env::EnvVarHook>()?
         .with_hook::<capsula_capture_command::CommandHook>()?
         .with_hook::<capsula_capture_machine::MachineHook>()?
+        .with_hook::<capsula_capture_json::JsonHook>()?
         .with_hook::<capsula_capture_toml::TomlHook>()?
         .with_hook::<capsula_notify_slack::SlackNotifyHook>()?
         .build())

--- a/docs/hooks/capture-json.md
+++ b/docs/hooks/capture-json.md
@@ -1,0 +1,84 @@
+---
+icon: material/hook
+---
+
+# capture-json
+
+Parses a single JSON file and embeds its parsed content in the run output
+under the `parameters` field, alongside the configured path in `file`.
+
+## Use Cases
+
+- Make experiment hyperparameters queryable across runs
+- Record the exact config used by a script in a structured, indexable form
+- Compose multiple `capture-json` entries to capture several config files
+
+## Configuration
+
+### Required Options
+
+| Option | Type   | Description                                                |
+| ------ | ------ | ---------------------------------------------------------- |
+| `path` | string | Path to the JSON file to parse, relative to project root.  |
+
+### Example
+
+```toml
+[[pre-run.hooks]]
+id = "capture-json"
+path = "config/sat1/orbit.json"
+```
+
+## Output Example
+
+The `file` field contains the path verbatim as written in the config (useful
+for distinguishing multiple `capture-json` outputs that share a basename).
+The `parameters` field contains the parsed JSON.
+
+```json
+{
+  "__meta": {
+    "id": "capture-json",
+    "config": {
+      "path": "config/sat1/orbit.json"
+    },
+    "success": true
+  },
+  "file": "config/sat1/orbit.json",
+  "parameters": {
+    "a": 1.42,
+    "b": "LEO"
+  }
+}
+```
+
+## Composing Multiple Files
+
+This hook captures exactly one file per instance. Register one entry per
+config file to capture them all:
+
+```toml
+[[pre-run.hooks]]
+id = "capture-json"
+path = "config/sat1/orbit.json"
+
+[[pre-run.hooks]]
+id = "capture-json"
+path = "config/sat2/orbit.json"
+```
+
+Each entry produces its own row in `pre-run.json` with its own `file` and
+`parameters` fields.
+
+## Error Behaviour
+
+The hook fails (recorded with `__meta.success: false`) when:
+
+- The file does not exist or is unreadable (`Io` error)
+- The file content is not valid JSON (`Json` error)
+
+A failing `capture-json` does not stop other hooks from running.
+
+## See Also
+
+- [`capture-file`](capture-file.md) — byte-exact archival of any file

--- a/docs/hooks/capture-json.md
+++ b/docs/hooks/capture-json.md
@@ -5,7 +5,7 @@ icon: material/hook
 # capture-json
 
 Parses a single JSON file and embeds its parsed content in the run output
-under the `parameters` field, alongside the configured path in `file`.
+under the `content` field.
 
 ## Use Cases
 
@@ -31,9 +31,9 @@ path = "config/sat1/orbit.json"
 
 ## Output Example
 
-The `file` field contains the path verbatim as written in the config (useful
-for distinguishing multiple `capture-json` outputs that share a basename).
-The `parameters` field contains the parsed JSON.
+The `content` field contains the parsed JSON. The configured path is not
+duplicated in the output body — it is already preserved in the standard
+`__meta.config.path` field injected by the orchestrator.
 
 ```json
 {
@@ -44,13 +44,15 @@ The `parameters` field contains the parsed JSON.
     },
     "success": true
   },
-  "file": "config/sat1/orbit.json",
-  "parameters": {
+  "content": {
     "a": 1.42,
     "b": "LEO"
   }
 }
 ```
+
+To distinguish multiple `capture-json` outputs (e.g., two files with the
+same basename), filter on `__meta.config.path`.
 
 ## Composing Multiple Files
 
@@ -67,8 +69,8 @@ id = "capture-json"
 path = "config/sat2/orbit.json"
 ```
 
-Each entry produces its own row in `pre-run.json` with its own `file` and
-`parameters` fields.
+Each entry produces its own row in `pre-run.json` with its own `content`
+field; the configured path is available under `__meta.config.path`.
 
 ## Error Behaviour
 
@@ -82,3 +84,4 @@ A failing `capture-json` does not stop other hooks from running.
 ## See Also
 
 - [`capture-file`](capture-file.md) — byte-exact archival of any file
+- [`capture-toml`](capture-toml.md) — same shape, for TOML inputs


### PR DESCRIPTION
Implements #987.

## Summary

Adds a new built-in hook `capture-json` that parses a single JSON file and
embeds its parsed content in the run output under `parameters`, alongside
the configured path in `file`. By design this hook captures exactly one
file per instance — compose multiple `[[pre-run.hooks]]` (or post-run)
entries to capture several config files.

## Why one file per instance

This shape mirrors capsula's compositional design (combine many small
hooks to express the desired capture), and keeps the output schema
trivially queryable from the server: the `parameters` field is the
exact parsed JSON, so `$.parameters.lr ? (@ >= 0.01)` against a single
`run_outputs.output` row works without any wrapping layer.

## Configuration

```toml
[[pre-run.hooks]]
id = "capture-json"
path = "config/sat1/orbit.json"
```

`path` is taken relative to `project_root` (absolute paths also accepted).

## Output shape

```json
{
  "__meta": {
    "id": "capture-json",
    "config": { "path": "config/sat1/orbit.json" },
    "success": true
  },
  "file": "config/sat1/orbit.json",
  "parameters": { "a": 1.42, "b": "LEO" }
}
```

- `file` preserves the path **verbatim** as written in the config, so
  multiple `capture-json` instances with the same basename remain
  distinguishable (`config/sat1/orbit.json` vs `config/sat2/orbit.json`).
- `parameters` contains the parsed JSON, ready for sql-json-path queries.

## Changes

- new crate: `crates/capsula-capture-json/` (Hook, Config, Captured, errors)
- registered in `capsula-registry` for both `PreRun` and `PostRun` phases
- workspace `Cargo.toml`: added `capsula-capture-json`
- docs: `docs/hooks/capture-json.md`

## Tests

6 unit tests in the crate (`cargo test -p capsula-capture-json`):

- `parses_valid_json_into_parameters_field`
- `file_field_preserves_configured_path_verbatim`
- `supports_nested_json_objects`
- `missing_file_returns_io_error`
- `invalid_json_returns_parse_error`
- `serialized_output_has_file_and_parameters_fields`

## Verification

- [x] `cargo build -p capsula-capture-json -p capsula-registry`
- [x] `cargo test -p capsula-capture-json` — 6/6 pass
- [x] `cargo clippy -p capsula-capture-json -p capsula-registry --all-targets -- -D warnings`
- [x] `cargo fmt --check`

## Follow-ups (separate PRs)

This PR is one of a small set replacing the abandoned single-PR
\`capture-parameter\` approach (#1008). Companion hooks (e.g. \`capture-yaml\`,
\`capture-toml\`) will follow in their own PRs with the same output shape.