### PR TITLE
fix(server): key run_outputs by hook_index, allowing duplicate hook_id rows

### DIFF
--- a/.sqlx/query-0f041bcff67becde780d8f50cd520ce827c65019c919c96f3bc748818b962057.json
+++ b/.sqlx/query-0f041bcff67becde780d8f50cd520ce827c65019c919c96f3bc748818b962057.json
@@ -1,0 +1,88 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT phase, hook_id, config, output, success, error\n                FROM run_outputs\n                WHERE run_id = $1\n                ORDER BY id\n                ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "phase",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "run_outputs",
+            "name": "phase"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "hook_id",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "run_outputs",
+            "name": "hook_id"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "config",
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "run_outputs",
+            "name": "config"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "output",
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "run_outputs",
+            "name": "output"
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "success",
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "run_outputs",
+            "name": "success"
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "error",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "run_outputs",
+            "name": "error"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "0f041bcff67becde780d8f50cd520ce827c65019c919c96f3bc748818b962057"
+}

--- a/.sqlx/query-253667fff2df6b67490a92694fc4726906d8febb34dfb419394de5a3e712275f.json
+++ b/.sqlx/query-253667fff2df6b67490a92694fc4726906d8febb34dfb419394de5a3e712275f.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COUNT(*)::bigint\n            FROM runs\n            WHERE vault = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8",
+        "origin": "Expression"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "253667fff2df6b67490a92694fc4726906d8febb34dfb419394de5a3e712275f"
+}

--- a/.sqlx/query-2bce98110bf0eb20eabd1f5674f9c8d8444dd73a26ce687164599fc5e154b1ae.json
+++ b/.sqlx/query-2bce98110bf0eb20eabd1f5674f9c8d8444dd73a26ce687164599fc5e154b1ae.json
@@ -1,0 +1,19 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                        INSERT INTO captured_files (run_id, path, size, hash, storage_path, content_type)\n                        VALUES ($1, $2, $3, $4, $5, $6)\n                        ON CONFLICT (run_id, path) DO UPDATE\n                        SET size = EXCLUDED.size,\n                            hash = EXCLUDED.hash,\n                            storage_path = EXCLUDED.storage_path,\n                            content_type = EXCLUDED.content_type\n                        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Int8",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "2bce98110bf0eb20eabd1f5674f9c8d8444dd73a26ce687164599fc5e154b1ae"
+}

--- a/.sqlx/query-3ca0c3873a46137f597f26a58ab662a523f2c9626334e201b85becf132e5966f.json
+++ b/.sqlx/query-3ca0c3873a46137f597f26a58ab662a523f2c9626334e201b85becf132e5966f.json
@@ -1,0 +1,21 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COUNT(*)::bigint\n            FROM runs\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8",
+        "origin": "Expression"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "3ca0c3873a46137f597f26a58ab662a523f2c9626334e201b85becf132e5966f"
+}

--- a/.sqlx/query-49d90745466a2a528baab5e668e9ce4ca794753b971a7955c82189b153bf8952.json
+++ b/.sqlx/query-49d90745466a2a528baab5e668e9ce4ca794753b971a7955c82189b153bf8952.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    INSERT INTO run_outputs (run_id, phase, hook_id, config, output, success, error, hook_index)\n                    VALUES ($1, 'post', $2, $3, $4, $5, $6, $7)\n                    ON CONFLICT (run_id, phase, hook_index) DO UPDATE\n                    SET hook_id = EXCLUDED.hook_id,\n                        config = EXCLUDED.config,\n                        output = EXCLUDED.output,\n                        success = EXCLUDED.success,\n                        error = EXCLUDED.error\n                    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Jsonb",
+        "Jsonb",
+        "Bool",
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "49d90745466a2a528baab5e668e9ce4ca794753b971a7955c82189b153bf8952"
+}

