### PR TITLE
Filter key events to only process key presses on Windows

### DIFF
--- a/crates/capsula-tui/src/event.rs
+++ b/crates/capsula-tui/src/event.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use anyhow::Result;
-use crossterm::event::{self, Event, KeyEvent, MouseEvent};
+use crossterm::event::{self, Event, KeyEvent, KeyEventKind, MouseEvent};
 
 /// Application-level event combining crossterm events with a periodic tick.
 pub enum AppEvent {
@@ -15,12 +15,76 @@ pub enum AppEvent {
 /// The 1-second timeout drives the elapsed-time display during an active run.
 pub fn next_event() -> Result<AppEvent> {
     if event::poll(Duration::from_secs(1))? {
-        match event::read()? {
-            Event::Key(key) => Ok(AppEvent::Key(key)),
-            Event::Mouse(mouse) => Ok(AppEvent::Mouse(mouse)),
-            _ => Ok(AppEvent::Tick),
-        }
+        Ok(classify_event(&event::read()?))
     } else {
         Ok(AppEvent::Tick)
+    }
+}
+
+/// Translate a raw crossterm [`Event`] into an [`AppEvent`].
+///
+/// Only key *press* events are surfaced as [`AppEvent::Key`]. On Windows the
+/// console backend reports both key press and key release events (Unix reports
+/// only presses), so the key-release event from the Enter used to launch
+/// `capsula tui` would otherwise be read on startup and immediately activate
+/// the focused button, starting the run without user input (see issue #1091).
+/// Everything that is not a key press or a mouse event becomes a [`AppEvent::Tick`].
+fn classify_event(event: &Event) -> AppEvent {
+    match event {
+        Event::Key(key) if key.kind == KeyEventKind::Press => AppEvent::Key(*key),
+        Event::Mouse(mouse) => AppEvent::Mouse(*mouse),
+        _ => AppEvent::Tick,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton};
+
+    use super::*;
+
+    #[test]
+    fn key_press_is_forwarded() {
+        let event = Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        match classify_event(&event) {
+            AppEvent::Key(key) => assert_eq!(key.code, KeyCode::Enter),
+            _ => panic!("expected a key event to be forwarded"),
+        }
+    }
+
+    #[test]
+    fn key_release_is_ignored() {
+        // On Windows crossterm reports key-release events; treating them as
+        // presses causes the run to start immediately on launch (issue #1091).
+        let event = Event::Key(KeyEvent::new_with_kind(
+            KeyCode::Enter,
+            KeyModifiers::NONE,
+            KeyEventKind::Release,
+        ));
+        assert!(matches!(classify_event(&event), AppEvent::Tick));
+    }
+
+    #[test]
+    fn key_repeat_is_ignored() {
+        let event = Event::Key(KeyEvent::new_with_kind(
+            KeyCode::Char(' '),
+            KeyModifiers::NONE,
+            KeyEventKind::Repeat,
+        ));
+        assert!(matches!(classify_event(&event), AppEvent::Tick));
+    }
+
+    #[test]
+    fn mouse_event_is_forwarded() {
+        let mouse = crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::Down(MouseButton::Left),
+            column: 3,
+            row: 4,
+            modifiers: KeyModifiers::NONE,
+        };
+        assert!(matches!(
+            classify_event(&Event::Mouse(mouse)),
+            AppEvent::Mouse(_)
+        ));
     }
 }


### PR DESCRIPTION
## Summary

Fix an issue where the TUI would immediately start a run on launch on Windows systems. The Windows console backend reports both key press and key release events, while Unix only reports presses. This caused the Enter key used to launch `capsula tui` to have its release event read on startup, immediately activating the focused button.

## Changes

- **Import `KeyEventKind`** from crossterm to distinguish between key press, release, and repeat events
- **Extract event classification logic** into a new `classify_event()` function that:
  - Only forwards key *press* events as `AppEvent::Key`
  - Ignores key release and repeat events (converts them to `AppEvent::Tick`)
  - Continues to forward mouse events normally
- **Add comprehensive test coverage** with four test cases:
  - `key_press_is_forwarded`: Verifies key presses are processed
  - `key_release_is_ignored`: Confirms Windows key release events don't trigger actions
  - `key_repeat_is_ignored`: Confirms repeated key events are ignored
  - `mouse_event_is_forwarded`: Verifies mouse events still work

## Implementation Details

The fix uses `KeyEventKind::Press` filtering to ensure only intentional key presses trigger application logic. This is a minimal, targeted change that solves the Windows-specific issue without affecting Unix behavior or other event handling.

https://claude.ai/code/session_01NqKWCNjDAuJMNcdZsy8WoZ