### PR TITLE
Add project-root-aware path type

### DIFF
--- a/crates/capsula-capture-command/src/lib.rs
+++ b/crates/capsula-capture-command/src/lib.rs
@@ -4,6 +4,7 @@ use crate::error::CommandHookError;
 use capsula_core::captured::Captured;
 use capsula_core::error::CapsulaResult;
 use capsula_core::hook::{Hook, HookOutcome, PhaseMarker, RuntimeParams};
+use capsula_core::project_path::ResolvedProjectPath;
 use capsula_core::run::PreparedRun;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -26,7 +27,7 @@ pub struct CommandHookConfig {
 #[derive(Debug)]
 pub struct CommandHook {
     config: CommandHookConfig,
-    working_dir: PathBuf,
+    working_dir: ResolvedProjectPath,
 }
 
 #[derive(Debug, Serialize)]
@@ -58,8 +59,8 @@ where
         }
 
         let working_dir = match &config.cwd {
-            Some(cwd) => capsula_core::util::resolve_relative(cwd, project_root)?,
-            None => project_root.to_path_buf(),
+            Some(cwd) => ResolvedProjectPath::resolve_existing(cwd, project_root)?,
+            None => ResolvedProjectPath::resolve_existing(project_root, project_root)?,
         };
 
         Ok(Self {
@@ -86,10 +87,10 @@ where
         debug!(
             "CommandHook: Executing command: {:?} in {}",
             self.config.command,
-            self.working_dir.display()
+            self.working_dir.as_path().display()
         );
         let mut cmd = Command::new(&self.config.command[0]);
-        cmd.current_dir(&self.working_dir);
+        cmd.current_dir(self.working_dir.as_path());
         if self.config.command.len() > 1 {
             cmd.args(&self.config.command[1..]);
         }

--- a/crates/capsula-capture-command/tests/command_hook.rs
+++ b/crates/capsula-capture-command/tests/command_hook.rs
@@ -6,6 +6,7 @@ use capsula_core::captured::Captured;
 use capsula_core::hook::{Hook, PreRun, RuntimeParams};
 use capsula_core::run::PreparedRun;
 use serde_json::json;
+use std::fs;
 use std::path::PathBuf;
 use ulid::Ulid;
 
@@ -193,4 +194,24 @@ fn command_hook_rejects_conflicting_status_policy() {
         result.is_err(),
         "success_codes and abort_on_failure should not be combined"
     );
+}
+
+#[test]
+fn command_hook_rejects_cwd_that_escapes_project_root() {
+    let parent = std::env::temp_dir().join(format!("capsula_command_test_{}", Ulid::new()));
+    let project_root = parent.join("project");
+    let outside = parent.join("outside");
+    fs::create_dir_all(&project_root).unwrap();
+    fs::create_dir_all(&outside).unwrap();
+
+    let config = json!({
+        "command": ["true"],
+        "cwd": "../outside"
+    });
+
+    let result = <CommandHook as Hook<PreRun>>::from_config(&config, &project_root);
+
+    assert!(result.is_err(), "cwd must stay within the project root");
+
+    fs::remove_dir_all(parent).ok();
 }

--- a/crates/capsula-capture-git-repo/src/lib.rs
+++ b/crates/capsula-capture-git-repo/src/lib.rs
@@ -4,6 +4,7 @@ use crate::error::GitHookError;
 use capsula_core::captured::Captured;
 use capsula_core::error::CapsulaResult;
 use capsula_core::hook::{Hook, HookOutcome, PhaseMarker, RuntimeParams};
+use capsula_core::project_path::ResolvedProjectPath;
 use capsula_core::run::PreparedRun;
 use git2::Repository;
 use serde::{Deserialize, Serialize};
@@ -36,7 +37,7 @@ pub struct GitHookConfig {
 #[derive(Debug)]
 pub struct GitHook {
     config: GitHookConfig,
-    working_dir: PathBuf,
+    working_dir: ResolvedProjectPath,
 }
 
 #[derive(Debug, Serialize)]
@@ -69,7 +70,7 @@ where
     ) -> CapsulaResult<Self> {
         let config: GitHookConfig = serde_json::from_value(config.clone())?;
 
-        let working_dir = capsula_core::util::resolve_relative(&config.path, project_root)?;
+        let working_dir = ResolvedProjectPath::resolve_existing(&config.path, project_root)?;
 
         Ok(Self {
             config,
@@ -91,17 +92,13 @@ where
         metadata: &PreparedRun,
         params: &RuntimeParams<P>,
     ) -> CapsulaResult<HookOutcome<Self::Output>> {
-        let repo_path = if self.working_dir.as_os_str().is_empty() {
-            std::env::current_dir()?
-        } else {
-            self.working_dir.clone()
-        };
+        let repo_path = self.working_dir.as_path();
 
         debug!(
             "GitHook: Discovering repository at: {}",
             repo_path.display()
         );
-        let repo = Repository::discover(&repo_path).map_err(|e| {
+        let repo = Repository::discover(repo_path).map_err(|e| {
             if e.code() == git2::ErrorCode::NotFound {
                 GitHookError::NotARepository
             } else {
@@ -177,7 +174,7 @@ where
         };
 
         let captured = GitCaptured {
-            working_dir: repo_path,
+            working_dir: repo_path.to_path_buf(),
             sha: oid.to_string(),
             is_dirty,
             is_pushed,

--- a/crates/capsula-capture-git-repo/tests/git_hook.rs
+++ b/crates/capsula-capture-git-repo/tests/git_hook.rs
@@ -180,6 +180,29 @@ fn push_to_remote(working_dir: &std::path::Path, remote_name: &str) {
 }
 
 #[test]
+fn git_hook_rejects_path_that_escapes_project_root() {
+    let parent = std::env::temp_dir().join(format!("capsula_git_test_{}", Ulid::new()));
+    let project_root = parent.join("project");
+    let outside = parent.join("outside");
+    fs::create_dir_all(&project_root).unwrap();
+    fs::create_dir_all(&outside).unwrap();
+
+    let config = json!({
+        "name": "escaped-repo",
+        "path": "../outside"
+    });
+
+    let result = <GitHook as Hook<PreRun>>::from_config(&config, &project_root);
+
+    assert!(
+        result.is_err(),
+        "git path must stay within the project root"
+    );
+
+    fs::remove_dir_all(parent).ok();
+}
+
+#[test]
 fn git_hook_detects_pushed_commit() {
     // Arrange
     let temp_dir = init_git_repo();

--- a/crates/capsula-core/src/error.rs
+++ b/crates/capsula-core/src/error.rs
@@ -18,6 +18,10 @@ pub enum CapsulaError {
     #[error("Serialization failed: {0}")]
     Serialization(#[from] serde_json::Error),
 
+    /// Project-root-aware path resolution failed
+    #[error(transparent)]
+    ProjectPath(#[from] crate::project_path::ProjectPathError),
+
     /// Configuration-related error
     #[error("Configuration error: {message}")]
     Configuration { message: String },

--- a/crates/capsula-core/src/lib.rs
+++ b/crates/capsula-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod captured;
 pub mod error;
 pub mod hook;
+pub mod project_path;
 pub mod run;
 pub mod util;

--- a/crates/capsula-core/src/project_path.rs
+++ b/crates/capsula-core/src/project_path.rs
@@ -1,0 +1,256 @@
+//! Project-root-aware path resolution.
+//!
+//! Capsula configuration commonly accepts paths that may be absolute or
+//! relative to the project root. This module exposes an invariant-carrying
+//! resolved path type: constructing a [`ResolvedProjectPath`] canonicalizes both
+//! the project root and the target path, resolves symlinks consistently, and
+//! rejects targets outside the project root.
+
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+/// Errors that can occur while resolving a project-root-aware path.
+#[derive(Debug, Error)]
+pub enum ProjectPathError {
+    /// The configured project root could not be canonicalized.
+    #[error("failed to resolve project root '{project_root}': {source}")]
+    ProjectRootCanonicalize {
+        /// The project root supplied by the caller.
+        project_root: PathBuf,
+        /// The underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The configured path could not be canonicalized after joining it to the
+    /// project root when needed.
+    #[error(
+        "failed to resolve project path '{input}' as '{resolved}' under project root '{project_root}': {source}"
+    )]
+    PathCanonicalize {
+        /// The original path from configuration.
+        input: PathBuf,
+        /// The path attempted after applying project-root-relative semantics.
+        resolved: PathBuf,
+        /// The canonicalized project root.
+        project_root: PathBuf,
+        /// The underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The canonical target is outside the canonical project root.
+    #[error(
+        "project path '{input}' resolved to '{resolved}', outside project root '{project_root}'"
+    )]
+    EscapesProjectRoot {
+        /// The original path from configuration.
+        input: PathBuf,
+        /// The canonical path that escaped the project root.
+        resolved: PathBuf,
+        /// The canonicalized project root.
+        project_root: PathBuf,
+    },
+}
+
+/// A canonicalized path that has been proven to be inside a canonical project
+/// root.
+///
+/// Fields are private, and the only public constructor is
+/// [`ResolvedProjectPath::resolve_existing`], so every value of this type is
+/// canonicalized and contained within its canonical project root.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ResolvedProjectPath {
+    path: PathBuf,
+    project_root: PathBuf,
+}
+
+impl ResolvedProjectPath {
+    /// Resolve `path` against `project_root`, canonicalize it, and require the
+    /// result to stay inside the canonical project root.
+    ///
+    /// Relative paths are resolved from `project_root`. Absolute paths are also
+    /// canonicalized and must still point inside `project_root`. The target path
+    /// must exist because canonicalization resolves symlinks.
+    pub fn resolve_existing(path: &Path, project_root: &Path) -> Result<Self, ProjectPathError> {
+        let canonical_root = project_root.canonicalize().map_err(|source| {
+            ProjectPathError::ProjectRootCanonicalize {
+                project_root: project_root.to_path_buf(),
+                source,
+            }
+        })?;
+        let joined = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            canonical_root.join(path)
+        };
+        let resolved =
+            joined
+                .canonicalize()
+                .map_err(|source| ProjectPathError::PathCanonicalize {
+                    input: path.to_path_buf(),
+                    resolved: joined,
+                    project_root: canonical_root.clone(),
+                    source,
+                })?;
+
+        if resolved.starts_with(&canonical_root) {
+            Ok(Self {
+                path: resolved,
+                project_root: canonical_root,
+            })
+        } else {
+            Err(ProjectPathError::EscapesProjectRoot {
+                input: path.to_path_buf(),
+                resolved,
+                project_root: canonical_root,
+            })
+        }
+    }
+
+    /// Return the canonicalized path.
+    #[must_use]
+    pub fn as_path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Return the canonicalized project root used for containment.
+    #[must_use]
+    pub fn project_root(&self) -> &Path {
+        &self.project_root
+    }
+
+    /// Clone the canonicalized path into a [`PathBuf`].
+    #[must_use]
+    pub fn to_path_buf(&self) -> PathBuf {
+        self.path.clone()
+    }
+
+    /// Consume this value and return the canonicalized path.
+    #[must_use]
+    pub fn into_path_buf(self) -> PathBuf {
+        self.path
+    }
+}
+
+impl AsRef<Path> for ResolvedProjectPath {
+    fn as_ref(&self) -> &Path {
+        self.as_path()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ProjectPathError, ResolvedProjectPath};
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use ulid::Ulid;
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let path =
+            std::env::temp_dir().join(format!("capsula_project_path_{name}_{}", Ulid::new()));
+        fs::create_dir_all(&path).expect("temp dir should be created");
+        path
+    }
+
+    #[test]
+    fn resolves_relative_path_inside_project_root() {
+        let root = temp_dir("relative");
+        let nested = root.join("nested");
+        fs::create_dir(&nested).expect("nested dir should be created");
+
+        let resolved = ResolvedProjectPath::resolve_existing(Path::new("nested"), &root)
+            .expect("path should resolve");
+
+        assert_eq!(resolved.as_path(), nested.canonicalize().unwrap());
+        assert_eq!(resolved.project_root(), root.canonicalize().unwrap());
+
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn canonicalizes_absolute_path_inside_project_root() {
+        let root = temp_dir("absolute");
+        let nested = root.join("nested");
+        fs::create_dir(&nested).expect("nested dir should be created");
+
+        let resolved = ResolvedProjectPath::resolve_existing(&nested, &root)
+            .expect("absolute in-project path should resolve");
+
+        assert_eq!(resolved.as_path(), nested.canonicalize().unwrap());
+
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn rejects_relative_path_that_escapes_project_root() {
+        let parent = temp_dir("relative_escape");
+        let root = parent.join("project");
+        let outside = parent.join("outside");
+        fs::create_dir(&root).expect("project dir should be created");
+        fs::create_dir(&outside).expect("outside dir should be created");
+
+        let result = ResolvedProjectPath::resolve_existing(Path::new("../outside"), &root);
+
+        assert!(matches!(
+            result,
+            Err(ProjectPathError::EscapesProjectRoot { .. })
+        ));
+
+        fs::remove_dir_all(parent).ok();
+    }
+
+    #[test]
+    fn rejects_absolute_path_outside_project_root() {
+        let parent = temp_dir("absolute_escape");
+        let root = parent.join("project");
+        let outside = parent.join("outside");
+        fs::create_dir(&root).expect("project dir should be created");
+        fs::create_dir(&outside).expect("outside dir should be created");
+
+        let result = ResolvedProjectPath::resolve_existing(&outside, &root);
+
+        assert!(matches!(
+            result,
+            Err(ProjectPathError::EscapesProjectRoot { .. })
+        ));
+
+        fs::remove_dir_all(parent).ok();
+    }
+
+    #[test]
+    fn rejects_missing_path() {
+        let root = temp_dir("missing");
+
+        let result = ResolvedProjectPath::resolve_existing(Path::new("missing"), &root);
+
+        assert!(matches!(
+            result,
+            Err(ProjectPathError::PathCanonicalize { .. })
+        ));
+
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlink_that_escapes_project_root() {
+        use std::os::unix::fs::symlink;
+
+        let parent = temp_dir("symlink_escape");
+        let root = parent.join("project");
+        let outside = parent.join("outside");
+        fs::create_dir(&root).expect("project dir should be created");
+        fs::create_dir(&outside).expect("outside dir should be created");
+        symlink(&outside, root.join("link")).expect("symlink should be created");
+
+        let result = ResolvedProjectPath::resolve_existing(Path::new("link"), &root);
+
+        assert!(matches!(
+            result,
+            Err(ProjectPathError::EscapesProjectRoot { .. })
+        ));
+
+        fs::remove_dir_all(parent).ok();
+    }
+}

--- a/crates/capsula-core/src/util.rs
+++ b/crates/capsula-core/src/util.rs
@@ -1,5 +1,6 @@
 //! Small pure-helper utilities shared across Capsula crates.
 
+use crate::project_path::ResolvedProjectPath;
 use std::path::{Path, PathBuf};
 
 /// Encode bytes as a lowercase hexadecimal string.
@@ -16,14 +17,13 @@ pub fn hex_encode(bytes: &[u8]) -> String {
 
 /// Resolve a path that may be absolute or relative to `project_root`.
 ///
-/// For absolute paths, returns a clone. For relative paths, joins against
-/// `project_root` and canonicalizes (which requires the path to exist).
+/// Both absolute and relative paths are canonicalized, and the result must stay
+/// within the canonical project root. Prefer using [`ResolvedProjectPath`] when
+/// the containment invariant matters beyond a single helper call.
 pub fn resolve_relative(path: &Path, project_root: &Path) -> std::io::Result<PathBuf> {
-    if path.is_absolute() {
-        Ok(path.to_path_buf())
-    } else {
-        project_root.join(path).canonicalize()
-    }
+    ResolvedProjectPath::resolve_existing(path, project_root)
+        .map(ResolvedProjectPath::into_path_buf)
+        .map_err(std::io::Error::other)
 }
 
 #[cfg(test)]
@@ -44,10 +44,10 @@ mod tests {
     }
 
     #[test]
-    fn resolve_relative_passes_absolute_through() {
-        let abs = Path::new("/does/not/exist/absolute");
-        let resolved = resolve_relative(abs, Path::new("/tmp")).unwrap();
-        assert_eq!(resolved, abs);
+    fn resolve_relative_canonicalizes_absolute_path_inside_project() {
+        let cwd = std::env::current_dir().unwrap();
+        let resolved = resolve_relative(&cwd, &cwd).unwrap();
+        assert_eq!(resolved, cwd.canonicalize().unwrap());
     }
 
     #[test]
@@ -57,5 +57,16 @@ mod tests {
         let resolved = resolve_relative(Path::new("."), &cwd).unwrap();
         // canonicalize resolves symlinks; on macOS this is /private/var/... etc.
         assert_eq!(resolved, cwd.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn resolve_relative_rejects_absolute_path_outside_project() {
+        let cwd = std::env::current_dir().unwrap();
+        let outside = cwd.parent().unwrap_or(&cwd);
+
+        if outside != cwd {
+            let result = resolve_relative(outside, &cwd);
+            assert!(result.is_err());
+        }
     }
 }


### PR DESCRIPTION
## Summary
- introduce ProjectRelativePath and ResolvedProjectPath for canonical, project-contained path resolution
- use it for capture-command cwd and capture-git-repo path configs
- update resolve_relative and tests for absolute/relative escape/symlink cases

## Testing
- just test
- just lint

Closes #575

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #1147
- <kbd>&nbsp;3&nbsp;</kbd> #1146
- <kbd>&nbsp;2&nbsp;</kbd> #1098 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #1097
<!-- GitButler Footer Boundary Bottom -->