### PR TITLE
fix(server): widen run_outputs uniqueness to include config_hash

### DIFF
--- a/.sqlx/query-0f041bcff67becde780d8f50cd520ce827c65019c919c96f3bc748818b962057.json
+++ b/.sqlx/query-0f041bcff67becde780d8f50cd520ce827c65019c919c96f3bc748818b962057.json
@@ -1,0 +1,88 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT phase, hook_id, config, output, success, error\n                FROM run_outputs\n                WHERE run_id = $1\n                ORDER BY id\n                ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "phase",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "run_outputs",
+            "name": "phase"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "hook_id",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "run_outputs",
+            "name": "hook_id"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "config",
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "run_outputs",
+            "name": "config"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "output",
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "run_outputs",
+            "name": "output"
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "success",
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "run_outputs",
+            "name": "success"
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "error",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "run_outputs",
+            "name": "error"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "0f041bcff67becde780d8f50cd520ce827c65019c919c96f3bc748818b962057"
+}

--- a/.sqlx/query-253667fff2df6b67490a92694fc4726906d8febb34dfb419394de5a3e712275f.json
+++ b/.sqlx/query-253667fff2df6b67490a92694fc4726906d8febb34dfb419394de5a3e712275f.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COUNT(*)::bigint\n            FROM runs\n            WHERE vault = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8",
+        "origin": "Expression"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "253667fff2df6b67490a92694fc4726906d8febb34dfb419394de5a3e712275f"
+}

--- a/.sqlx/query-2bce98110bf0eb20eabd1f5674f9c8d8444dd73a26ce687164599fc5e154b1ae.json
+++ b/.sqlx/query-2bce98110bf0eb20eabd1f5674f9c8d8444dd73a26ce687164599fc5e154b1ae.json
@@ -1,0 +1,19 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                        INSERT INTO captured_files (run_id, path, size, hash, storage_path, content_type)\n                        VALUES ($1, $2, $3, $4, $5, $6)\n                        ON CONFLICT (run_id, path) DO UPDATE\n                        SET size = EXCLUDED.size,\n                            hash = EXCLUDED.hash,\n                            storage_path = EXCLUDED.storage_path,\n                            content_type = EXCLUDED.content_type\n                        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Int8",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "2bce98110bf0eb20eabd1f5674f9c8d8444dd73a26ce687164599fc5e154b1ae"
+}

--- a/.sqlx/query-3ca0c3873a46137f597f26a58ab662a523f2c9626334e201b85becf132e5966f.json
+++ b/.sqlx/query-3ca0c3873a46137f597f26a58ab662a523f2c9626334e201b85becf132e5966f.json
@@ -1,0 +1,21 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COUNT(*)::bigint\n            FROM runs\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8",
+        "origin": "Expression"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "3ca0c3873a46137f597f26a58ab662a523f2c9626334e201b85becf132e5966f"
+}

--- a/.sqlx/query-5390e0718e63f799170ac58d5414efbea1eb4005e01d7ba2283a2cdb55c7241f.json
+++ b/.sqlx/query-5390e0718e63f799170ac58d5414efbea1eb4005e01d7ba2283a2cdb55c7241f.json
@@ -1,0 +1,162 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, name, timestamp, command, vault, project_root,\n                   exit_code, duration_ms, stdout, stderr,\n                   created_at, updated_at\n            FROM runs\n            WHERE vault = $1\n            ORDER BY timestamp DESC\n            LIMIT $2 OFFSET $3\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "id"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "name"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "timestamp",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "timestamp"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "command",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "command"
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "vault",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "vault"
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "project_root",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "project_root"
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "exit_code",
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "exit_code"
+          }
+        }
+      },
+      {
+        "ordinal": 7,
+        "name": "duration_ms",
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "duration_ms"
+          }
+        }
+      },
+      {
+        "ordinal": 8,
+        "name": "stdout",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "stdout"
+          }
+        }
+      },
+      {
+        "ordinal": 9,
+        "name": "stderr",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "stderr"
+          }
+        }
+      },
+      {
+        "ordinal": 10,
+        "name": "created_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "created_at"
+          }
+        }
+      },
+      {
+        "ordinal": 11,
+        "name": "updated_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "updated_at"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "5390e0718e63f799170ac58d5414efbea1eb4005e01d7ba2283a2cdb55c7241f"
+}