--- a/.sqlx/query-5390e0718e63f799170ac58d5414efbea1eb4005e01d7ba2283a2cdb55c7241f.json
+++ b/.sqlx/query-5390e0718e63f799170ac58d5414efbea1eb4005e01d7ba2283a2cdb55c7241f.json
@@ -1,0 +1,162 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, name, timestamp, command, vault, project_root,\n                   exit_code, duration_ms, stdout, stderr,\n                   created_at, updated_at\n            FROM runs\n            WHERE vault = $1\n            ORDER BY timestamp DESC\n            LIMIT $2 OFFSET $3\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "id"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "name"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "timestamp",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "timestamp"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "command",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "command"
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "vault",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "vault"
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "project_root",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "project_root"
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "exit_code",
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "exit_code"
+          }
+        }
+      },
+      {
+        "ordinal": 7,
+        "name": "duration_ms",
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "duration_ms"
+          }
+        }
+      },
+      {
+        "ordinal": 8,
+        "name": "stdout",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "stdout"
+          }
+        }
+      },
+      {
+        "ordinal": 9,
+        "name": "stderr",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "stderr"
+          }
+        }
+      },
+      {
+        "ordinal": 10,
+        "name": "created_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "created_at"
+          }
+        }
+      },
+      {
+        "ordinal": 11,
+        "name": "updated_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "updated_at"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "5390e0718e63f799170ac58d5414efbea1eb4005e01d7ba2283a2cdb55c7241f"
+}

--- a/.sqlx/query-59181e58fa315b4454e5629f30356607aa515590ecc9e1283a7d45dea3c9bfa0.json
+++ b/.sqlx/query-59181e58fa315b4454e5629f30356607aa515590ecc9e1283a7d45dea3c9bfa0.json
@@ -1,0 +1,33 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT vault as name, COUNT(*) as \"run_count!\"\n        FROM runs\n        GROUP BY vault\n        ORDER BY vault\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "vault"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "run_count!",
+        "type_info": "Int8",
+        "origin": "Expression"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      null
+    ]
+  },
+  "hash": "59181e58fa315b4454e5629f30356607aa515590ecc9e1283a7d45dea3c9bfa0"
+}

--- a/.sqlx/query-6004f67752c9a00900bedbec9a8248e5789a4d861a0cfdfde4cc811e962ddb10.json
+++ b/.sqlx/query-6004f67752c9a00900bedbec9a8248e5789a4d861a0cfdfde4cc811e962ddb10.json
@@ -1,0 +1,160 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, name, timestamp, command, vault, project_root,\n               exit_code, duration_ms, stdout, stderr,\n               created_at, updated_at\n        FROM runs\n        WHERE id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "id"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "name"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "timestamp",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "timestamp"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "command",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "command"
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "vault",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "vault"
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "project_root",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "project_root"
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "exit_code",
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "exit_code"
+          }
+        }
+      },
+      {
+        "ordinal": 7,
+        "name": "duration_ms",
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "duration_ms"
+          }
+        }
+      },
+      {
+        "ordinal": 8,
+        "name": "stdout",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "stdout"
+          }
+        }
+      },
+      {
+        "ordinal": 9,
+        "name": "stderr",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "stderr"
+          }
+        }
+      },
+      {
+        "ordinal": 10,
+        "name": "created_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "created_at"
+          }
+        }
+      },
+      {
+        "ordinal": 11,
+        "name": "updated_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "updated_at"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "6004f67752c9a00900bedbec9a8248e5789a4d861a0cfdfde4cc811e962ddb10"
+}

--- a/.sqlx/query-6db1f3116868cbd029cdd9243e52381844ff8d46c1855e38f6372cfdf12599ef.json
+++ b/.sqlx/query-6db1f3116868cbd029cdd9243e52381844ff8d46c1855e38f6372cfdf12599ef.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO runs (\n            id, name, timestamp, command, vault, project_root,\n            exit_code, duration_ms, stdout, stderr\n        ) VALUES (\n            $1, $2, $3, $4, $5, $6,\n            $7, $8, $9, $10\n        )\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Timestamptz",
+        "Text",
+        "Text",
+        "Text",
+        "Int4",
+        "Int4",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "6db1f3116868cbd029cdd9243e52381844ff8d46c1855e38f6372cfdf12599ef"
+}

