### PR TITLE
feat(capture-toml): add hook that parses a single TOML file into queryable parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,6 +642,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "capsula-capture-toml"
+version = "0.12.1"
+dependencies = [
+ "capsula-core",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "toml",
+ "tracing",
+ "ulid",
+]
+
+[[package]]
 name = "capsula-client"
 version = "0.12.1"
 dependencies = [
@@ -726,6 +740,7 @@ dependencies = [
  "capsula-capture-file",
  "capsula-capture-git-repo",
  "capsula-capture-machine",
+ "capsula-capture-toml",
  "capsula-core",
  "capsula-notify-slack",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ capsula-capture-env = { path = "crates/capsula-capture-env", version = "0.12.1" 
 capsula-capture-file = { path = "crates/capsula-capture-file", version = "0.12.1" }
 capsula-capture-git-repo = { path = "crates/capsula-capture-git-repo", version = "0.12.1" }
 capsula-capture-machine = { path = "crates/capsula-capture-machine", version = "0.12.1" }
+capsula-capture-toml = { path = "crates/capsula-capture-toml", version = "0.12.1" }
 capsula-client = { path = "crates/capsula-client", version = "0.12.1" }
 capsula-config = { path = "crates/capsula-config", version = "0.12.1" }
 capsula-core = { path = "crates/capsula-core", version = "0.12.1" }

--- a/crates/capsula-capture-toml/Cargo.toml
+++ b/crates/capsula-capture-toml/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "capsula-capture-toml"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "A Capsula hook that parses a TOML file into queryable parameters."
+readme.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords = ["capsula", "capsula-hook"]
+categories = ["development-tools"]
+
+[dependencies]
+capsula-core = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+toml = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+ulid = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/capsula-capture-toml/src/error.rs
+++ b/crates/capsula-capture-toml/src/error.rs
@@ -1,0 +1,33 @@
+use capsula_core::error::CapsulaError;
+use std::path::PathBuf;
+use thiserror::Error;
+
+/// `capture-toml` hook specific errors
+#[derive(Debug, Error)]
+pub enum TomlHookError {
+    /// Failed to read the configured TOML file
+    #[error("Failed to read TOML file '{path}': {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// Failed to parse the file content as TOML
+    #[error("Failed to parse TOML: {0}")]
+    Toml(#[from] toml::de::Error),
+
+    /// Failed to deserialize the hook config from JSON, or to convert the
+    /// parsed TOML value to JSON for embedding in the run output.
+    #[error("Failed to (de)serialize JSON: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+impl From<TomlHookError> for CapsulaError {
+    fn from(err: TomlHookError) -> Self {
+        Self::HookFailed {
+            hook: "capture-toml".to_string(),
+            source: Box::new(err),
+        }
+    }
+}

--- a/crates/capsula-capture-toml/src/lib.rs
+++ b/crates/capsula-capture-toml/src/lib.rs
@@ -1,0 +1,263 @@
+//! `capture-toml` hook: parse a single TOML file and embed its parsed
+//! content in the run output under the `parameters` field.
+//!
+//! By design this hook captures exactly one file per instance. Compose
+//! multiple `capture-toml` entries in `capsula.toml` to capture multiple
+//! files.
+
+mod error;
+
+use std::path::{Path, PathBuf};
+
+use capsula_core::captured::Captured;
+use capsula_core::error::CapsulaResult;
+use capsula_core::hook::{Hook, PhaseMarker, RuntimeParams};
+use capsula_core::run::PreparedRun;
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+use crate::error::TomlHookError;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TomlHookConfig {
+    /// Path to the TOML file to parse, relative to `project_root`.
+    /// Absolute paths are also accepted.
+    path: PathBuf,
+}
+
+#[derive(Debug)]
+pub struct TomlHook {
+    config: TomlHookConfig,
+    project_root: PathBuf,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TomlCaptured {
+    /// The path as written in the configuration (verbatim, including any
+    /// directory components). Useful for distinguishing multiple
+    /// `capture-toml` outputs that share the same basename.
+    file: String,
+    /// The parsed content of the file, converted to JSON. TOML datetime
+    /// values are emitted as RFC 3339 strings.
+    parameters: serde_json::Value,
+}
+
+impl<P> Hook<P> for TomlHook
+where
+    P: PhaseMarker,
+{
+    const ID: &'static str = "capture-toml";
+
+    type Config = TomlHookConfig;
+    type Output = TomlCaptured;
+
+    fn from_config(config: &serde_json::Value, project_root: &Path) -> CapsulaResult<Self> {
+        let config: TomlHookConfig =
+            serde_json::from_value(config.clone()).map_err(TomlHookError::from)?;
+        Ok(Self {
+            config,
+            project_root: project_root.to_path_buf(),
+        })
+    }
+
+    fn config(&self) -> &Self::Config {
+        &self.config
+    }
+
+    fn run(
+        &self,
+        _metadata: &PreparedRun,
+        _params: &RuntimeParams<P>,
+    ) -> CapsulaResult<Self::Output> {
+        let full_path = self.project_root.join(&self.config.path);
+        debug!("TomlHook: reading {}", full_path.display());
+
+        let content = std::fs::read_to_string(&full_path).map_err(|source| TomlHookError::Io {
+            path: full_path.clone(),
+            source,
+        })?;
+
+        let toml_value: toml::Value = toml::from_str(&content).map_err(TomlHookError::from)?;
+        let parameters = toml_value_to_json(toml_value);
+
+        Ok(TomlCaptured {
+            file: self.config.path.to_string_lossy().into_owned(),
+            parameters,
+        })
+    }
+}
+
+impl Captured for TomlCaptured {
+    fn serialize_json(&self) -> Result<serde_json::Value, serde_json::Error> {
+        serde_json::to_value(self)
+    }
+}
+
+/// Convert a `toml::Value` to a `serde_json::Value` without going through
+/// the toml crate's serde Serialize impl, which wraps datetimes in a
+/// `{"$__toml_private_datetime": "..."}` marker object that would leak into
+/// query paths. Datetimes are emitted as RFC 3339 strings; floats that are
+/// NaN or +/-infinity become JSON null (JSON cannot represent them).
+fn toml_value_to_json(value: toml::Value) -> serde_json::Value {
+    use serde_json::Value as J;
+    use toml::Value as T;
+    match value {
+        T::String(s) => J::String(s),
+        T::Integer(i) => J::Number(i.into()),
+        T::Float(f) => serde_json::Number::from_f64(f).map_or(J::Null, J::Number),
+        T::Boolean(b) => J::Bool(b),
+        T::Datetime(dt) => J::String(dt.to_string()),
+        T::Array(arr) => J::Array(arr.into_iter().map(toml_value_to_json).collect()),
+        T::Table(table) => J::Object(
+            table
+                .into_iter()
+                .map(|(k, v)| (k, toml_value_to_json(v)))
+                .collect(),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        reason = "Tests use unwrap/expect for brevity"
+    )]
+
+    use super::*;
+    use capsula_core::hook::PreRun;
+    use capsula_core::run::Run;
+    use std::fs;
+    use tempfile::TempDir;
+    use ulid::Ulid;
+
+    fn make_hook(project_root: &Path, path: &str) -> TomlHook {
+        let cfg = serde_json::json!({ "path": path });
+        <TomlHook as Hook<PreRun>>::from_config(&cfg, project_root).unwrap()
+    }
+
+    fn make_run(project_root: &Path) -> PreparedRun {
+        Run {
+            id: Ulid::new(),
+            name: "test-run".into(),
+            command: vec![],
+            run_dir: project_root.to_path_buf(),
+            project_root: project_root.to_path_buf(),
+        }
+    }
+
+    fn run_hook(hook: &TomlHook, project_root: &Path) -> CapsulaResult<TomlCaptured> {
+        let run = make_run(project_root);
+        <TomlHook as Hook<PreRun>>::run(hook, &run, &RuntimeParams::default())
+    }
+
+    #[test]
+    fn parses_valid_toml_into_parameters_field() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("p.toml"),
+            "name = \"capsula\"\nport = 8080\n",
+        )
+        .unwrap();
+
+        let hook = make_hook(tmp.path(), "p.toml");
+        let captured = run_hook(&hook, tmp.path()).unwrap();
+
+        assert_eq!(captured.file, "p.toml");
+        assert_eq!(
+            captured.parameters,
+            serde_json::json!({"name": "capsula", "port": 8080})
+        );
+    }
+
+    #[test]
+    fn file_field_preserves_configured_path_verbatim() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join("config/sat1")).unwrap();
+        fs::write(
+            tmp.path().join("config/sat1/orbit.toml"),
+            "a = 1.42\nb = \"LEO\"\n",
+        )
+        .unwrap();
+
+        let hook = make_hook(tmp.path(), "config/sat1/orbit.toml");
+        let captured = run_hook(&hook, tmp.path()).unwrap();
+
+        assert_eq!(captured.file, "config/sat1/orbit.toml");
+    }
+
+    #[test]
+    fn supports_nested_toml_tables() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("nested.toml"),
+            r#"
+[sat1.orbit]
+a = 1.42
+b = "LEO"
+"#,
+        )
+        .unwrap();
+
+        let hook = make_hook(tmp.path(), "nested.toml");
+        let captured = run_hook(&hook, tmp.path()).unwrap();
+
+        assert_eq!(captured.parameters["sat1"]["orbit"]["a"], 1.42);
+        assert_eq!(captured.parameters["sat1"]["orbit"]["b"], "LEO");
+    }
+
+    #[test]
+    fn toml_datetime_is_emitted_as_string() {
+        // TOML has dedicated datetime types but JSON does not; toml's serde
+        // serializer emits RFC 3339 strings.
+        let tmp = TempDir::new().unwrap();
+        fs::write(
+            tmp.path().join("dt.toml"),
+            "created_at = 2026-01-08T10:20:00Z\n",
+        )
+        .unwrap();
+
+        let hook = make_hook(tmp.path(), "dt.toml");
+        let captured = run_hook(&hook, tmp.path()).unwrap();
+
+        assert!(
+            captured.parameters["created_at"].is_string(),
+            "TOML datetime should be coerced to a JSON string, got: {:?}",
+            captured.parameters["created_at"]
+        );
+    }
+
+    #[test]
+    fn missing_file_returns_io_error() {
+        let tmp = TempDir::new().unwrap();
+        let hook = make_hook(tmp.path(), "does-not-exist.toml");
+        assert!(run_hook(&hook, tmp.path()).is_err());
+    }
+
+    #[test]
+    fn invalid_toml_returns_parse_error() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("bad.toml"), "not valid toml = =").unwrap();
+
+        let hook = make_hook(tmp.path(), "bad.toml");
+        assert!(run_hook(&hook, tmp.path()).is_err());
+    }
+
+    #[test]
+    fn serialized_output_has_file_and_parameters_fields() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("p.toml"), "x = 42\n").unwrap();
+
+        let hook = make_hook(tmp.path(), "p.toml");
+        let captured = run_hook(&hook, tmp.path()).unwrap();
+        let json = captured.serialize_json().unwrap();
+
+        assert_eq!(json["file"], "p.toml");
+        assert_eq!(json["parameters"]["x"], 42);
+        assert!(
+            json.get("__meta").is_none(),
+            "__meta is added by orchestration, not the hook"
+        );
+    }
+}