--- a/.sqlx/query-59181e58fa315b4454e5629f30356607aa515590ecc9e1283a7d45dea3c9bfa0.json
+++ b/.sqlx/query-59181e58fa315b4454e5629f30356607aa515590ecc9e1283a7d45dea3c9bfa0.json
@@ -1,0 +1,33 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT vault as name, COUNT(*) as \"run_count!\"\n        FROM runs\n        GROUP BY vault\n        ORDER BY vault\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "vault"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "run_count!",
+        "type_info": "Int8",
+        "origin": "Expression"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      null
+    ]
+  },
+  "hash": "59181e58fa315b4454e5629f30356607aa515590ecc9e1283a7d45dea3c9bfa0"
+}

--- a/.sqlx/query-6004f67752c9a00900bedbec9a8248e5789a4d861a0cfdfde4cc811e962ddb10.json
+++ b/.sqlx/query-6004f67752c9a00900bedbec9a8248e5789a4d861a0cfdfde4cc811e962ddb10.json
@@ -1,0 +1,160 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, name, timestamp, command, vault, project_root,\n               exit_code, duration_ms, stdout, stderr,\n               created_at, updated_at\n        FROM runs\n        WHERE id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "id"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "name"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "timestamp",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "timestamp"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "command",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "command"
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "vault",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "vault"
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "project_root",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "project_root"
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "exit_code",
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "exit_code"
+          }
+        }
+      },
+      {
+        "ordinal": 7,
+        "name": "duration_ms",
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "duration_ms"
+          }
+        }
+      },
+      {
+        "ordinal": 8,
+        "name": "stdout",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "stdout"
+          }
+        }
+      },
+      {
+        "ordinal": 9,
+        "name": "stderr",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "stderr"
+          }
+        }
+      },
+      {
+        "ordinal": 10,
+        "name": "created_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "created_at"
+          }
+        }
+      },
+      {
+        "ordinal": 11,
+        "name": "updated_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "updated_at"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "6004f67752c9a00900bedbec9a8248e5789a4d861a0cfdfde4cc811e962ddb10"
+}

--- a/.sqlx/query-657153a374a4356d214f3b6fb482520b0a11c0d7616075b6c4a860a933dc50b6.json
+++ b/.sqlx/query-657153a374a4356d214f3b6fb482520b0a11c0d7616075b6c4a860a933dc50b6.json
@@ -1,0 +1,19 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    INSERT INTO run_outputs (run_id, phase, hook_id, config, output, success, error)\n                    VALUES ($1, 'pre', $2, $3, $4, $5, $6)\n                    ON CONFLICT (run_id, phase, hook_id, config_hash) DO UPDATE\n                    SET output = EXCLUDED.output,\n                        success = EXCLUDED.success,\n                        error = EXCLUDED.error\n                    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Jsonb",
+        "Jsonb",
+        "Bool",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "657153a374a4356d214f3b6fb482520b0a11c0d7616075b6c4a860a933dc50b6"
+}

--- a/.sqlx/query-6db1f3116868cbd029cdd9243e52381844ff8d46c1855e38f6372cfdf12599ef.json
+++ b/.sqlx/query-6db1f3116868cbd029cdd9243e52381844ff8d46c1855e38f6372cfdf12599ef.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO runs (\n            id, name, timestamp, command, vault, project_root,\n            exit_code, duration_ms, stdout, stderr\n        ) VALUES (\n            $1, $2, $3, $4, $5, $6,\n            $7, $8, $9, $10\n        )\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Timestamptz",
+        "Text",
+        "Text",
+        "Text",
+        "Int4",
+        "Int4",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "6db1f3116868cbd029cdd9243e52381844ff8d46c1855e38f6372cfdf12599ef"
+}

