### PR TITLE
Delay Docker Hub digest PR creation until stable

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -7,6 +7,15 @@
   },
   packageRules: [
     {
+      // Docker Hub provides a tag timestamp, but Renovate cannot reliably know
+      // the true per-digest publish time. Wait until the minimumReleaseAge
+      // stability check is no longer pending before opening Docker Hub digest PRs.
+      matchDatasources: ["docker"],
+      matchUpdateTypes: ["digest"],
+      matchRegistryUrls: ["https://index.docker.io"],
+      prCreation: "not-pending",
+    },
+    {
       matchUpdateTypes: ["lockFileMaintenance"],
       minimumReleaseAge: null,
     },


### PR DESCRIPTION
## Summary
- Delay Docker Hub digest update PRs until Renovate's minimum release age stability check is no longer pending
- Document why Docker Hub digest updates need this special handling

## Tests
- just lint
- just test