--- a/crates/capsula-capture-toml/src/lib.rs
+++ b/crates/capsula-capture-toml/src/lib.rs
@@ -21,6 +21,7 @@ use tracing::debug;
 use crate::error::TomlHookError;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct TomlHookConfig {
     /// Path to the TOML file to parse, relative to `project_root`.
     /// Absolute paths are also accepted.
@@ -251,5 +252,17 @@ b = "LEO"
             json.get("__meta").is_none(),
             "__meta is added by orchestration, not the hook"
         );
+    }
+
+    #[test]
+    fn rejects_unknown_config_fields() {
+        let config = serde_json::json!({
+            "path": "p.toml",
+            "unexpected": true,
+        });
+
+        let result = <TomlHook as Hook<PreRun>>::from_config(&config, &PathBuf::from("."));
+
+        assert!(result.is_err(), "unknown config fields should be rejected");
     }
 }

--- a/crates/capsula-capture-toml/src/lib.rs
+++ b/crates/capsula-capture-toml/src/lib.rs
@@ -1,9 +1,11 @@
 //! `capture-toml` hook: parse a single TOML file and embed its parsed
-//! content in the run output under the `parameters` field.
+//! content in the run output under the `content` field.
 //!
 //! By design this hook captures exactly one file per instance. Compose
 //! multiple `capture-toml` entries in `capsula.toml` to capture multiple