--- a/.sqlx/query-7fd5f7e93525d1ac895e25ccb052fffba21510d8544b89bd046808a0e845c5c3.json
+++ b/.sqlx/query-7fd5f7e93525d1ac895e25ccb052fffba21510d8544b89bd046808a0e845c5c3.json
@@ -1,0 +1,19 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    INSERT INTO run_outputs (run_id, phase, hook_id, config, output, success, error)\n                    VALUES ($1, 'post', $2, $3, $4, $5, $6)\n                    ON CONFLICT (run_id, phase, hook_id, config_hash) DO UPDATE\n                    SET output = EXCLUDED.output,\n                        success = EXCLUDED.success,\n                        error = EXCLUDED.error\n                    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Jsonb",
+        "Jsonb",
+        "Bool",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "7fd5f7e93525d1ac895e25ccb052fffba21510d8544b89bd046808a0e845c5c3"
+}

--- a/.sqlx/query-b796189d0adca977fe24628310096b0c8bf310e4fd7d88c59c44fa50cfe8b787.json
+++ b/.sqlx/query-b796189d0adca977fe24628310096b0c8bf310e4fd7d88c59c44fa50cfe8b787.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT vault as name, COUNT(*) as \"run_count!\"\n        FROM runs\n        WHERE vault = $1\n        GROUP BY vault\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "vault"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "run_count!",
+        "type_info": "Int8",
+        "origin": "Expression"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      null
+    ]
+  },
+  "hash": "b796189d0adca977fe24628310096b0c8bf310e4fd7d88c59c44fa50cfe8b787"
+}

--- a/.sqlx/query-b846e106182e01de04189f0bdc8151e9176b783611b124db0cae4246b5590816.json
+++ b/.sqlx/query-b846e106182e01de04189f0bdc8151e9176b783611b124db0cae4246b5590816.json
@@ -1,0 +1,53 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT storage_path, content_type, path as file_path\n        FROM captured_files\n        WHERE run_id = $1 AND path = $2\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "storage_path",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "captured_files",
+            "name": "storage_path"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "content_type",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "captured_files",
+            "name": "content_type"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "file_path",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "captured_files",
+            "name": "path"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "b846e106182e01de04189f0bdc8151e9176b783611b124db0cae4246b5590816"
+}

--- a/.sqlx/query-dde3c4130e0eb80838ebd1816e71d7d389cbe1768b2b38ceafb1f9d44f77eb39.json
+++ b/.sqlx/query-dde3c4130e0eb80838ebd1816e71d7d389cbe1768b2b38ceafb1f9d44f77eb39.json
@@ -1,0 +1,88 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT phase, hook_id, config, output, success, error\n        FROM run_outputs\n        WHERE run_id = $1\n        ORDER BY id\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "phase",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "run_outputs",
+            "name": "phase"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "hook_id",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "run_outputs",
+            "name": "hook_id"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "config",
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "run_outputs",
+            "name": "config"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "output",
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "run_outputs",
+            "name": "output"
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "success",
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "run_outputs",
+            "name": "success"
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "error",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "run_outputs",
+            "name": "error"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "dde3c4130e0eb80838ebd1816e71d7d389cbe1768b2b38ceafb1f9d44f77eb39"
+}

--- a/.sqlx/query-e957b05d3f124f5f63e52cb47b4554f205ebc5c5dfdf94d82396534cf7981ecd.json
+++ b/.sqlx/query-e957b05d3f124f5f63e52cb47b4554f205ebc5c5dfdf94d82396534cf7981ecd.json
@@ -1,0 +1,161 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, name, timestamp, command, vault, project_root,\n                   exit_code, duration_ms, stdout, stderr,\n                   created_at, updated_at\n            FROM runs\n            ORDER BY timestamp DESC\n            LIMIT $1 OFFSET $2\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "id"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "name"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "timestamp",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "timestamp"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "command",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "command"
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "vault",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "vault"
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "project_root",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "project_root"
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "exit_code",
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "exit_code"
+          }
+        }
+      },
+      {
+        "ordinal": 7,
+        "name": "duration_ms",
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "duration_ms"
+          }
+        }
+      },
+      {
+        "ordinal": 8,
+        "name": "stdout",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "stdout"
+          }
+        }
+      },
+      {
+        "ordinal": 9,
+        "name": "stderr",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "stderr"
+          }
+        }
+      },
+      {
+        "ordinal": 10,
+        "name": "created_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "created_at"
+          }
+        }
+      },
+      {
+        "ordinal": 11,
+        "name": "updated_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "updated_at"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "e957b05d3f124f5f63e52cb47b4554f205ebc5c5dfdf94d82396534cf7981ecd"
+}