--- a/.sqlx/query-b796189d0adca977fe24628310096b0c8bf310e4fd7d88c59c44fa50cfe8b787.json
+++ b/.sqlx/query-b796189d0adca977fe24628310096b0c8bf310e4fd7d88c59c44fa50cfe8b787.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT vault as name, COUNT(*) as \"run_count!\"\n        FROM runs\n        WHERE vault = $1\n        GROUP BY vault\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "vault"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "run_count!",
+        "type_info": "Int8",
+        "origin": "Expression"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      null
+    ]
+  },
+  "hash": "b796189d0adca977fe24628310096b0c8bf310e4fd7d88c59c44fa50cfe8b787"
+}

--- a/.sqlx/query-b846e106182e01de04189f0bdc8151e9176b783611b124db0cae4246b5590816.json
+++ b/.sqlx/query-b846e106182e01de04189f0bdc8151e9176b783611b124db0cae4246b5590816.json
@@ -1,0 +1,53 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT storage_path, content_type, path as file_path\n        FROM captured_files\n        WHERE run_id = $1 AND path = $2\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "storage_path",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "captured_files",
+            "name": "storage_path"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "content_type",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "captured_files",
+            "name": "content_type"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "file_path",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "captured_files",
+            "name": "path"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "b846e106182e01de04189f0bdc8151e9176b783611b124db0cae4246b5590816"
+}

--- a/.sqlx/query-c7c4ec6f5fa41b069d5e2d03ffa220e300f7fb666d8944f2dd8502331d91a195.json
+++ b/.sqlx/query-c7c4ec6f5fa41b069d5e2d03ffa220e300f7fb666d8944f2dd8502331d91a195.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    INSERT INTO run_outputs (run_id, phase, hook_id, config, output, success, error, hook_index)\n                    VALUES ($1, 'pre', $2, $3, $4, $5, $6, $7)\n                    ON CONFLICT (run_id, phase, hook_index) DO UPDATE\n                    SET hook_id = EXCLUDED.hook_id,\n                        config = EXCLUDED.config,\n                        output = EXCLUDED.output,\n                        success = EXCLUDED.success,\n                        error = EXCLUDED.error\n                    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Jsonb",
+        "Jsonb",
+        "Bool",
+        "Text",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "c7c4ec6f5fa41b069d5e2d03ffa220e300f7fb666d8944f2dd8502331d91a195"
+}

--- a/.sqlx/query-dde3c4130e0eb80838ebd1816e71d7d389cbe1768b2b38ceafb1f9d44f77eb39.json
+++ b/.sqlx/query-dde3c4130e0eb80838ebd1816e71d7d389cbe1768b2b38ceafb1f9d44f77eb39.json
@@ -1,0 +1,88 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT phase, hook_id, config, output, success, error\n        FROM run_outputs\n        WHERE run_id = $1\n        ORDER BY id\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "phase",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "run_outputs",
+            "name": "phase"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "hook_id",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "run_outputs",
+            "name": "hook_id"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "config",
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "run_outputs",
+            "name": "config"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "output",
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "run_outputs",
+            "name": "output"
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "success",
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "run_outputs",
+            "name": "success"
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "error",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "run_outputs",
+            "name": "error"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "dde3c4130e0eb80838ebd1816e71d7d389cbe1768b2b38ceafb1f9d44f77eb39"
+}

