### PR TITLE
Add capture-dir hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,6 +590,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "capsula-capture-dir"
+version = "0.12.1"
+dependencies = [
+ "capsula-core",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tracing",
+ "ulid",
+]
+
+[[package]]
 name = "capsula-capture-env"
 version = "0.12.1"
 dependencies = [
@@ -722,6 +735,7 @@ version = "0.12.1"
 dependencies = [
  "capsula-capture-command",
  "capsula-capture-cwd",
+ "capsula-capture-dir",
  "capsula-capture-env",
  "capsula-capture-file",
  "capsula-capture-git-repo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ axum = { version = "0.8", features = ["multipart"] }
 capsula-api-types = { path = "crates/capsula-api-types", version = "0.12.1" }
 capsula-capture-command = { path = "crates/capsula-capture-command", version = "0.12.1" }
 capsula-capture-cwd = { path = "crates/capsula-capture-cwd", version = "0.12.1" }
+capsula-capture-dir = { path = "crates/capsula-capture-dir", version = "0.12.1" }
 capsula-capture-env = { path = "crates/capsula-capture-env", version = "0.12.1" }
 capsula-capture-file = { path = "crates/capsula-capture-file", version = "0.12.1" }
 capsula-capture-git-repo = { path = "crates/capsula-capture-git-repo", version = "0.12.1" }

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Capsula creates an organized directory:
     └── output.txt              # Your output file
 ```
 
-Hooks that produce file artifacts (e.g., `capture-file`, `capture-git-repo`) each
+Hooks that produce file artifacts (e.g., `capture-file`, `capture-dir`, `capture-git-repo`) each
 get a dedicated subdirectory named `{phase}-{index}-{hook_id}/`, which prevents
 filename collisions between hooks.
 

--- a/crates/capsula-capture-dir/Cargo.toml
+++ b/crates/capsula-capture-dir/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "capsula-capture-dir"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "A Capsula hook that captures directory contents."
+readme.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords = ["capsula", "capsula-hook"]
+categories = ["development-tools", "filesystem"]
+
+[dependencies]
+capsula-core = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+ulid = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/capsula-capture-dir/src/error.rs
+++ b/crates/capsula-capture-dir/src/error.rs
@@ -1,0 +1,53 @@
+use capsula_core::error::CapsulaError;
+use std::path::PathBuf;
+use thiserror::Error;
+
+/// Directory hook specific errors.
+#[derive(Debug, Error)]
+pub enum DirHookError {
+    #[error("Directory not found: {path}")]
+    DirectoryNotFound { path: PathBuf },
+
+    #[error("Path is not a directory: {path}")]
+    NotADirectory { path: PathBuf },
+
+    #[error("Failed to resolve directory {path}: {source}")]
+    ResolveDirectory {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("Invalid directory name: {path}")]
+    InvalidDirectoryName { path: PathBuf },
+
+    #[error("capture-dir hook requires an artifact directory but none was provided")]
+    ArtifactDirMissing,
+
+    #[error("Cannot move directory {source_dir} into destination {destination} inside itself")]
+    DestinationInsideSource {
+        source_dir: PathBuf,
+        destination: PathBuf,
+    },
+
+    #[error("Destination already exists: {path}")]
+    DestinationAlreadyExists { path: PathBuf },
+
+    #[error("Failed to compute path of {path} relative to {base}")]
+    StripPrefix { path: PathBuf, base: PathBuf },
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Failed to serialize directory hook: {0}")]
+    Serialization(#[from] serde_json::Error),
+}
+
+impl From<DirHookError> for CapsulaError {
+    fn from(err: DirHookError) -> Self {
+        Self::HookFailed {
+            hook: "capture-dir".to_string(),
+            source: Box::new(err),
+        }
+    }
+}

--- a/crates/capsula-capture-dir/src/hash.rs
+++ b/crates/capsula-capture-dir/src/hash.rs
@@ -1,0 +1,23 @@
+use capsula_core::util::hex_encode;
+use sha2::Digest;
+use sha2::Sha256;
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::Path;
+
+pub fn file_digest_sha256(path: impl AsRef<Path>) -> std::io::Result<String> {
+    let file = File::open(path.as_ref())?;
+    let mut reader = BufReader::new(file);
+    let mut hasher = Sha256::new();
+    let mut buffer = [0; 8192];
+
+    loop {
+        let bytes_read = reader.read(&mut buffer)?;
+        if bytes_read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..bytes_read]);
+    }
+
+    Ok(hex_encode(hasher.finalize().as_ref()))
+}

--- a/crates/capsula-capture-dir/src/lib.rs
+++ b/crates/capsula-capture-dir/src/lib.rs
@@ -1,0 +1,353 @@
+mod error;
+mod hash;
+
+use crate::error::DirHookError;
+use crate::hash::file_digest_sha256;
+use capsula_core::captured::Captured;
+use capsula_core::error::{CapsulaError, CapsulaResult};
+use capsula_core::hook::{Hook, PhaseMarker, RuntimeParams};
+use capsula_core::run::PreparedRun;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use tracing::debug;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DirHookConfig {
+    path: PathBuf,
+    #[serde(default)]
+    mode: CaptureMode,
+    #[serde(default)]
+    hash: HashAlgorithm,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum CaptureMode {
+    #[default]
+    Copy,
+    Move,
+    None,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum HashAlgorithm {
+    #[default]
+    Sha256,
+    None,
+}
+
+#[derive(Debug)]
+pub struct DirHook {
+    config: DirHookConfig,
+}
+
+#[derive(Debug, Clone)]
+struct SourceFile {
+    path: PathBuf,
+    relative_path: PathBuf,
+}
+
+#[derive(Debug, Default)]
+struct DirectorySnapshot {
+    directories: Vec<PathBuf>,
+    files: Vec<SourceFile>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DirCapturedFile {
+    path: PathBuf,
+    relative_path: PathBuf,
+    captured_path: Option<PathBuf>,
+    hash: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DirCaptured {
+    path: PathBuf,
+    captured_path: Option<PathBuf>,
+    directories: Vec<PathBuf>,
+    files: Vec<DirCapturedFile>,
+}
+
+impl Captured for DirCaptured {
+    fn serialize_json(&self) -> Result<serde_json::Value, serde_json::Error> {
+        serde_json::to_value(self)
+    }
+}
+
+impl<P> Hook<P> for DirHook
+where
+    P: PhaseMarker,
+{
+    const ID: &'static str = "capture-dir";
+
+    type Config = DirHookConfig;
+    type Output = DirCaptured;
+
+    fn from_config(
+        config: &serde_json::Value,
+        _project_root: &std::path::Path,
+    ) -> CapsulaResult<Self> {
+        let config: DirHookConfig = serde_json::from_value(config.clone())?;
+        Ok(Self { config })
+    }
+
+    fn config(&self) -> &Self::Config {
+        &self.config
+    }
+
+    fn run(
+        &self,
+        metadata: &PreparedRun,
+        params: &RuntimeParams<P>,
+    ) -> CapsulaResult<Self::Output> {
+        self.run(metadata, params.artifact_dir.as_deref())
+            .map_err(CapsulaError::from)
+    }
+
+    fn needs_artifact_dir(&self) -> bool {
+        !matches!(self.config.mode, CaptureMode::None)
+    }
+}
+
+impl DirHook {
+    fn run(
+        &self,
+        metadata: &PreparedRun,
+        artifact_dir: Option<&Path>,
+    ) -> Result<DirCaptured, DirHookError> {
+        let source_dir =
+            Self::resolve_existing_directory(&metadata.project_root, &self.config.path)?;
+        debug!("DirHook: Capturing directory: {}", source_dir.display());
+
+        let captured_path = self.destination_root(&source_dir, artifact_dir)?;
+        let excluded_roots = Self::excluded_roots(&source_dir, metadata, artifact_dir);
+        let snapshot = Self::snapshot_directory(&source_dir, &excluded_roots)?;
+        let directories = snapshot.directories.clone();
+        let files = self.captured_files(&snapshot, captured_path.as_deref())?;
+
+        match (&self.config.mode, captured_path.as_deref()) {
+            (CaptureMode::Copy, Some(destination)) => {
+                debug!(
+                    "DirHook: Copying directory {} to {}",
+                    source_dir.display(),
+                    destination.display()
+                );
+                Self::copy_snapshot(&snapshot, destination)?;
+            }
+            (CaptureMode::Move, Some(destination)) => {
+                debug!(
+                    "DirHook: Moving directory {} to {}",
+                    source_dir.display(),
+                    destination.display()
+                );
+                Self::move_directory(&source_dir, destination)?;
+            }
+            (CaptureMode::None, None) => {
+                debug!("DirHook: Not copying directory because mode is none");
+            }
+            (CaptureMode::Copy | CaptureMode::Move, None) => {
+                return Err(DirHookError::ArtifactDirMissing);
+            }
+            (CaptureMode::None, Some(_)) => unreachable!("mode none never creates a destination"),
+        }
+
+        debug!("DirHook: Captured {} files", files.len());
+        Ok(DirCaptured {
+            path: source_dir,
+            captured_path,
+            directories,
+            files,
+        })
+    }
+
+    fn resolve_existing_directory(
+        project_root: &Path,
+        configured_path: &Path,
+    ) -> Result<PathBuf, DirHookError> {
+        let path = if configured_path.is_absolute() {
+            configured_path.to_path_buf()
+        } else {
+            project_root.join(configured_path)
+        };
+
+        let canonical = path.canonicalize().map_err(|source| match source.kind() {
+            std::io::ErrorKind::NotFound => DirHookError::DirectoryNotFound { path: path.clone() },
+            _ => DirHookError::ResolveDirectory {
+                path: path.clone(),
+                source,
+            },
+        })?;
+
+        if canonical.is_dir() {
+            Ok(canonical)
+        } else {
+            Err(DirHookError::NotADirectory { path: canonical })
+        }
+    }
+
+    fn destination_root(
+        &self,
+        source_dir: &Path,
+        artifact_dir: Option<&Path>,
+    ) -> Result<Option<PathBuf>, DirHookError> {
+        match self.config.mode {
+            CaptureMode::Copy | CaptureMode::Move => {
+                let artifact_dir = artifact_dir.ok_or(DirHookError::ArtifactDirMissing)?;
+                let directory_name =
+                    source_dir
+                        .file_name()
+                        .ok_or_else(|| DirHookError::InvalidDirectoryName {
+                            path: source_dir.to_path_buf(),
+                        })?;
+                Ok(Some(artifact_dir.join(directory_name)))
+            }
+            CaptureMode::None => Ok(None),
+        }
+    }
+
+    fn excluded_roots(
+        source_dir: &Path,
+        metadata: &PreparedRun,
+        artifact_dir: Option<&Path>,
+    ) -> Vec<PathBuf> {
+        [Some(metadata.run_dir.as_path()), artifact_dir]
+            .into_iter()
+            .flatten()
+            .filter_map(|path| path.canonicalize().ok())
+            .filter(|path| path.starts_with(source_dir) && path != source_dir)
+            .collect()
+    }
+
+    fn snapshot_directory(
+        source_dir: &Path,
+        excluded_roots: &[PathBuf],
+    ) -> Result<DirectorySnapshot, DirHookError> {
+        let mut snapshot = DirectorySnapshot::default();
+        Self::snapshot_directory_inner(source_dir, source_dir, excluded_roots, &mut snapshot)?;
+        snapshot.directories.sort();
+        snapshot
+            .files
+            .sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+        Ok(snapshot)
+    }
+
+    fn snapshot_directory_inner(
+        root: &Path,
+        current: &Path,
+        excluded_roots: &[PathBuf],
+        snapshot: &mut DirectorySnapshot,
+    ) -> Result<(), DirHookError> {
+        let mut entries = std::fs::read_dir(current)?.collect::<Result<Vec<_>, _>>()?;
+        entries.sort_by_key(std::fs::DirEntry::path);
+
+        entries.into_iter().try_for_each(|entry| {
+            let path = entry.path();
+            if excluded_roots
+                .iter()
+                .any(|excluded| path.starts_with(excluded))
+            {
+                debug!("DirHook: Skipping excluded path: {}", path.display());
+                return Ok(());
+            }
+
+            let file_type = entry.file_type()?;
+            if file_type.is_dir() {
+                let relative_path = path
+                    .strip_prefix(root)
+                    .map_err(|_| DirHookError::StripPrefix {
+                        path: path.clone(),
+                        base: root.to_path_buf(),
+                    })?
+                    .to_path_buf();
+                snapshot.directories.push(relative_path);
+                Self::snapshot_directory_inner(root, &path, excluded_roots, snapshot)
+            } else if file_type.is_file() {
+                let relative_path = path
+                    .strip_prefix(root)
+                    .map_err(|_| DirHookError::StripPrefix {
+                        path: path.clone(),
+                        base: root.to_path_buf(),
+                    })?
+                    .to_path_buf();
+                snapshot.files.push(SourceFile {
+                    path,
+                    relative_path,
+                });
+                Ok(())
+            } else {
+                debug!("DirHook: Skipping special path: {}", path.display());
+                Ok(())
+            }
+        })
+    }
+
+    fn captured_files(
+        &self,
+        snapshot: &DirectorySnapshot,
+        destination_root: Option<&Path>,
+    ) -> Result<Vec<DirCapturedFile>, DirHookError> {
+        snapshot
+            .files
+            .iter()
+            .map(|file| {
+                let hash = match self.config.hash {
+                    HashAlgorithm::Sha256 => {
+                        debug!(
+                            "DirHook: Computing SHA256 hash for: {}",
+                            file.path.display()
+                        );
+                        Some(format!("sha256:{}", file_digest_sha256(&file.path)?))
+                    }
+                    HashAlgorithm::None => None,
+                };
+                let captured_path = destination_root.map(|root| root.join(&file.relative_path));
+                Ok(DirCapturedFile {
+                    path: file.path.clone(),
+                    relative_path: file.relative_path.clone(),
+                    captured_path,
+                    hash,
+                })
+            })
+            .collect()
+    }
+
+    fn copy_snapshot(
+        snapshot: &DirectorySnapshot,
+        destination_root: &Path,
+    ) -> Result<(), DirHookError> {
+        std::fs::create_dir_all(destination_root)?;
+        snapshot.directories.iter().try_for_each(|relative_path| {
+            std::fs::create_dir_all(destination_root.join(relative_path))
+        })?;
+        snapshot.files.iter().try_for_each(|file| {
+            let destination = destination_root.join(&file.relative_path);
+            if let Some(parent) = destination.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::copy(&file.path, destination)
+                .map(|_| ())
+                .map_err(DirHookError::from)
+        })
+    }
+
+    fn move_directory(source_dir: &Path, destination: &Path) -> Result<(), DirHookError> {
+        if destination.starts_with(source_dir) {
+            return Err(DirHookError::DestinationInsideSource {
+                source_dir: source_dir.to_path_buf(),
+                destination: destination.to_path_buf(),
+            });
+        }
+        if destination.exists() {
+            return Err(DirHookError::DestinationAlreadyExists {
+                path: destination.to_path_buf(),
+            });
+        }
+        if let Some(parent) = destination.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::rename(source_dir, destination)?;
+        Ok(())
+    }
+}

--- a/crates/capsula-capture-dir/tests/dir_hook.rs
+++ b/crates/capsula-capture-dir/tests/dir_hook.rs
@@ -1,0 +1,185 @@
+//! Tests for the `DirHook` directory capture functionality.
+#![cfg(test)]
+
+use capsula_capture_dir::DirHook;
+use capsula_core::captured::Captured;
+use capsula_core::hook::{Hook, PreRun, RuntimeParams};
+use capsula_core::run::PreparedRun;
+use serde_json::json;
+use std::fs;
+use std::path::Path;
+use ulid::Ulid;
+
+fn test_run(project_root: &Path, run_dir: &Path) -> PreparedRun {
+    PreparedRun {
+        id: Ulid::new(),
+        name: "test-run".to_string(),
+        command: vec![],
+        run_dir: run_dir.to_path_buf(),
+        project_root: project_root.to_path_buf(),
+    }
+}
+
+#[test]
+fn dir_hook_copies_directory_contents_preserving_tree() {
+    let temp_dir = std::env::temp_dir().join(format!("capsula_test_{}", Ulid::new()));
+    let run_dir = temp_dir.join("run");
+    let artifact_dir = run_dir.join("pre-0-capture-dir");
+    let input_dir = temp_dir.join("input");
+    let nested_dir = input_dir.join("nested");
+    let empty_dir = input_dir.join("empty");
+    fs::create_dir_all(&artifact_dir).unwrap();
+    fs::create_dir_all(&nested_dir).unwrap();
+    fs::create_dir_all(&empty_dir).unwrap();
+    fs::write(input_dir.join("root.txt"), b"root content").unwrap();
+    fs::write(nested_dir.join("data.txt"), b"nested content").unwrap();
+
+    let config = json!({
+        "path": "input",
+        "mode": "copy",
+        "hash": "sha256"
+    });
+    let hook = <DirHook as Hook<PreRun>>::from_config(&config, &temp_dir).expect("from_config ok");
+    let run_metadata = test_run(&temp_dir, &run_dir);
+    let params = RuntimeParams::<PreRun>::with_artifact_dir(artifact_dir.clone());
+
+    let captured = hook.run(&run_metadata, &params).expect("run ok");
+    let output = captured
+        .serialize_json()
+        .expect("serialization should succeed");
+
+    assert_eq!(
+        output.get("captured_path").and_then(|value| value.as_str()),
+        Some(artifact_dir.join("input").to_string_lossy().as_ref())
+    );
+
+    let directories = output
+        .get("directories")
+        .and_then(|value| value.as_array())
+        .unwrap();
+    assert_eq!(directories.len(), 2, "Should report nested and empty dirs");
+
+    let files = output
+        .get("files")
+        .and_then(|value| value.as_array())
+        .unwrap();
+    assert_eq!(files.len(), 2, "Should capture both files in the tree");
+    assert!(
+        files.iter().all(|file| file
+            .get("hash")
+            .and_then(|value| value.as_str())
+            .is_some_and(|hash| hash.starts_with("sha256:"))),
+        "Should hash every captured file"
+    );
+
+    assert!(artifact_dir.join("input/root.txt").exists());
+    assert!(artifact_dir.join("input/nested/data.txt").exists());
+    assert!(artifact_dir.join("input/empty").is_dir());
+    assert!(input_dir.join("root.txt").exists());
+    assert!(nested_dir.join("data.txt").exists());
+
+    fs::remove_dir_all(&temp_dir).ok();
+}
+
+#[test]
+fn dir_hook_hashes_directory_without_artifact_dir_in_none_mode() {
+    let temp_dir = std::env::temp_dir().join(format!("capsula_test_{}", Ulid::new()));
+    let run_dir = temp_dir.join("run");
+    let input_dir = temp_dir.join("input");
+    fs::create_dir_all(&run_dir).unwrap();
+    fs::create_dir_all(&input_dir).unwrap();
+    fs::write(input_dir.join("metadata.txt"), b"metadata only").unwrap();
+
+    let config = json!({
+        "path": "input",
+        "mode": "none",
+        "hash": "sha256"
+    });
+    let hook = <DirHook as Hook<PreRun>>::from_config(&config, &temp_dir).expect("from_config ok");
+    let run_metadata = test_run(&temp_dir, &run_dir);
+    let params = RuntimeParams::<PreRun>::default();
+
+    let captured = hook.run(&run_metadata, &params).expect("run ok");
+    let output = captured
+        .serialize_json()
+        .expect("serialization should succeed");
+
+    assert!(
+        output.get("captured_path").unwrap().is_null(),
+        "Should not need a destination in none mode"
+    );
+    let files = output
+        .get("files")
+        .and_then(|value| value.as_array())
+        .unwrap();
+    assert_eq!(files.len(), 1, "Should still report files");
+    assert!(files[0].get("captured_path").unwrap().is_null());
+    assert!(
+        files[0]
+            .get("hash")
+            .and_then(|value| value.as_str())
+            .is_some_and(|hash| hash.starts_with("sha256:"))
+    );
+
+    fs::remove_dir_all(&temp_dir).ok();
+}
+
+#[test]
+fn dir_hook_moves_directory_contents() {
+    let temp_dir = std::env::temp_dir().join(format!("capsula_test_{}", Ulid::new()));
+    let run_dir = temp_dir.join("run");
+    let artifact_dir = run_dir.join("pre-0-capture-dir");
+    let input_dir = temp_dir.join("moveme");
+    fs::create_dir_all(&artifact_dir).unwrap();
+    fs::create_dir_all(&input_dir).unwrap();
+    fs::write(input_dir.join("output.txt"), b"move me").unwrap();
+
+    let config = json!({
+        "path": "moveme",
+        "mode": "move",
+        "hash": "none"
+    });
+    let hook = <DirHook as Hook<PreRun>>::from_config(&config, &temp_dir).expect("from_config ok");
+    let run_metadata = test_run(&temp_dir, &run_dir);
+    let params = RuntimeParams::<PreRun>::with_artifact_dir(artifact_dir.clone());
+
+    let captured = hook.run(&run_metadata, &params).expect("run ok");
+    let output = captured
+        .serialize_json()
+        .expect("serialization should succeed");
+
+    let files = output
+        .get("files")
+        .and_then(|value| value.as_array())
+        .unwrap();
+    assert_eq!(files.len(), 1, "Should report the moved file");
+    assert!(artifact_dir.join("moveme/output.txt").exists());
+    assert!(!input_dir.exists(), "Original directory should be moved");
+
+    fs::remove_dir_all(&temp_dir).ok();
+}
+
+#[test]
+fn dir_hook_errors_when_path_is_file() {
+    let temp_dir = std::env::temp_dir().join(format!("capsula_test_{}", Ulid::new()));
+    let run_dir = temp_dir.join("run");
+    let artifact_dir = run_dir.join("pre-0-capture-dir");
+    fs::create_dir_all(&artifact_dir).unwrap();
+    fs::write(temp_dir.join("not-a-dir.txt"), b"not a directory").unwrap();
+
+    let config = json!({
+        "path": "not-a-dir.txt",
+        "mode": "copy",
+        "hash": "none"
+    });
+    let hook = <DirHook as Hook<PreRun>>::from_config(&config, &temp_dir).expect("from_config ok");
+    let run_metadata = test_run(&temp_dir, &run_dir);
+    let params = RuntimeParams::<PreRun>::with_artifact_dir(artifact_dir);
+
+    let error = hook
+        .run(&run_metadata, &params)
+        .expect_err("file paths should fail");
+    assert!(error.to_string().contains("capture-dir"));
+
+    fs::remove_dir_all(&temp_dir).ok();
+}

--- a/crates/capsula-registry/Cargo.toml
+++ b/crates/capsula-registry/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["development-tools"]
 [dependencies]
 capsula-capture-command = { workspace = true }
 capsula-capture-cwd = { workspace = true }
+capsula-capture-dir = { workspace = true }
 capsula-capture-env = { workspace = true }
 capsula-capture-file = { workspace = true }
 capsula-capture-git-repo = { workspace = true }

--- a/crates/capsula-registry/src/lib.rs
+++ b/crates/capsula-registry/src/lib.rs
@@ -180,6 +180,7 @@ where
 fn standard_hook_registry<P: PhaseMarker>() -> Result<HookRegistry<P>, RegistryError>
 where
     capsula_capture_cwd::CwdHook: capsula_core::hook::Hook<P>,
+    capsula_capture_dir::DirHook: capsula_core::hook::Hook<P>,
     capsula_capture_git_repo::GitHook: capsula_core::hook::Hook<P>,
     capsula_capture_file::FileHook: capsula_core::hook::Hook<P>,
     capsula_capture_env::EnvVarHook: capsula_core::hook::Hook<P>,
@@ -189,6 +190,7 @@ where
 {
     Ok(RegistryBuilder::new()
         .with_hook::<capsula_capture_cwd::CwdHook>()?
+        .with_hook::<capsula_capture_dir::DirHook>()?
         .with_hook::<capsula_capture_git_repo::GitHook>()?
         .with_hook::<capsula_capture_file::FileHook>()?
         .with_hook::<capsula_capture_env::EnvVarHook>()?
@@ -206,4 +208,16 @@ pub fn standard_pre_run_hook_registry() -> Result<HookRegistry<PreRun>, Registry
 /// Create a standard registry with all built-in hook types for post-run phase
 pub fn standard_post_run_hook_registry() -> Result<HookRegistry<PostRun>, RegistryError> {
     standard_hook_registry::<PostRun>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RegistryError, standard_pre_run_hook_registry};
+
+    #[test]
+    fn standard_registry_includes_capture_dir() -> Result<(), RegistryError> {
+        let registry = standard_pre_run_hook_registry()?;
+        assert!(registry.registered_types().contains(&"capture-dir"));
+        Ok(())
+    }
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,7 +80,7 @@ Capsula stores everything in `.capsula/`:
     └── output.txt              # Your captured file
 ```
 
-Hooks that produce file artifacts (e.g., `capture-file`, `capture-git-repo`) each
+Hooks that produce file artifacts (e.g., `capture-file`, `capture-dir`, `capture-git-repo`) each
 get a dedicated subdirectory named `{phase}-{index}-{hook_id}/`. This prevents
 filename collisions between hooks and keeps each hook's outputs isolated.
 
@@ -98,6 +98,7 @@ cat .capsula/my-project/2025-01-09/143022-happy-river/_capsula/pre-run.json
 | [capture-env](hooks/capture-env.md) | Captures environment variables | Pre-run |
 | [capture-git-repo](hooks/capture-git-repo.md) | Captures git repository state | Pre-run |
 | [capture-file](hooks/capture-file.md) | Captures files (copy/move/hash) | Both |
+| [capture-dir](hooks/capture-dir.md) | Captures directory trees (copy/move/hash files) | Both |
 | [capture-machine](hooks/capture-machine.md) | Captures system information | Pre-run |
 | [capture-command](hooks/capture-command.md) | Runs commands and captures output | Both |
 | [notify-slack](hooks/notify-slack.md) | Sends Slack notifications | Both |

--- a/docs/hooks/capture-dir.md
+++ b/docs/hooks/capture-dir.md
@@ -1,0 +1,83 @@
+---
+icon: material/hook
+---
+
+# capture-dir
+
+Captures a directory tree by copying it, moving it, or recording file hashes.
+
+## Use Cases
+
+- Preserve a full output directory
+- Archive generated reports with nested assets
+- Hash all files in an input dataset without copying it
+
+## Configuration
+
+### Required Options
+
+| Option | Type | Description |
+| -------- | ------ | ------------- |
+| `path` | string | Directory path to capture, relative to the project root unless absolute |
+
+### Optional Options
+
+| Option | Type | Default | Description |
+| -------- | ------ | --------- | ------------- |
+| `mode` | string | `"copy"` | How to handle the directory: `"copy"`, `"move"`, or `"none"` |
+| `hash` | string | `"sha256"` | Hash algorithm for files: `"sha256"` or `"none"` |
+
+### Mode Options
+
+- `"copy"` - Copies the directory into the hook's artifact directory and leaves the original directory in place
+- `"move"` - Moves the directory into the hook's artifact directory and removes the original directory
+- `"none"` - Only records matching file metadata and hashes; no artifact directory is created
+
+!!! note "Per-hook artifact directory"
+    For `"copy"` and `"move"`, the captured directory is placed under a
+    per-hook artifact directory named `{phase}-{index}-capture-dir/` under the
+    run directory (for example, `post-0-capture-dir/results/`). The directory
+    tree is preserved.
+
+### Example
+
+```toml
+[[post-run.hooks]]
+id = "capture-dir"
+path = "results"
+mode = "copy"
+hash = "sha256"
+```
+
+## Output Example
+
+```json
+{
+  "__meta": {
+    "id": "capture-dir",
+    "config": {
+      "path": "results",
+      "mode": "copy",
+      "hash": "sha256"
+    },
+    "success": true
+  },
+  "path": "/path/to/project/results",
+  "captured_path": ".capsula/my-vault/2025-01-09/143022-happy-river/post-0-capture-dir/results",
+  "directories": ["assets"],
+  "files": [
+    {
+      "path": "/path/to/project/results/data.csv",
+      "relative_path": "data.csv",
+      "captured_path": ".capsula/my-vault/2025-01-09/143022-happy-river/post-0-capture-dir/results/data.csv",
+      "hash": "sha256:a1b2c3d4e5f6..."
+    },
+    {
+      "path": "/path/to/project/results/assets/plot.png",
+      "relative_path": "assets/plot.png",
+      "captured_path": ".capsula/my-vault/2025-01-09/143022-happy-river/post-0-capture-dir/results/assets/plot.png",
+      "hash": "sha256:b2c3d4e5f6g7..."
+    }
+  ]
+}
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,7 @@ Capsula creates an organized directory:
     └── output.txt              # Your output file
 ```
 
-Hooks that produce file artifacts (e.g., `capture-file`, `capture-git-repo`) each
+Hooks that produce file artifacts (e.g., `capture-file`, `capture-dir`, `capture-git-repo`) each
 get a dedicated subdirectory named `{phase}-{index}-{hook_id}/`, which prevents
 filename collisions between hooks.
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -53,6 +53,7 @@ nav = [
     { "capture-env" = "hooks/capture-env.md" },
     { "capture-git-repo" = "hooks/capture-git-repo.md" },
     { "capture-file" = "hooks/capture-file.md" },
+    { "capture-dir" = "hooks/capture-dir.md" },
     { "capture-machine" = "hooks/capture-machine.md" },
     { "capture-command" = "hooks/capture-command.md" },
     { "notify-slack" = "hooks/notify-slack.md" },


### PR DESCRIPTION
## Summary
- Add `capture-dir` hook for copying, moving, or hashing directory trees
- Register the hook in the built-in pre/post registries
- Add tests and documentation for the new hook

## Tests
- `just lint`
- `just test`

Closes #1057