--- a/.sqlx/query-f38f557ced45f15bc7dd1092ffe3944bb30c6abd914c24bde081c92f01fe0871.json
+++ b/.sqlx/query-f38f557ced45f15bc7dd1092ffe3944bb30c6abd914c24bde081c92f01fe0871.json
@@ -1,0 +1,76 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT path, size, hash, storage_path, content_type\n        FROM captured_files\n        WHERE run_id = $1\n        ORDER BY path\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "path",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "captured_files",
+            "name": "path"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "size",
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "captured_files",
+            "name": "size"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "hash",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "captured_files",
+            "name": "hash"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "storage_path",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "captured_files",
+            "name": "storage_path"
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "content_type",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "captured_files",
+            "name": "content_type"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      true
+    ]
+  },
+  "hash": "f38f557ced45f15bc7dd1092ffe3944bb30c6abd914c24bde081c92f01fe0871"
+}

--- a/crates/capsula-server/migrations/20260612000000_add_config_hash_to_run_outputs.sql
+++ b/crates/capsula-server/migrations/20260612000000_add_config_hash_to_run_outputs.sql
@@ -1,0 +1,20 @@
+-- Multiple instances of the same hook_id within a single (run_id, phase)
+-- are a first-class case for capsula-toml / capsula-json -style hooks
+-- that capture exactly one file per [[*-run.hooks]] entry. The previous
+-- UNIQUE(run_id, phase, hook_id) index caused later uploads to silently
+-- overwrite earlier ones via ON CONFLICT.
+--
+-- This migration adds a generated `config_hash` column derived from the
+-- canonical jsonb text representation of the hook config, and widens the
+-- uniqueness key to include it. Two hook outputs with the same hook_id
+-- but distinct configs now coexist; a re-upload of the same hook+config
+-- still UPSERTs the existing row, preserving idempotency.
+
+ALTER TABLE run_outputs
+ADD COLUMN config_hash TEXT
+GENERATED ALWAYS AS (md5(coalesce(config::text, ''))) STORED;
+
+DROP INDEX idx_run_outputs_unique;
+
+CREATE UNIQUE INDEX idx_run_outputs_unique
+ON run_outputs(run_id, phase, hook_id, config_hash);