--- a/.sqlx/query-e957b05d3f124f5f63e52cb47b4554f205ebc5c5dfdf94d82396534cf7981ecd.json
+++ b/.sqlx/query-e957b05d3f124f5f63e52cb47b4554f205ebc5c5dfdf94d82396534cf7981ecd.json
@@ -1,0 +1,161 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, name, timestamp, command, vault, project_root,\n                   exit_code, duration_ms, stdout, stderr,\n                   created_at, updated_at\n            FROM runs\n            ORDER BY timestamp DESC\n            LIMIT $1 OFFSET $2\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "id"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "name"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "timestamp",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "timestamp"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "command",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "command"
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "vault",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "vault"
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "project_root",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "project_root"
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "exit_code",
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "exit_code"
+          }
+        }
+      },
+      {
+        "ordinal": 7,
+        "name": "duration_ms",
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "duration_ms"
+          }
+        }
+      },
+      {
+        "ordinal": 8,
+        "name": "stdout",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "stdout"
+          }
+        }
+      },
+      {
+        "ordinal": 9,
+        "name": "stderr",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "stderr"
+          }
+        }
+      },
+      {
+        "ordinal": 10,
+        "name": "created_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "created_at"
+          }
+        }
+      },
+      {
+        "ordinal": 11,
+        "name": "updated_at",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "runs",
+            "name": "updated_at"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "e957b05d3f124f5f63e52cb47b4554f205ebc5c5dfdf94d82396534cf7981ecd"
+}

--- a/.sqlx/query-f38f557ced45f15bc7dd1092ffe3944bb30c6abd914c24bde081c92f01fe0871.json
+++ b/.sqlx/query-f38f557ced45f15bc7dd1092ffe3944bb30c6abd914c24bde081c92f01fe0871.json
@@ -1,0 +1,76 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT path, size, hash, storage_path, content_type\n        FROM captured_files\n        WHERE run_id = $1\n        ORDER BY path\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "path",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "captured_files",
+            "name": "path"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "size",
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "captured_files",
+            "name": "size"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "hash",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "captured_files",
+            "name": "hash"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "storage_path",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "captured_files",
+            "name": "storage_path"
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "content_type",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "captured_files",
+            "name": "content_type"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      true
+    ]
+  },
+  "hash": "f38f557ced45f15bc7dd1092ffe3944bb30c6abd914c24bde081c92f01fe0871"
+}

--- a/crates/capsula-server/migrations/20260613000000_add_hook_index_to_run_outputs.sql
+++ b/crates/capsula-server/migrations/20260613000000_add_hook_index_to_run_outputs.sql
@@ -1,0 +1,40 @@
+-- Multiple instances of the same hook_id within a single (run_id, phase)
+-- are a first-class case for capsula-toml / capsula-json / capture-command
+-- style hooks that can appear several times in [[*-run.hooks]] arrays. The
+-- previous UNIQUE(run_id, phase, hook_id) index caused later uploads to
+-- silently overwrite earlier ones via ON CONFLICT.
+--
+-- This migration adds a `hook_index` column that records each hook's
+-- position in the capsula.toml `pre_run` / `post_run` array — global
+-- within the phase, not per hook_id. Querying becomes natural:
+--
+--   ORDER BY hook_index           -- original array order
+--   WHERE  hook_index = 2          -- "the 3rd hook in pre_run"
+--
+-- and the unique key (run_id, phase, hook_index) does not need to mention
+-- hook_id at all.
+--
+-- Backfill: existing rows get a global ordinal within each (run_id, phase)
+-- using insertion order (id) as a proxy for original array position. Under
+-- the old UNIQUE(run_id, phase, hook_id) constraint there is no ambiguity,
+-- so the assignment is stable.
+
+ALTER TABLE run_outputs
+ADD COLUMN hook_index INTEGER NOT NULL DEFAULT 0;
+
+UPDATE run_outputs r
+SET hook_index = o.new_index
+FROM (
+    SELECT id,
+           ROW_NUMBER() OVER (
+               PARTITION BY run_id, phase
+               ORDER BY id
+           ) - 1 AS new_index
+    FROM run_outputs
+) AS o
+WHERE r.id = o.id;
+
+DROP INDEX idx_run_outputs_unique;
+
+CREATE UNIQUE INDEX idx_run_outputs_unique
+ON run_outputs(run_id, phase, hook_index);

