### PR TITLE
Reject unknown hook config fields

### DIFF
--- a/crates/capsula-capture-command/src/lib.rs
+++ b/crates/capsula-capture-command/src/lib.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 use tracing::debug;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct CommandHookConfig {
     command: Vec<String>,
     #[serde(default)]

--- a/crates/capsula-capture-command/tests/command_hook.rs
+++ b/crates/capsula-capture-command/tests/command_hook.rs
@@ -144,3 +144,15 @@ fn command_hook_captures_stderr() {
         "stderr should contain error message"
     );
 }
+
+#[test]
+fn command_hook_rejects_unknown_config_fields() {
+    let config = json!({
+        "command": ["true"],
+        "abort_on_failure_typo": true
+    });
+
+    let result = <CommandHook as Hook<PreRun>>::from_config(&config, &PathBuf::from("."));
+
+    assert!(result.is_err(), "unknown config fields should be rejected");
+}

--- a/crates/capsula-capture-cwd/src/lib.rs
+++ b/crates/capsula-capture-cwd/src/lib.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 use tracing::debug;
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct CwdHookConfig {}
 
 #[derive(Debug, Default)]
@@ -40,12 +41,11 @@ where
     type Output = CwdCaptured;
 
     fn from_config(
-        _config: &serde_json::Value,
+        config: &serde_json::Value,
         _project_root: &std::path::Path,
     ) -> CapsulaResult<Self> {
-        Ok(Self {
-            config: CwdHookConfig {},
-        })
+        let config: CwdHookConfig = serde_json::from_value(config.clone())?;
+        Ok(Self { config })
     }
 
     fn config(&self) -> &Self::Config {

--- a/crates/capsula-capture-cwd/tests/cwd_context.rs
+++ b/crates/capsula-capture-cwd/tests/cwd_context.rs
@@ -5,6 +5,8 @@ use capsula_capture_cwd::CwdHook;
 use capsula_core::captured::Captured;
 use capsula_core::hook::{Hook, PreRun, RuntimeParams};
 use capsula_core::run::PreparedRun;
+use serde_json::json;
+use std::path::PathBuf;
 use ulid::Ulid;
 
 #[test]
@@ -43,4 +45,15 @@ fn cwd_hook_captures_current_dir_and_json() {
         expected.to_string_lossy(),
         "JSON 'cwd' should match current_dir string"
     );
+}
+
+#[test]
+fn cwd_hook_rejects_unknown_config_fields() {
+    let config = json!({
+        "unexpected": true
+    });
+
+    let result = <CwdHook as Hook<PreRun>>::from_config(&config, &PathBuf::from("."));
+
+    assert!(result.is_err(), "unknown config fields should be rejected");
 }

--- a/crates/capsula-capture-env/src/lib.rs
+++ b/crates/capsula-capture-env/src/lib.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use tracing::debug;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct EnvVarHookConfig {
     name: String,
 }

--- a/crates/capsula-capture-env/tests/env_hook.rs
+++ b/crates/capsula-capture-env/tests/env_hook.rs
@@ -97,3 +97,15 @@ fn env_hook_captures_missing_variable() {
     // Assert
     assert!(json.get("value").unwrap().is_null());
 }
+
+#[test]
+fn env_hook_rejects_unknown_config_fields() {
+    let config = json!({
+        "name": "PATH",
+        "unexpected": true
+    });
+
+    let result = <EnvVarHook as Hook<PreRun>>::from_config(&config, &PathBuf::from("."));
+
+    assert!(result.is_err(), "unknown config fields should be rejected");
+}