--- a/crates/capsula-server/src/lib.rs
+++ b/crates/capsula-server/src/lib.rs
@@ -1172,9 +1172,8 @@ async fn upload_files(
                     r#"
                     INSERT INTO run_outputs (run_id, phase, hook_id, config, output, success, error)
                     VALUES ($1, 'pre', $2, $3, $4, $5, $6)
-                    ON CONFLICT (run_id, phase, hook_id) DO UPDATE
-                    SET config = EXCLUDED.config,
-                        output = EXCLUDED.output,
+                    ON CONFLICT (run_id, phase, hook_id, config_hash) DO UPDATE
+                    SET output = EXCLUDED.output,
                         success = EXCLUDED.success,
                         error = EXCLUDED.error
                     "#,
@@ -1210,9 +1209,8 @@ async fn upload_files(
                     r#"
                     INSERT INTO run_outputs (run_id, phase, hook_id, config, output, success, error)
                     VALUES ($1, 'post', $2, $3, $4, $5, $6)
-                    ON CONFLICT (run_id, phase, hook_id) DO UPDATE
-                    SET config = EXCLUDED.config,
-                        output = EXCLUDED.output,
+                    ON CONFLICT (run_id, phase, hook_id, config_hash) DO UPDATE
+                    SET output = EXCLUDED.output,
                         success = EXCLUDED.success,
                         error = EXCLUDED.error
                     "#,

--- a/crates/capsula-server/tests/api_tests.rs
+++ b/crates/capsula-server/tests/api_tests.rs
@@ -623,3 +623,146 @@ async fn test_hook_outputs_storage() {
     assert_eq!(post_hooks[0]["__meta"]["id"], "file");
     assert_eq!(post_hooks[0]["__meta"]["success"], true);
 }
+
+#[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "End-to-end regression test covering three distinct uploads and their\
+              assertions; splitting would obscure the regression scenario."
+)]
+async fn multiple_hook_instances_with_same_id_coexist() {
+    // Regression for #1017: multiple hook outputs with the same hook_id but
+    // distinct configs (typical for capture-json / capture-toml) must all
+    // survive on the server, distinguished by the generated config_hash
+    // column in the UNIQUE index.
+    let ctx = TestContext::new().await;
+    let client = reqwest::Client::new();
+
+    let run_id = "01MULTIHOOK00000000000000";
+
+    let run_data = json!({
+        "id": run_id,
+        "name": "test-multi-hook",
+        "timestamp": "2026-06-12T10:00:00Z",
+        "command": "cargo test",
+        "vault": "multi-hook-vault",
+        "project_root": "/tmp/test",
+        "exit_code": 0,
+        "duration_ms": 100,
+        "stdout": null,
+        "stderr": null
+    });
+    let response = client
+        .post(format!("{}/api/v1/runs", ctx.base_url()))
+        .json(&run_data)
+        .send()
+        .await
+        .expect("create run");
+    assert_eq!(response.status(), 201);
+
+    // Two capture-json hooks for the SAME phase with DIFFERENT config paths.
+    // Before the config_hash widening they would collide on
+    // UNIQUE(run_id, phase, hook_id) and the second would overwrite the first.
+    let pre_run_hooks = json!([
+        {
+            "__meta": {
+                "id": "capture-json",
+                "config": { "path": "config/sat1/orbit.json" },
+                "success": true,
+                "error": null
+            },
+            "content": { "a": 1.42 }
+        },
+        {
+            "__meta": {
+                "id": "capture-json",
+                "config": { "path": "config/sat2/orbit.json" },
+                "success": true,
+                "error": null
+            },
+            "content": { "a": 2.5 }
+        }
+    ]);
+
+    let form = reqwest::multipart::Form::new()
+        .text("run_id", run_id.to_string())
+        .text("pre_run", pre_run_hooks.to_string());
+    let response = client
+        .post(format!("{}/api/v1/upload", ctx.base_url()))
+        .multipart(form)
+        .send()
+        .await
+        .expect("upload hooks");
+    assert_eq!(response.status(), 200);
+    let body: serde_json::Value = response.json().await.expect("parse upload body");
+    assert_eq!(
+        body["pre_run_hooks"], 2,
+        "both pre-run hook instances must persist"
+    );
+
+    // Verify both rows survived via GET /api/v1/runs/{id}.
+    let response = client
+        .get(format!("{}/api/v1/runs/{run_id}", ctx.base_url()))
+        .send()
+        .await
+        .expect("get run");
+    assert_eq!(response.status(), 200);
+    let body: serde_json::Value = response.json().await.expect("parse body");
+    let pre = body["pre_run_hooks"]
+        .as_array()
+        .expect("pre_run_hooks array");
+    assert_eq!(pre.len(), 2, "both capture-json rows must be present");
+
+    // Distinct content survives — each row reflects its own config.
+    let mut a_values: Vec<f64> = pre
+        .iter()
+        .map(|h| h["content"]["a"].as_f64().expect("number"))
+        .collect();
+    a_values.sort_by(f64::total_cmp);
+    assert_eq!(a_values, vec![1.42, 2.5]);
+
+    // Re-uploading the SAME hook (same hook_id, same config) must be
+    // idempotent: it should UPSERT the existing row, not duplicate it.
+    let same_hook_replay = json!([{
+        "__meta": {
+            "id": "capture-json",
+            "config": { "path": "config/sat1/orbit.json" },
+            "success": true,
+            "error": null
+        },
+        "content": { "a": 9.99 }
+    }]);
+    let form = reqwest::multipart::Form::new()
+        .text("run_id", run_id.to_string())
+        .text("pre_run", same_hook_replay.to_string());
+    let response = client
+        .post(format!("{}/api/v1/upload", ctx.base_url()))
+        .multipart(form)
+        .send()
+        .await
+        .expect("re-upload hook");
+    assert_eq!(response.status(), 200);
+
+    let response = client
+        .get(format!("{}/api/v1/runs/{run_id}", ctx.base_url()))
+        .send()
+        .await
+        .expect("get run after re-upload");
+    let body: serde_json::Value = response.json().await.expect("parse body");
+    let pre = body["pre_run_hooks"]
+        .as_array()
+        .expect("pre_run_hooks array");
+    assert_eq!(
+        pre.len(),
+        2,
+        "re-upload with same hook+config must UPSERT, not duplicate"
+    );
+
+    // The sat1 row was updated to 9.99; sat2 still has 2.5.
+    let mut a_values: Vec<f64> = pre
+        .iter()
+        .map(|h| h["content"]["a"].as_f64().expect("number"))
+        .collect();
+    a_values.sort_by(f64::total_cmp);
+    assert_eq!(a_values, vec![2.5, 9.99]);
+}