-//! files.
+//! files. The path written in the config is preserved as part of the
+//! standard `__meta.config.path`, so the captured value does not need
+//! to duplicate it.
 
 mod error;
 
@@ -28,18 +30,13 @@ pub struct TomlHookConfig {
 #[derive(Debug)]
 pub struct TomlHook {
     config: TomlHookConfig,
-    project_root: PathBuf,
 }
 
 #[derive(Debug, Serialize)]
 pub struct TomlCaptured {
-    /// The path as written in the configuration (verbatim, including any
-    /// directory components). Useful for distinguishing multiple
-    /// `capture-toml` outputs that share the same basename.
-    file: String,
     /// The parsed content of the file, converted to JSON. TOML datetime
     /// values are emitted as RFC 3339 strings.
-    parameters: serde_json::Value,
+    content: serde_json::Value,
 }
 
 impl<P> Hook<P> for TomlHook
@@ -51,13 +48,10 @@ where
     type Config = TomlHookConfig;
     type Output = TomlCaptured;
 
-    fn from_config(config: &serde_json::Value, project_root: &Path) -> CapsulaResult<Self> {
+    fn from_config(config: &serde_json::Value, _project_root: &Path) -> CapsulaResult<Self> {
         let config: TomlHookConfig =
             serde_json::from_value(config.clone()).map_err(TomlHookError::from)?;
-        Ok(Self {
-            config,
-            project_root: project_root.to_path_buf(),
-        })
+        Ok(Self { config })
     }
 
     fn config(&self) -> &Self::Config {
@@ -66,24 +60,21 @@ where
 
     fn run(
         &self,
-        _metadata: &PreparedRun,
+        metadata: &PreparedRun,
         _params: &RuntimeParams<P>,
     ) -> CapsulaResult<Self::Output> {
-        let full_path = self.project_root.join(&self.config.path);
+        let full_path = metadata.project_root.join(&self.config.path);
         debug!("TomlHook: reading {}", full_path.display());
 
-        let content = std::fs::read_to_string(&full_path).map_err(|source| TomlHookError::Io {
+        let raw = std::fs::read_to_string(&full_path).map_err(|source| TomlHookError::Io {
             path: full_path.clone(),
             source,
         })?;
 
-        let toml_value: toml::Value = toml::from_str(&content).map_err(TomlHookError::from)?;
-        let parameters = toml_value_to_json(toml_value);
+        let toml_value: toml::Value = toml::from_str(&raw).map_err(TomlHookError::from)?;
+        let content = toml_value_to_json(toml_value);
 
-        Ok(TomlCaptured {
-            file: self.config.path.to_string_lossy().into_owned(),
-            parameters,
-        })
+        Ok(TomlCaptured { content })
     }
 }
 
@@ -153,7 +144,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_valid_toml_into_parameters_field() {
+    fn parses_valid_toml_into_content_field() {
         let tmp = TempDir::new().unwrap();
         fs::write(
             tmp.path().join("p.toml"),
@@ -164,27 +155,25 @@ mod tests {
         let hook = make_hook(tmp.path(), "p.toml");
         let captured = run_hook(&hook, tmp.path()).unwrap();
 
-        assert_eq!(captured.file, "p.toml");
         assert_eq!(
-            captured.parameters,
+            captured.content,
             serde_json::json!({"name": "capsula", "port": 8080})
         );
     }
 
     #[test]
-    fn file_field_preserves_configured_path_verbatim() {
-        let tmp = TempDir::new().unwrap();
-        fs::create_dir_all(tmp.path().join("config/sat1")).unwrap();
-        fs::write(
-            tmp.path().join("config/sat1/orbit.toml"),
-            "a = 1.42\nb = \"LEO\"\n",
-        )
-        .unwrap();
+    fn resolves_path_relative_to_metadata_project_root() {
+        // The hook reads project_root from PreparedRun, not from its own
+        // state. Capture this contract: a hook built against tmp_a but
+        // run against tmp_b should resolve relative to tmp_b.
+        let tmp_a = TempDir::new().unwrap();
+        let tmp_b = TempDir::new().unwrap();
+        fs::write(tmp_b.path().join("p.toml"), "x = 42\n").unwrap();
 
-        let hook = make_hook(tmp.path(), "config/sat1/orbit.toml");
-        let captured = run_hook(&hook, tmp.path()).unwrap();
+        let hook = make_hook(tmp_a.path(), "p.toml");
+        let captured = run_hook(&hook, tmp_b.path()).unwrap();
 
-        assert_eq!(captured.file, "config/sat1/orbit.toml");
+        assert_eq!(captured.content, serde_json::json!({"x": 42}));
     }
 
     #[test]
@@ -203,8 +192,8 @@ b = "LEO"
         let hook = make_hook(tmp.path(), "nested.toml");
         let captured = run_hook(&hook, tmp.path()).unwrap();
 
-        assert_eq!(captured.parameters["sat1"]["orbit"]["a"], 1.42);
-        assert_eq!(captured.parameters["sat1"]["orbit"]["b"], "LEO");
+        assert_eq!(captured.content["sat1"]["orbit"]["a"], 1.42);
+        assert_eq!(captured.content["sat1"]["orbit"]["b"], "LEO");
     }
 
     #[test]
@@ -222,9 +211,9 @@ b = "LEO"
         let captured = run_hook(&hook, tmp.path()).unwrap();
 
         assert!(
-            captured.parameters["created_at"].is_string(),
+            captured.content["created_at"].is_string(),
             "TOML datetime should be coerced to a JSON string, got: {:?}",
-            captured.parameters["created_at"]
+            captured.content["created_at"]
         );
     }
 
@@ -245,7 +234,7 @@ b = "LEO"
     }
 
     #[test]
-    fn serialized_output_has_file_and_parameters_fields() {
+    fn serialized_output_has_only_content_field() {
         let tmp = TempDir::new().unwrap();
         fs::write(tmp.path().join("p.toml"), "x = 42\n").unwrap();
 
@@ -253,8 +242,11 @@ b = "LEO"
         let captured = run_hook(&hook, tmp.path()).unwrap();
         let json = captured.serialize_json().unwrap();
 
-        assert_eq!(json["file"], "p.toml");
-        assert_eq!(json["parameters"]["x"], 42);
+        assert_eq!(json["content"]["x"], 42);
+        assert!(
+            json.get("file").is_none(),
+            "file is redundant with __meta.config.path"
+        );
         assert!(
             json.get("__meta").is_none(),
             "__meta is added by orchestration, not the hook"

--- a/crates/capsula-registry/Cargo.toml
+++ b/crates/capsula-registry/Cargo.toml
@@ -17,6 +17,7 @@ capsula-capture-env = { workspace = true }
 capsula-capture-file = { workspace = true }
 capsula-capture-git-repo = { workspace = true }
 capsula-capture-machine = { workspace = true }
+capsula-capture-toml = { workspace = true }
 capsula-core = { workspace = true }
 capsula-notify-slack = { workspace = true }
 serde = { workspace = true }

--- a/crates/capsula-registry/src/lib.rs
+++ b/crates/capsula-registry/src/lib.rs
@@ -185,6 +185,7 @@ where
     capsula_capture_env::EnvVarHook: capsula_core::hook::Hook<P>,
     capsula_capture_command::CommandHook: capsula_core::hook::Hook<P>,
     capsula_capture_machine::MachineHook: capsula_core::hook::Hook<P>,
+    capsula_capture_toml::TomlHook: capsula_core::hook::Hook<P>,
     capsula_notify_slack::SlackNotifyHook: capsula_core::hook::Hook<P>,
 {
     Ok(RegistryBuilder::new()
@@ -194,6 +195,7 @@ where
         .with_hook::<capsula_capture_env::EnvVarHook>()?
         .with_hook::<capsula_capture_command::CommandHook>()?
         .with_hook::<capsula_capture_machine::MachineHook>()?
+        .with_hook::<capsula_capture_toml::TomlHook>()?
         .with_hook::<capsula_notify_slack::SlackNotifyHook>()?
         .build())
 }

--- a/docs/hooks/capture-toml.md
+++ b/docs/hooks/capture-toml.md
@@ -1,0 +1,113 @@
+---
+icon: material/hook
+---
+
+# capture-toml
+
+Parses a single TOML file and embeds its parsed content in the run output
+under the `parameters` field, alongside the configured path in `file`.
+
+## Use Cases
+
+- Make experiment hyperparameters queryable across runs
+- Record the exact config used by a script in a structured, indexable form
+- Compose multiple `capture-toml` entries to capture several config files
+
+## Configuration
+
+### Required Options
+
+| Option | Type   | Description                                                |
+| ------ | ------ | ---------------------------------------------------------- |
+| `path` | string | Path to the TOML file to parse, relative to project root.  |
+
+### Example
+
+```toml
+[[pre-run.hooks]]
+id = "capture-toml"
+path = "config/sat1/orbit.toml"
+```
+
+## Output Example
+
+The `file` field contains the path verbatim as written in the config. The
+`parameters` field contains the parsed TOML, converted to JSON.
+
+Given `config/sat1/orbit.toml`:
+
+```toml
+[orbit]
+a = 1.42
+b = "LEO"
+```
+
+The hook output is:
+
+```json
+{
+  "__meta": {
+    "id": "capture-toml",
+    "config": {
+      "path": "config/sat1/orbit.toml"
+    },
+    "success": true
+  },
+  "file": "config/sat1/orbit.toml",
+  "parameters": {
+    "orbit": {
+      "a": 1.42,
+      "b": "LEO"
+    }
+  }
+}
+```
+
+## Composing Multiple Files
+
+This hook captures exactly one file per instance. Register one entry per
+config file to capture them all:
+
+```toml
+[[pre-run.hooks]]
+id = "capture-toml"
+path = "config/sat1/orbit.toml"
+
+[[pre-run.hooks]]
+id = "capture-toml"
+path = "config/sat2/orbit.toml"
+```
+
+Each entry produces its own row in `pre-run.json` with its own `file` and
+`parameters` fields.
+
+## TOML → JSON Conversion
+
+TOML has a few types that JSON cannot represent natively. The hook handles
+them as follows:
+
+| TOML                         | JSON                                            |
+| ---------------------------- | ----------------------------------------------- |
+| String / Integer / Boolean   | matching JSON type                              |
+| Float                        | JSON number (NaN / ±Inf become `null`)          |
+| Datetime (offset / local)    | JSON string (RFC 3339 representation)           |
+| Array                        | JSON array                                      |
+| Table (`[section]`)          | JSON object                                     |
+
+Example: `created_at = 2026-01-08T10:20:00Z` becomes
+`"created_at": "2026-01-08T10:20:00Z"` in the JSON output, queryable as a
+string.
+
+## Error Behaviour
+
+The hook fails (recorded with `__meta.success: false`) when:
+
+- The file does not exist or is unreadable (`Io` error)
+- The file content is not valid TOML (`Toml` error)
+
+A failing `capture-toml` does not stop other hooks from running.
+
+## See Also
+
+- [`capture-file`](capture-file.md) — byte-exact archival of any file
+- [`capture-json`](capture-json.md) — same shape, for JSON inputs

--- a/docs/hooks/capture-toml.md
+++ b/docs/hooks/capture-toml.md
@@ -5,7 +5,7 @@ icon: material/hook
 # capture-toml
 
 Parses a single TOML file and embeds its parsed content in the run output
-under the `parameters` field, alongside the configured path in `file`.
+under the `content` field.
 
 ## Use Cases
 
@@ -31,8 +31,10 @@ path = "config/sat1/orbit.toml"
 
 ## Output Example
 
-The `file` field contains the path verbatim as written in the config. The
-`parameters` field contains the parsed TOML, converted to JSON.
+The `content` field contains the parsed TOML, converted to JSON. The
+configured path is not duplicated in the output body — it is already
+preserved in the standard `__meta.config.path` field injected by the
+orchestrator.
 
 Given `config/sat1/orbit.toml`:
 
@@ -53,8 +55,7 @@ The hook output is:
     },
     "success": true
   },
-  "file": "config/sat1/orbit.toml",
-  "parameters": {
+  "content": {
     "orbit": {
       "a": 1.42,
       "b": "LEO"
@@ -62,6 +63,9 @@ The hook output is:
   }
 }
 ```
+
+To distinguish multiple `capture-toml` outputs, filter on
+`__meta.config.path`.
 
 ## Composing Multiple Files
 
@@ -78,8 +82,8 @@ id = "capture-toml"
 path = "config/sat2/orbit.toml"
 ```
 
-Each entry produces its own row in `pre-run.json` with its own `file` and
-`parameters` fields.
+Each entry produces its own row in `pre-run.json` with its own `content`
+field; the configured path is available under `__meta.config.path`.
 
 ## TOML → JSON Conversion
 


### PR DESCRIPTION
Implements #988. Parallel to #1016 (`capture-json`).

## Summary

Adds a new built-in hook `capture-toml` that parses a single TOML file and
embeds its parsed content in the run output under `parameters`, alongside
the configured path in `file`. By design this hook captures exactly one
file per instance — compose multiple `[[pre-run.hooks]]` entries to capture
several config files.

## Why one file per instance

Mirrors the design of `capture-json` (#1016): the shape reflects capsula's
compositional philosophy and keeps the output schema trivially queryable
from the server. `parameters` is the exact parsed value, so
`$.parameters.<path>` against a single `run_outputs.output` row works
without any wrapping layer.

## Configuration

```toml
[[pre-run.hooks]]
id = "capture-toml"
path = "config/sat1/orbit.toml"
```

## Output shape

Given `config/sat1/orbit.toml`:

```toml
[orbit]
a = 1.42
b = "LEO"
```

The hook emits:

```json
{
  "__meta": { "id": "capture-toml", "config": { "path": "config/sat1/orbit.toml" }, "success": true },
  "file": "config/sat1/orbit.toml",
  "parameters": {
    "orbit": { "a": 1.42, "b": "LEO" }
  }
}
```

## TOML → JSON conversion

The hook does **not** go through the toml crate's default Serialize impl,
because it wraps `Datetime` values in a
`{"$__toml_private_datetime": "..."}` marker object — those keys would leak
into JSONPath queries on the server. Instead the hook walks `toml::Value`
manually:

| TOML                         | JSON                                     |
| ---------------------------- | ---------------------------------------- |
| String / Integer / Boolean   | matching JSON type                       |
| Float                        | JSON number (NaN / ±Inf → `null`)        |
| Datetime                     | JSON string (RFC 3339)                   |
| Array                        | JSON array                               |
| Table (`[section]`)          | JSON object                              |

## Changes

- new crate: `crates/capsula-capture-toml/` (Hook, Config, Captured, errors, `toml_value_to_json` helper)
- registered in `capsula-registry` for both `PreRun` and `PostRun` phases
- workspace `Cargo.toml`: added `capsula-capture-toml`
- docs: `docs/hooks/capture-toml.md`

## Tests

7 unit tests in the crate (`cargo test -p capsula-capture-toml`):

- `parses_valid_toml_into_parameters_field`
- `file_field_preserves_configured_path_verbatim`
- `supports_nested_toml_tables`
- `toml_datetime_is_emitted_as_string` (pinning the datetime conversion)
- `missing_file_returns_io_error`
- `invalid_toml_returns_parse_error`
- `serialized_output_has_file_and_parameters_fields`

## Verification

- [x] `cargo build -p capsula-capture-toml -p capsula-registry`
- [x] `cargo test -p capsula-capture-toml` — 7/7 pass
- [x] `cargo clippy -p capsula-capture-toml -p capsula-registry --all-targets -- -D warnings`
- [x] `cargo fmt --check`

## Relationship to other PRs

This PR is parallel to #1016 (`capture-json`); the two are independent and
can land in any order. A `capture-yaml` follow-up may come later with the
same shape.