--- a/crates/capsula-capture-file/src/lib.rs
+++ b/crates/capsula-capture-file/src/lib.rs
@@ -12,6 +12,7 @@ use std::path::{Path, PathBuf};
 use tracing::debug;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct FileHookConfig {
     glob: String,
     #[serde(default)]

--- a/crates/capsula-capture-file/tests/file_hook.rs
+++ b/crates/capsula-capture-file/tests/file_hook.rs
@@ -393,3 +393,16 @@ fn file_hook_matches_glob_pattern() {
     // Cleanup
     fs::remove_dir_all(&temp_dir).ok();
 }
+
+#[test]
+fn file_hook_rejects_unknown_config_fields() {
+    let config = json!({
+        "glob": "*.txt",
+        "mode": "copy",
+        "copy": true
+    });
+
+    let result = <FileHook as Hook<PreRun>>::from_config(&config, &std::env::temp_dir());
+
+    assert!(result.is_err(), "unknown config fields should be rejected");
+}

--- a/crates/capsula-capture-git-repo/src/lib.rs
+++ b/crates/capsula-capture-git-repo/src/lib.rs
@@ -17,6 +17,7 @@ fn default_remote() -> String {
 
 /// Configuration for `GitHook`
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GitHookConfig {
     name: String,
     path: PathBuf,

--- a/crates/capsula-capture-git-repo/tests/git_hook.rs
+++ b/crates/capsula-capture-git-repo/tests/git_hook.rs
@@ -963,3 +963,16 @@ fn git_hook_detects_untracked_files_as_dirty() {
     // Cleanup
     fs::remove_dir_all(&temp_dir).ok();
 }
+
+#[test]
+fn git_hook_rejects_unknown_config_fields() {
+    let config = json!({
+        "name": "test-repo",
+        "path": ".",
+        "allow_dirty_typo": false
+    });
+
+    let result = <GitHook as Hook<PreRun>>::from_config(&config, &std::env::temp_dir());
+
+    assert!(result.is_err(), "unknown config fields should be rejected");
+}

--- a/crates/capsula-capture-machine/src/lib.rs
+++ b/crates/capsula-capture-machine/src/lib.rs
@@ -10,6 +10,7 @@ use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind, System};
 use tracing::debug;
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct MachineHookConfig {}
 
 #[derive(Debug, Default)]
@@ -46,12 +47,11 @@ where
     type Output = MachineCaptured;
 
     fn from_config(
-        _config: &serde_json::Value,
+        config: &serde_json::Value,
         _project_root: &std::path::Path,
     ) -> CapsulaResult<Self> {
-        Ok(Self {
-            config: MachineHookConfig {},
-        })
+        let config: MachineHookConfig = serde_json::from_value(config.clone())?;
+        Ok(Self { config })
     }
 
     fn config(&self) -> &Self::Config {

--- a/crates/capsula-capture-machine/tests/machine_hook.rs
+++ b/crates/capsula-capture-machine/tests/machine_hook.rs
@@ -81,3 +81,14 @@ fn machine_hook_default_config() {
 
     assert!(json.is_object(), "Should return valid JSON object");
 }
+
+#[test]
+fn machine_hook_rejects_unknown_config_fields() {
+    let config = json!({
+        "unexpected": true
+    });
+
+    let result = <MachineHook as Hook<PreRun>>::from_config(&config, &PathBuf::from("."));
+
+    assert!(result.is_err(), "unknown config fields should be rejected");
+}

--- a/crates/capsula-cli/tests/cli_integration.rs
+++ b/crates/capsula-cli/tests/cli_integration.rs
@@ -179,6 +179,42 @@ fn test_capsula_run_exits_nonzero_when_pre_run_requests_abort() {
 }
 
 #[test]
+fn test_capsula_run_rejects_unknown_hook_config_fields() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_path = temp_dir.path().join("capsula.toml");
+    let config_content = r#"
+[vault]
+name = "test-vault"
+
+[[pre-run.hooks]]
+id = "capture-command"
+command = ["sh", "-c", "true"]
+abort_on_failure_typo = true
+"#;
+    fs::write(&config_path, config_content).unwrap();
+    let sentinel_path = temp_dir.path().join("should-not-run");
+
+    let mut cmd = cargo_bin_cmd!("capsula");
+    cmd.current_dir(temp_dir.path())
+        .arg("--config")
+        .arg(&config_path)
+        .arg("run")
+        .arg("sh")
+        .arg("-c")
+        .arg("touch should-not-run");
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("unknown field"))
+        .stderr(predicate::str::contains("abort_on_failure_typo"));
+
+    assert!(
+        !sentinel_path.exists(),
+        "command should not execute when hook config contains unknown fields"
+    );
+}
+
+#[test]
 fn test_capsula_run_creates_run_directory() {
     let temp_dir = TempDir::new().unwrap();
     let config_path = create_test_config(&temp_dir, "test-vault");

--- a/crates/capsula-config/src/lib.rs
+++ b/crates/capsula-config/src/lib.rs
@@ -165,18 +165,18 @@ path = "."
 
 [[pre-run.hooks]]
 id = "capture-file"
-path = "capsula.toml"
-copy = true
-hash = true
+glob = "capsula.toml"
+mode = "copy"
+hash = "sha256"
 
 [[pre-run.hooks]]
 id = "capture-file"
-path = "Cargo.toml"
-hash = true
+glob = "Cargo.toml"
+hash = "sha256"
 
 [[post-run.hooks]]
 id = "capture-env"
-key = "PATH"
+name = "PATH"
 "#;
 
         let config = CapsulaConfig::from_toml_str(config_str).unwrap();

--- a/crates/capsula-notify-slack/src/lib.rs
+++ b/crates/capsula-notify-slack/src/lib.rs
@@ -29,6 +29,7 @@ const MAX_SLACK_ATTACHMENTS: usize = 10;
 /// attachment_globs = ["*.png", "outputs/*.jpg"]
 /// ```
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SlackNotifyHookConfig {
     channel: String,
     #[serde(default = "token_from_env")]

--- a/crates/capsula-notify-slack/tests/slack_hook.rs
+++ b/crates/capsula-notify-slack/tests/slack_hook.rs
@@ -126,3 +126,16 @@ fn slack_hook_parses_config_without_attachments() {
         "attachment_globs should default to empty vec"
     );
 }
+
+#[test]
+fn slack_hook_rejects_unknown_config_fields() {
+    let config = json!({
+        "channel": "#test-channel",
+        "token": "xoxb-test-token",
+        "attachment_glob": ["*.png"]
+    });
+
+    let result = <SlackNotifyHook as Hook<PreRun>>::from_config(&config, &PathBuf::from("."));
+
+    assert!(result.is_err(), "unknown config fields should be rejected");
+}


### PR DESCRIPTION
## Summary
- add `deny_unknown_fields` to every hook config struct
- deserialize empty hook configs in `from_config` so unknown keys are rejected
- add hook and CLI coverage for unknown config fields

## Tests
- `just lint`
- `just test`

Closes #1084