--- a/crates/capsula-server/src/lib.rs
+++ b/crates/capsula-server/src/lib.rs
@@ -1167,13 +1167,23 @@ async fn upload_files(
 
     if let Some(ref rid) = run_id {
         if let Some(hooks) = pre_run_hooks {
-            for hook in hooks {
+            // hook_index is the position of the hook in the capsula.toml
+            // pre_run array — global within the phase, not per hook_id.
+            // The unique key (run_id, phase, hook_index) combined with this
+            // enumeration lets multiple instances of the same hook_id
+            // (e.g., several `capture-json` or `capture-command` entries)
+            // coexist as separate rows. See migration
+            // 20260613000000_add_hook_index_to_run_outputs.sql.
+            for (idx, hook) in hooks.iter().enumerate() {
+                let hook_index = i32::try_from(idx).unwrap_or(i32::MAX);
+
                 let result = sqlx::query!(
                     r#"
-                    INSERT INTO run_outputs (run_id, phase, hook_id, config, output, success, error)
-                    VALUES ($1, 'pre', $2, $3, $4, $5, $6)
-                    ON CONFLICT (run_id, phase, hook_id) DO UPDATE
-                    SET config = EXCLUDED.config,
+                    INSERT INTO run_outputs (run_id, phase, hook_id, config, output, success, error, hook_index)
+                    VALUES ($1, 'pre', $2, $3, $4, $5, $6, $7)
+                    ON CONFLICT (run_id, phase, hook_index) DO UPDATE
+                    SET hook_id = EXCLUDED.hook_id,
+                        config = EXCLUDED.config,
                         output = EXCLUDED.output,
                         success = EXCLUDED.success,
                         error = EXCLUDED.error
@@ -1183,7 +1193,8 @@ async fn upload_files(
                     hook.meta.config,
                     hook.output,
                     hook.meta.success,
-                    hook.meta.error
+                    hook.meta.error,
+                    hook_index
                 )
                 .execute(&state.pool)
                 .await;
@@ -1205,13 +1216,16 @@ async fn upload_files(
         }
 
         if let Some(hooks) = post_run_hooks {
-            for hook in hooks {
+            for (idx, hook) in hooks.iter().enumerate() {
+                let hook_index = i32::try_from(idx).unwrap_or(i32::MAX);
+
                 let result = sqlx::query!(
                     r#"
-                    INSERT INTO run_outputs (run_id, phase, hook_id, config, output, success, error)
-                    VALUES ($1, 'post', $2, $3, $4, $5, $6)
-                    ON CONFLICT (run_id, phase, hook_id) DO UPDATE
-                    SET config = EXCLUDED.config,
+                    INSERT INTO run_outputs (run_id, phase, hook_id, config, output, success, error, hook_index)
+                    VALUES ($1, 'post', $2, $3, $4, $5, $6, $7)
+                    ON CONFLICT (run_id, phase, hook_index) DO UPDATE
+                    SET hook_id = EXCLUDED.hook_id,
+                        config = EXCLUDED.config,
                         output = EXCLUDED.output,
                         success = EXCLUDED.success,
                         error = EXCLUDED.error
@@ -1221,7 +1235,8 @@ async fn upload_files(
                     hook.meta.config,
                     hook.output,
                     hook.meta.success,
-                    hook.meta.error
+                    hook.meta.error,
+                    hook_index
                 )
                 .execute(&state.pool)
                 .await;

--- a/crates/capsula-server/tests/api_tests.rs
+++ b/crates/capsula-server/tests/api_tests.rs
@@ -623,3 +623,255 @@ async fn test_hook_outputs_storage() {
     assert_eq!(post_hooks[0]["__meta"]["id"], "file");
     assert_eq!(post_hooks[0]["__meta"]["success"], true);
 }
+
+#[tokio::test]
+async fn multiple_hooks_with_distinct_configs_coexist() {
+    // Regression for #1017: two capture-json hooks with the same hook_id
+    // but distinct configs must both survive on the server. With the new
+    // hook_index column they sit at array positions 0 and 1.
+    let ctx = TestContext::new().await;
+    let client = reqwest::Client::new();
+
+    let run_id = "01HOOKIDX00000000000000A";
+    let response = client
+        .post(format!("{}/api/v1/runs", ctx.base_url()))
+        .json(&json!({
+            "id": run_id,
+            "name": "multi-hooks-distinct",
+            "timestamp": "2026-06-13T10:00:00Z",
+            "command": "test",
+            "vault": "hook-index-vault",
+            "project_root": "/tmp/test",
+            "exit_code": 0,
+            "duration_ms": 100,
+            "stdout": null,
+            "stderr": null,
+        }))
+        .send()
+        .await
+        .expect("create run");
+    assert_eq!(response.status(), 201);
+
+    let pre_run_hooks = json!([
+        {
+            "__meta": {
+                "id": "capture-json",
+                "config": { "path": "config/sat1.json" },
+                "success": true,
+                "error": null
+            },
+            "content": { "a": 1.0 }
+        },
+        {
+            "__meta": {
+                "id": "capture-json",
+                "config": { "path": "config/sat2.json" },
+                "success": true,
+                "error": null
+            },
+            "content": { "a": 2.0 }
+        }
+    ]);
+
+    let form = reqwest::multipart::Form::new()
+        .text("run_id", run_id.to_string())
+        .text("pre_run", pre_run_hooks.to_string());
+    let response = client
+        .post(format!("{}/api/v1/upload", ctx.base_url()))
+        .multipart(form)
+        .send()
+        .await
+        .expect("upload hooks");
+    assert_eq!(response.status(), 200);
+    let body: serde_json::Value = response.json().await.expect("parse upload body");
+    assert_eq!(body["pre_run_hooks"], 2);
+
+    let response = client
+        .get(format!("{}/api/v1/runs/{run_id}", ctx.base_url()))
+        .send()
+        .await
+        .expect("get run");
+    let body: serde_json::Value = response.json().await.expect("parse body");
+    let pre = body["pre_run_hooks"]
+        .as_array()
+        .expect("pre_run_hooks array");
+    assert_eq!(pre.len(), 2, "both rows must persist");
+}
+
+#[tokio::test]
+async fn multiple_hooks_with_identical_configs_coexist() {
+    // Reviewer's concern that closed #1019: two hooks with the same
+    // hook_id AND the same config (e.g., two capture-command hooks
+    // running the identical command) should still produce distinct rows.
+    // A config-hash discriminator would collide; hook_index uses array
+    // position, so they remain separate.
+    let ctx = TestContext::new().await;
+    let client = reqwest::Client::new();
+
+    let run_id = "01HOOKIDX00000000000000B";
+    let response = client
+        .post(format!("{}/api/v1/runs", ctx.base_url()))
+        .json(&json!({
+            "id": run_id,
+            "name": "multi-hooks-identical",
+            "timestamp": "2026-06-13T10:00:00Z",
+            "command": "test",
+            "vault": "hook-index-vault",
+            "project_root": "/tmp/test",
+            "exit_code": 0,
+            "duration_ms": 100,
+            "stdout": null,
+            "stderr": null,
+        }))
+        .send()
+        .await
+        .expect("create run");
+    assert_eq!(response.status(), 201);
+
+    let pre_run_hooks = json!([
+        {
+            "__meta": {
+                "id": "capture-command",
+                "config": { "command": "echo hello" },
+                "success": true,
+                "error": null
+            },
+            "stdout": "first invocation",
+            "exit_code": 0
+        },
+        {
+            "__meta": {
+                "id": "capture-command",
+                "config": { "command": "echo hello" },
+                "success": true,
+                "error": null
+            },
+            "stdout": "second invocation",
+            "exit_code": 0
+        }
+    ]);
+
+    let form = reqwest::multipart::Form::new()
+        .text("run_id", run_id.to_string())
+        .text("pre_run", pre_run_hooks.to_string());
+    let response = client
+        .post(format!("{}/api/v1/upload", ctx.base_url()))
+        .multipart(form)
+        .send()
+        .await
+        .expect("upload hooks");
+    assert_eq!(response.status(), 200);
+    let body: serde_json::Value = response.json().await.expect("parse body");
+    assert_eq!(body["pre_run_hooks"], 2);
+
+    let response = client
+        .get(format!("{}/api/v1/runs/{run_id}", ctx.base_url()))
+        .send()
+        .await
+        .expect("get run");
+    let body: serde_json::Value = response.json().await.expect("parse body");
+    let pre = body["pre_run_hooks"]
+        .as_array()
+        .expect("pre_run_hooks array");
+    assert_eq!(pre.len(), 2);
+    let stdouts: Vec<&str> = pre
+        .iter()
+        .map(|h| h["stdout"].as_str().expect("stdout"))
+        .collect();
+    assert!(
+        stdouts.contains(&"first invocation"),
+        "missing first invocation, got: {stdouts:?}"
+    );
+    assert!(
+        stdouts.contains(&"second invocation"),
+        "missing second invocation, got: {stdouts:?}"
+    );
+}
+
+#[tokio::test]
+async fn re_upload_with_same_array_is_idempotent() {
+    // The hook_index is stable for re-uploads of the same capsula.toml
+    // structure, so ON CONFLICT UPSERTs the existing row instead of
+    // creating a duplicate.
+    let ctx = TestContext::new().await;
+    let client = reqwest::Client::new();
+
+    let run_id = "01HOOKIDX00000000000000C";
+    let response = client
+        .post(format!("{}/api/v1/runs", ctx.base_url()))
+        .json(&json!({
+            "id": run_id,
+            "name": "re-upload-test",
+            "timestamp": "2026-06-13T10:00:00Z",
+            "command": "test",
+            "vault": "hook-index-vault",
+            "project_root": "/tmp/test",
+            "exit_code": 0,
+            "duration_ms": 100,
+            "stdout": null,
+            "stderr": null,
+        }))
+        .send()
+        .await
+        .expect("create run");
+    assert_eq!(response.status(), 201);
+
+    let upload = |variant: &str| {
+        let body = json!([
+            {
+                "__meta": {
+                    "id": "capture-json",
+                    "config": { "path": "config/a.json" },
+                    "success": true,
+                    "error": null
+                },
+                "content": { "v": variant }
+            },
+            {
+                "__meta": {
+                    "id": "capture-json",
+                    "config": { "path": "config/b.json" },
+                    "success": true,
+                    "error": null
+                },
+                "content": { "v": variant }
+            }
+        ]);
+        reqwest::multipart::Form::new()
+            .text("run_id", run_id.to_string())
+            .text("pre_run", body.to_string())
+    };
+
+    let response = client
+        .post(format!("{}/api/v1/upload", ctx.base_url()))
+        .multipart(upload("first"))
+        .send()
+        .await
+        .expect("first upload");
+    assert_eq!(response.status(), 200);
+
+    let response = client
+        .post(format!("{}/api/v1/upload", ctx.base_url()))
+        .multipart(upload("second"))
+        .send()
+        .await
+        .expect("second upload");
+    assert_eq!(response.status(), 200);
+
+    let response = client
+        .get(format!("{}/api/v1/runs/{run_id}", ctx.base_url()))
+        .send()
+        .await
+        .expect("get run");
+    let body: serde_json::Value = response.json().await.expect("parse body");
+    let pre = body["pre_run_hooks"]
+        .as_array()
+        .expect("pre_run_hooks array");
+    assert_eq!(pre.len(), 2, "re-upload must UPSERT, not duplicate");
+    for hook in pre {
+        assert_eq!(
+            hook["content"]["v"], "second",
+            "every row should reflect the latest upload"
+        );
+    }
+}


### PR DESCRIPTION

Refs #1017. Replaces the closed #1019 (which used a config hash and was rejected because two hooks with the same hook_id AND same config — e.g. two `capture-command` rows running the identical command — would still collide).

## Approach

Use each hook's **global position** in the capsula.toml `pre_run` / `post_run` array as the discriminator. The upload handler iterates each incoming JSON array with `.enumerate()` and supplies `hook_index` on every INSERT. The unique key tightens to `(run_id, phase, hook_index)` and no longer mentions `hook_id`.

This is what the original issue suggested ("hook index, or explicit hook instance id") and what the reviewer pointed toward. It works regardless of whether the colliding hooks have distinct or identical configs.

## Why drop `hook_id` from the unique key

The user pointed out that querying on a per-`hook_id` index is awkward, while a global `hook_index` lets you write natural SQL:

```sql
-- Show hooks in original capsula.toml order
ORDER BY phase, hook_index;

-- Find "the 3rd pre-run hook"
WHERE phase = 'pre' AND hook_index = 2;
```

`hook_id` stays as a regular column for filtering / display but no longer participates in the uniqueness constraint.

## Migration

```sql
ALTER TABLE run_outputs
ADD COLUMN hook_index INTEGER NOT NULL DEFAULT 0;

-- Backfill: assign sequential hook_index within each (run_id, phase)
-- using insertion order (id) as proxy for original array position.
UPDATE run_outputs r SET hook_index = o.new_index
FROM (
    SELECT id,
           ROW_NUMBER() OVER (PARTITION BY run_id, phase ORDER BY id) - 1 AS new_index
    FROM run_outputs
) AS o
WHERE r.id = o.id;

DROP INDEX idx_run_outputs_unique;
CREATE UNIQUE INDEX idx_run_outputs_unique
ON run_outputs(run_id, phase, hook_index);
```

Under the previous `UNIQUE(run_id, phase, hook_id)` there was at most one row per `(run_id, phase, hook_id)`, so the backfill assignment is unambiguous and re-uploads of historical runs continue to UPSERT correctly.

## Runtime

Both upload `INSERT` statements (pre and post phases) now:

- Use `for (idx, hook) in hooks.iter().enumerate()` to compute `hook_index`.
- Bind `hook_index` as `$7`.
- Use `ON CONFLICT (run_id, phase, hook_index)` (no `hook_id`).
- `SET hook_id = EXCLUDED.hook_id` is included so re-uploads with an edited `capsula.toml` (different hook at the same position) reflect the new id.

## Tests

Three integration tests against a real Postgres via testcontainers:

1. `multiple_hooks_with_distinct_configs_coexist` — the original #1017 case (two `capture-json` with different paths). Both rows persist.
2. `multiple_hooks_with_identical_configs_coexist` — the reviewer's concern that closed #1019 (two `capture-command` with the **same** command, distinguished only by position). Both rows persist with distinct `stdout`s.
3. `re_upload_with_same_array_is_idempotent` — re-uploading the same array structure UPSERTs existing rows instead of duplicating, and updates `content` to the latest payload.

## Verification

- [x] `cargo build -p capsula-server`
- [x] `cargo test -p capsula-server --test api_tests multiple_hooks` — 2/2 pass
- [x] `cargo test -p capsula-server --test api_tests re_upload` — 1/1 pass
- [x] `cargo test -p capsula-server --test api_tests test_hook_outputs_storage` — existing regression unchanged
- [x] `cargo clippy -p capsula-server --all-targets -- -D warnings`
- [x] `cargo fmt --check -p capsula-server`
- [x] `.sqlx/` cache regenerated and checked in

## Notes

The migration is forward-only and safe to apply to an existing database: existing rows are already unique under the old key, the backfill is deterministic, and the new index covers them without duplicate-resolution work.