### PR DESCRIPTION

Closes #1017.

## Problem

`run_outputs` had `UNIQUE(run_id, phase, hook_id)`. The upload handler
used that key as the `ON CONFLICT` target, so a second hook with the
same `hook_id` in the same phase silently **overwrote** the first.

This was visible in the new `capture-json` / `capture-toml` hooks, which
are explicitly designed to be registered multiple times in one phase —
one entry per file to capture. Only the last upload survived.

## Fix

Add a generated `config_hash` column derived from the canonical jsonb
text of `config`, and widen the uniqueness key to include it:

```sql
ALTER TABLE run_outputs
ADD COLUMN config_hash TEXT
GENERATED ALWAYS AS (md5(coalesce(config::text, ''))) STORED;

DROP INDEX idx_run_outputs_unique;
CREATE UNIQUE INDEX idx_run_outputs_unique
ON run_outputs(run_id, phase, hook_id, config_hash);
```

Postgres canonicalizes jsonb text (sorted keys, no whitespace), so the
hash is stable across re-uploads of the same config — the runtime never
has to compute the hash itself.

Both upload INSERT statements switch to
`ON CONFLICT (run_id, phase, hook_id, config_hash) DO UPDATE`, with
`config = EXCLUDED.config` dropped from the SET clause (a matching
config_hash implies an equivalent config, so it is a no-op).

Existing rows are unique under the old key, so the generated column
backfills deterministically without any duplicate-resolution step.

## Tests

New integration test `multiple_hook_instances_with_same_id_coexist`
exercises three uploads against a real Postgres via testcontainers:

1. Upload two `capture-json` hooks with identical `hook_id` but distinct
   `config.path` values → both rows persist.
2. Fetch the run → both `content` payloads come back.
3. Re-upload one of the two with the *same* config but a different
   `content` → existing row is UPSERTed (no duplicate created); the
   other row is untouched.

## Verification

- [x] `cargo test -p capsula-server --test api_tests multiple_hook_instances_with_same_id_coexist`
- [x] `cargo test -p capsula-server --test api_tests test_hook_outputs_storage` (existing regression — unchanged)
- [x] `cargo sqlx prepare --workspace --check` clean — `.sqlx/` cache is checked in
- [x] `cargo clippy -p capsula-server --all-targets -- -D warnings`
- [x] `cargo fmt --check -p capsula-server`

## Notes

- The migration is forward-only and safe to apply to an existing
  database: existing rows are already unique under the old key, so the
  generated column does not introduce conflicts.
- The `.sqlx/` offline query cache is regenerated and committed to keep
  the CI `sqlx prepare --check` job green.