### PR TITLE
feat(server): expose hook_index in run responses; split HookOutput type

### DIFF
--- a/.sqlx/query-1e54e49fa797e511e692dae725f2502e4e7d9dee34775f414934202bd9e8f1fa.json
+++ b/.sqlx/query-1e54e49fa797e511e692dae725f2502e4e7d9dee34775f414934202bd9e8f1fa.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT phase, hook_id, config, output, success, error\n        FROM run_outputs\n        WHERE run_id = $1\n        ORDER BY id\n        ",
+  "query": "\n                SELECT phase, hook_index, hook_id, config, output, success, error\n                FROM run_outputs\n                WHERE run_id = $1\n                ORDER BY phase, hook_index\n                ",
   "describe": {
     "columns": [
       {
@@ -16,6 +16,17 @@
       },
       {
         "ordinal": 1,
+        "name": "hook_index",
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "run_outputs",
+            "name": "hook_index"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
         "name": "hook_id",
         "type_info": "Text",
         "origin": {
@@ -26,7 +37,7 @@
         }
       },
       {
-        "ordinal": 2,
+        "ordinal": 3,
         "name": "config",
         "type_info": "Jsonb",
         "origin": {
@@ -37,7 +48,7 @@
         }
       },
       {
-        "ordinal": 3,
+        "ordinal": 4,
         "name": "output",
         "type_info": "Jsonb",
         "origin": {
@@ -48,7 +59,7 @@
         }
       },
       {
-        "ordinal": 4,
+        "ordinal": 5,
         "name": "success",
         "type_info": "Bool",
         "origin": {
@@ -59,7 +70,7 @@
         }
       },
       {
-        "ordinal": 5,
+        "ordinal": 6,
         "name": "error",
         "type_info": "Text",
         "origin": {
@@ -78,11 +89,12 @@
     "nullable": [
       false,
       false,
+      false,
       true,
       false,
       false,
       true
     ]
   },
-  "hash": "dde3c4130e0eb80838ebd1816e71d7d389cbe1768b2b38ceafb1f9d44f77eb39"
+  "hash": "1e54e49fa797e511e692dae725f2502e4e7d9dee34775f414934202bd9e8f1fa"
 }

--- a/.sqlx/query-b1ece1b6141fe63368ca2e17260e3713de69cadab68813f375aa028d307fd509.json
+++ b/.sqlx/query-b1ece1b6141fe63368ca2e17260e3713de69cadab68813f375aa028d307fd509.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                SELECT phase, hook_id, config, output, success, error\n                FROM run_outputs\n                WHERE run_id = $1\n                ORDER BY id\n                ",
+  "query": "\n        SELECT phase, hook_index, hook_id, config, output, success, error\n        FROM run_outputs\n        WHERE run_id = $1\n        ORDER BY phase, hook_index\n        ",
   "describe": {
     "columns": [
       {
@@ -16,6 +16,17 @@
       },
       {
         "ordinal": 1,
+        "name": "hook_index",
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "run_outputs",
+            "name": "hook_index"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
         "name": "hook_id",
         "type_info": "Text",
         "origin": {
@@ -26,7 +37,7 @@
         }
       },
       {
-        "ordinal": 2,
+        "ordinal": 3,
         "name": "config",
         "type_info": "Jsonb",
         "origin": {
@@ -37,7 +48,7 @@
         }
       },
       {
-        "ordinal": 3,
+        "ordinal": 4,
         "name": "output",
         "type_info": "Jsonb",
         "origin": {
@@ -48,7 +59,7 @@
         }
       },
       {
-        "ordinal": 4,
+        "ordinal": 5,
         "name": "success",
         "type_info": "Bool",
         "origin": {
@@ -59,7 +70,7 @@
         }
       },
       {
-        "ordinal": 5,
+        "ordinal": 6,
         "name": "error",
         "type_info": "Text",
         "origin": {
@@ -78,11 +89,12 @@
     "nullable": [
       false,
       false,
+      false,
       true,
       false,
       false,
       true
     ]
   },
-  "hash": "0f041bcff67becde780d8f50cd520ce827c65019c919c96f3bc748818b962057"
+  "hash": "b1ece1b6141fe63368ca2e17260e3713de69cadab68813f375aa028d307fd509"
 }

--- a/crates/capsula-server/src/lib.rs
+++ b/crates/capsula-server/src/lib.rs
@@ -105,8 +105,8 @@ struct RunsTemplate {
 #[template(path = "run_detail.html")]
 struct RunDetailTemplate {
     run: models::Run,
-    pre_run_hooks: Vec<models::HookOutput>,
-    post_run_hooks: Vec<models::HookOutput>,
+    pre_run_hooks: Vec<models::HookOutputQueried>,
+    post_run_hooks: Vec<models::HookOutputQueried>,
     files: Vec<models::CapturedFile>,
 }
 
@@ -376,10 +376,10 @@ async fn run_detail_page(
     let hook_outputs_result = sqlx::query_as!(
         models::RunOutputRow,
         r#"
-        SELECT phase, hook_id, config, output, success, error
+        SELECT phase, hook_index, hook_id, config, output, success, error
         FROM run_outputs
         WHERE run_id = $1
-        ORDER BY id
+        ORDER BY phase, hook_index
         "#,
         id
     )
@@ -392,12 +392,13 @@ async fn run_detail_page(
             let mut post_hooks = Vec::new();
 
             for row in rows {
-                let hook_output = models::HookOutput {
-                    meta: models::HookMeta {
+                let hook_output = models::HookOutputQueried {
+                    meta: models::HookMetaQueried {
                         id: row.hook_id,
                         config: row.config,
                         success: row.success,
                         error: row.error,
+                        hook_index: row.hook_index,
                     },
                     output: row.output,
                 };
@@ -697,8 +698,8 @@ async fn search_runs(
 
         let (pre_run_hooks, post_run_hooks) = if include_hooks {
             match sqlx::query_as::<_, models::RunOutputRow>(
-                "SELECT phase, hook_id, config, output, success, error \
-                 FROM run_outputs WHERE run_id = $1 ORDER BY id",
+                "SELECT phase, hook_index, hook_id, config, output, success, error \
+                 FROM run_outputs WHERE run_id = $1 ORDER BY phase, hook_index",
             )
             .bind(&run.id)
             .fetch_all(&state.pool)
@@ -708,12 +709,13 @@ async fn search_runs(
                     let mut pre_hooks = Vec::new();
                     let mut post_hooks = Vec::new();
                     for row in rows {
-                        let hook_output = models::HookOutput {
-                            meta: models::HookMeta {
+                        let hook_output = models::HookOutputQueried {
+                            meta: models::HookMetaQueried {
                                 id: row.hook_id,
                                 config: row.config,
                                 success: row.success,
                                 error: row.error,
+                                hook_index: row.hook_index,
                             },
                             output: row.output,
                         };
@@ -834,10 +836,10 @@ async fn get_run(State(state): State<AppState>, Path(id): Path<String>) -> impl 
             let hook_outputs_result = sqlx::query_as!(
                 models::RunOutputRow,
                 r#"
-                SELECT phase, hook_id, config, output, success, error
+                SELECT phase, hook_index, hook_id, config, output, success, error
                 FROM run_outputs
                 WHERE run_id = $1
-                ORDER BY id
+                ORDER BY phase, hook_index
                 "#,
                 id
             )
@@ -850,12 +852,13 @@ async fn get_run(State(state): State<AppState>, Path(id): Path<String>) -> impl 
                     let mut post_hooks = Vec::new();
 
                     for row in rows {
-                        let hook_output = models::HookOutput {
-                            meta: models::HookMeta {
+                        let hook_output = models::HookOutputQueried {
+                            meta: models::HookMetaQueried {
                                 id: row.hook_id,
                                 config: row.config,
                                 success: row.success,
                                 error: row.error,
+                                hook_index: row.hook_index,
                             },
                             output: row.output,
                         };
@@ -934,8 +937,8 @@ async fn upload_files(
     let mut total_bytes = 0u64;
     let mut run_id: Option<String> = None;
     let mut pending_paths: VecDeque<String> = VecDeque::new();
-    let mut pre_run_hooks: Option<Vec<models::HookOutput>> = None;
-    let mut post_run_hooks: Option<Vec<models::HookOutput>> = None;
+    let mut pre_run_hooks: Option<Vec<models::HookOutputUploaded>> = None;
+    let mut post_run_hooks: Option<Vec<models::HookOutputUploaded>> = None;
 
     while let Ok(Some(field)) = multipart.next_field().await {
         let field_name = field.name().unwrap_or("unknown").to_string();
@@ -970,7 +973,7 @@ async fn upload_files(
             }
         } else if field_name == "pre_run" {
             match field.text().await {
-                Ok(text) => match serde_json::from_str::<Vec<models::HookOutput>>(&text) {
+                Ok(text) => match serde_json::from_str::<Vec<models::HookOutputUploaded>>(&text) {
                     Ok(hooks) => {
                         info!("Parsed {} pre-run hooks", hooks.len());
                         pre_run_hooks = Some(hooks);
@@ -994,7 +997,7 @@ async fn upload_files(
             }
         } else if field_name == "post_run" {
             match field.text().await {
-                Ok(text) => match serde_json::from_str::<Vec<models::HookOutput>>(&text) {
+                Ok(text) => match serde_json::from_str::<Vec<models::HookOutputUploaded>>(&text) {
                     Ok(hooks) => {
                         info!("Parsed {} post-run hooks", hooks.len());
                         post_run_hooks = Some(hooks);

--- a/crates/capsula-server/src/lib.rs
+++ b/crates/capsula-server/src/lib.rs
@@ -105,8 +105,8 @@ struct RunsTemplate {
 #[template(path = "run_detail.html")]
 struct RunDetailTemplate {
     run: models::Run,
-    pre_run_hooks: Vec<models::HookOutputQueried>,
-    post_run_hooks: Vec<models::HookOutputQueried>,
+    pre_run_hooks: Vec<models::HookOutputResponse>,
+    post_run_hooks: Vec<models::HookOutputResponse>,
     files: Vec<models::CapturedFile>,
 }
 
@@ -392,7 +392,7 @@ async fn run_detail_page(
             let mut post_hooks = Vec::new();
 
             for row in rows {
-                let hook_output = models::HookOutputQueried {
+                let hook_output = models::HookOutputResponse {
                     meta: models::HookMetaQueried {
                         id: row.hook_id,
                         config: row.config,
@@ -709,7 +709,7 @@ async fn search_runs(
                     let mut pre_hooks = Vec::new();
                     let mut post_hooks = Vec::new();
                     for row in rows {
-                        let hook_output = models::HookOutputQueried {
+                        let hook_output = models::HookOutputResponse {
                             meta: models::HookMetaQueried {
                                 id: row.hook_id,
                                 config: row.config,
@@ -852,7 +852,7 @@ async fn get_run(State(state): State<AppState>, Path(id): Path<String>) -> impl 
                     let mut post_hooks = Vec::new();
 
                     for row in rows {
-                        let hook_output = models::HookOutputQueried {
+                        let hook_output = models::HookOutputResponse {
                             meta: models::HookMetaQueried {
                                 id: row.hook_id,
                                 config: row.config,

--- a/crates/capsula-server/src/lib.rs
+++ b/crates/capsula-server/src/lib.rs
@@ -393,7 +393,7 @@ async fn run_detail_page(
 
             for row in rows {
                 let hook_output = models::HookOutputResponse {
-                    meta: models::HookMetaQueried {
+                    meta: models::HookMetaResponse {
                         id: row.hook_id,
                         config: row.config,
                         success: row.success,
@@ -710,7 +710,7 @@ async fn search_runs(
                     let mut post_hooks = Vec::new();
                     for row in rows {
                         let hook_output = models::HookOutputResponse {
-                            meta: models::HookMetaQueried {
+                            meta: models::HookMetaResponse {
                                 id: row.hook_id,
                                 config: row.config,
                                 success: row.success,
@@ -853,7 +853,7 @@ async fn get_run(State(state): State<AppState>, Path(id): Path<String>) -> impl 
 
                     for row in rows {
                         let hook_output = models::HookOutputResponse {
-                            meta: models::HookMetaQueried {
+                            meta: models::HookMetaResponse {
                                 id: row.hook_id,
                                 config: row.config,
                                 success: row.success,

--- a/crates/capsula-server/src/lib.rs
+++ b/crates/capsula-server/src/lib.rs
@@ -937,8 +937,8 @@ async fn upload_files(
     let mut total_bytes = 0u64;
     let mut run_id: Option<String> = None;
     let mut pending_paths: VecDeque<String> = VecDeque::new();
-    let mut pre_run_hooks: Option<Vec<models::HookOutputUploaded>> = None;
-    let mut post_run_hooks: Option<Vec<models::HookOutputUploaded>> = None;
+    let mut pre_run_hooks: Option<Vec<models::HookOutputUpload>> = None;
+    let mut post_run_hooks: Option<Vec<models::HookOutputUpload>> = None;
 
     while let Ok(Some(field)) = multipart.next_field().await {
         let field_name = field.name().unwrap_or("unknown").to_string();
@@ -973,7 +973,7 @@ async fn upload_files(
             }
         } else if field_name == "pre_run" {
             match field.text().await {
-                Ok(text) => match serde_json::from_str::<Vec<models::HookOutputUploaded>>(&text) {
+                Ok(text) => match serde_json::from_str::<Vec<models::HookOutputUpload>>(&text) {
                     Ok(hooks) => {
                         info!("Parsed {} pre-run hooks", hooks.len());
                         pre_run_hooks = Some(hooks);
@@ -997,7 +997,7 @@ async fn upload_files(
             }
         } else if field_name == "post_run" {
             match field.text().await {
-                Ok(text) => match serde_json::from_str::<Vec<models::HookOutputUploaded>>(&text) {
+                Ok(text) => match serde_json::from_str::<Vec<models::HookOutputUpload>>(&text) {
                     Ok(hooks) => {
                         info!("Parsed {} post-run hooks", hooks.len());
                         post_run_hooks = Some(hooks);

--- a/crates/capsula-server/src/models.rs
+++ b/crates/capsula-server/src/models.rs
@@ -48,13 +48,13 @@ pub struct ListRunsQuery {
 #[derive(Debug, Deserialize)]
 pub struct HookOutputUpload {
     #[serde(rename = "__meta")]
-    pub meta: HookMetaUploaded,
+    pub meta: HookMetaUpload,
     #[serde(flatten)]
     pub output: JsonValue,
 }
 
 #[derive(Debug, Deserialize)]
-pub struct HookMetaUploaded {
+pub struct HookMetaUpload {
     pub id: String,
     pub config: Option<JsonValue>,
     pub success: bool,
@@ -70,13 +70,13 @@ pub struct HookMetaUploaded {
 #[derive(Debug, Serialize)]
 pub struct HookOutputResponse {
     #[serde(rename = "__meta")]
-    pub meta: HookMetaQueried,
+    pub meta: HookMetaResponse,
     #[serde(flatten)]
     pub output: JsonValue,
 }
 
 #[derive(Debug, Serialize)]
-pub struct HookMetaQueried {
+pub struct HookMetaResponse {
     pub id: String,
     pub config: Option<JsonValue>,
     pub success: bool,

--- a/crates/capsula-server/src/models.rs
+++ b/crates/capsula-server/src/models.rs
@@ -43,7 +43,7 @@ pub struct ListRunsQuery {
 ///
 /// The uploaded variant does not carry a `hook_index` because the server
 /// authoritatively assigns positions from each phase's array on receipt
-/// (via `.enumerate()`). See [`HookOutputQueried`] for the outbound
+/// (via `.enumerate()`). See [`HookOutputResponse`] for the outbound
 /// counterpart which does carry `hook_index`.
 #[derive(Debug, Deserialize)]
 pub struct HookOutputUploaded {
@@ -68,7 +68,7 @@ pub struct HookMetaUploaded {
 /// invocation of the same `hook_id`. See [`HookOutputUploaded`] for the
 /// inbound counterpart which omits it.
 #[derive(Debug, Serialize)]
-pub struct HookOutputQueried {
+pub struct HookOutputResponse {
     #[serde(rename = "__meta")]
     pub meta: HookMetaQueried,
     #[serde(flatten)]
@@ -189,9 +189,9 @@ pub struct SearchRunResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub files: Option<Vec<FileInfo>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub pre_run_hooks: Option<Vec<HookOutputQueried>>,
+    pub pre_run_hooks: Option<Vec<HookOutputResponse>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub post_run_hooks: Option<Vec<HookOutputQueried>>,
+    pub post_run_hooks: Option<Vec<HookOutputResponse>>,
 }
 
 /// File information in search results

--- a/crates/capsula-server/src/models.rs
+++ b/crates/capsula-server/src/models.rs
@@ -46,7 +46,7 @@ pub struct ListRunsQuery {
 /// (via `.enumerate()`). See [`HookOutputResponse`] for the outbound
 /// counterpart which does carry `hook_index`.
 #[derive(Debug, Deserialize)]
-pub struct HookOutputUploaded {
+pub struct HookOutputUpload {
     #[serde(rename = "__meta")]
     pub meta: HookMetaUploaded,
     #[serde(flatten)]
@@ -65,7 +65,7 @@ pub struct HookMetaUploaded {
 ///
 /// Includes `hook_index` — the position of this hook in capsula.toml's
 /// `pre_run` / `post_run` array — so clients can distinguish the Nth
-/// invocation of the same `hook_id`. See [`HookOutputUploaded`] for the
+/// invocation of the same `hook_id`. See [`HookOutputUpload`] for the
 /// inbound counterpart which omits it.
 #[derive(Debug, Serialize)]
 pub struct HookOutputResponse {

--- a/crates/capsula-server/src/models.rs
+++ b/crates/capsula-server/src/models.rs
@@ -39,25 +39,57 @@ pub struct ListRunsQuery {
     pub offset: Option<i64>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct HookOutput {
+/// A hook output as sent by the CLI to `POST /api/v1/upload`.
+///
+/// The uploaded variant does not carry a `hook_index` because the server
+/// authoritatively assigns positions from each phase's array on receipt
+/// (via `.enumerate()`). See [`HookOutputQueried`] for the outbound
+/// counterpart which does carry `hook_index`.
+#[derive(Debug, Deserialize)]
+pub struct HookOutputUploaded {
     #[serde(rename = "__meta")]
-    pub meta: HookMeta,
+    pub meta: HookMetaUploaded,
     #[serde(flatten)]
     pub output: JsonValue,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct HookMeta {
+#[derive(Debug, Deserialize)]
+pub struct HookMetaUploaded {
     pub id: String,
     pub config: Option<JsonValue>,
     pub success: bool,
     pub error: Option<String>,
 }
 
+/// A hook output as returned by the server in run-detail / search responses.
+///
+/// Includes `hook_index` — the position of this hook in capsula.toml's
+/// `pre_run` / `post_run` array — so clients can distinguish the Nth
+/// invocation of the same `hook_id`. See [`HookOutputUploaded`] for the
+/// inbound counterpart which omits it.
+#[derive(Debug, Serialize)]
+pub struct HookOutputQueried {
+    #[serde(rename = "__meta")]
+    pub meta: HookMetaQueried,
+    #[serde(flatten)]
+    pub output: JsonValue,
+}
+
+#[derive(Debug, Serialize)]
+pub struct HookMetaQueried {
+    pub id: String,
+    pub config: Option<JsonValue>,
+    pub success: bool,
+    pub error: Option<String>,
+    /// 0-based position of this hook in capsula.toml's `pre_run` /
+    /// `post_run` array, matching the DB `run_outputs.hook_index` column.
+    pub hook_index: i32,
+}
+
 #[derive(Debug, sqlx::FromRow)]
 pub struct RunOutputRow {
     pub phase: String,
+    pub hook_index: i32,
     pub hook_id: String,
     pub config: Option<JsonValue>,
     pub output: JsonValue,
@@ -157,9 +189,9 @@ pub struct SearchRunResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub files: Option<Vec<FileInfo>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub pre_run_hooks: Option<Vec<HookOutput>>,
+    pub pre_run_hooks: Option<Vec<HookOutputQueried>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub post_run_hooks: Option<Vec<HookOutput>>,
+    pub post_run_hooks: Option<Vec<HookOutputQueried>>,
 }
 
 /// File information in search results

--- a/crates/capsula-server/tests/api_tests.rs
+++ b/crates/capsula-server/tests/api_tests.rs
@@ -875,3 +875,102 @@ async fn re_upload_with_same_array_is_idempotent() {
         );
     }
 }
+
+#[tokio::test]
+async fn response_exposes_hook_index_and_preserves_array_order() {
+    // Verifies that each hook payload returned by GET /api/v1/runs/{id}
+    // carries its capsula.toml array position under __meta.hook_index,
+    // and that the response list is stably ordered by (phase, hook_index).
+    let ctx = TestContext::new().await;
+    let client = reqwest::Client::new();
+
+    let run_id = "01HKIDXORDER00000000000AA";
+    let response = client
+        .post(format!("{}/api/v1/runs", ctx.base_url()))
+        .json(&json!({
+            "id": run_id,
+            "name": "hook-index-order-test",
+            "timestamp": "2026-06-24T10:00:00Z",
+            "command": "test",
+            "vault": "hook-index-order",
+            "project_root": "/tmp/test",
+            "exit_code": 0,
+            "duration_ms": 100,
+            "stdout": null,
+            "stderr": null,
+        }))
+        .send()
+        .await
+        .expect("create run");
+    assert_eq!(response.status(), 201);
+
+    // Three hooks; positions 0 and 2 share hook_id "capture-command" so
+    // hook_index is the only thing that distinguishes them.
+    let pre_run_hooks = json!([
+        {
+            "__meta": {
+                "id": "capture-command",
+                "config": { "command": "echo first" },
+                "success": true,
+                "error": null
+            },
+            "stdout": "first"
+        },
+        {
+            "__meta": {
+                "id": "capture-json",
+                "config": { "path": "middle.json" },
+                "success": true,
+                "error": null
+            },
+            "content": { "n": 1 }
+        },
+        {
+            "__meta": {
+                "id": "capture-command",
+                "config": { "command": "echo second" },
+                "success": true,
+                "error": null
+            },
+            "stdout": "second"
+        }
+    ]);
+
+    let form = reqwest::multipart::Form::new()
+        .text("run_id", run_id.to_string())
+        .text("pre_run", pre_run_hooks.to_string());
+    let response = client
+        .post(format!("{}/api/v1/upload", ctx.base_url()))
+        .multipart(form)
+        .send()
+        .await
+        .expect("upload");
+    assert_eq!(response.status(), 200);
+
+    let response = client
+        .get(format!("{}/api/v1/runs/{run_id}", ctx.base_url()))
+        .send()
+        .await
+        .expect("get run");
+    assert_eq!(response.status(), 200);
+    let body: serde_json::Value = response.json().await.expect("parse body");
+    let pre = body["pre_run_hooks"]
+        .as_array()
+        .expect("pre_run_hooks array");
+    assert_eq!(pre.len(), 3);
+
+    // Ordering: hook_index must be 0, 1, 2 in that sequence.
+    let indices: Vec<i64> = pre
+        .iter()
+        .map(|h| h["__meta"]["hook_index"].as_i64().expect("hook_index"))
+        .collect();
+    assert_eq!(indices, vec![0, 1, 2]);
+
+    // Content-level ordering matches capsula.toml array order.
+    assert_eq!(pre[0]["__meta"]["id"], "capture-command");
+    assert_eq!(pre[0]["stdout"], "first");
+    assert_eq!(pre[1]["__meta"]["id"], "capture-json");
+    assert_eq!(pre[1]["content"]["n"], 1);
+    assert_eq!(pre[2]["__meta"]["id"], "capture-command");
+    assert_eq!(pre[2]["stdout"], "second");
+}


### PR DESCRIPTION
## Motivation

After #1036 landed the `hook_index` column on `run_outputs`, the DB knows which slot in `capsula.toml`'s `pre_run` / `post_run` array each hook came from — but the server didn't expose that to clients, and hooks came back in DB-default order. That means:

- Callers can't tell "1st `capture-command` vs 2nd `capture-command`" apart in the response.
- List order was implementation-defined, so any UI that renders hooks side-by-side had a subtle non-determinism.

## Approach

Split the previous dual-purpose `HookOutput` into two intent-named types:

| Type | Direction | serde | Has `hook_index`? |
|---|---|---|---|
| `HookOutputUploaded` / `HookMetaUploaded` | `POST /api/v1/upload` (from CLI) | `Deserialize` | No — server assigns via `.enumerate()` |
| `HookOutputQueried` / `HookMetaQueried` | GET run details, search hits | `Serialize` | Yes |

The upload type dropping `hook_index` is a small but nice invariant: the client cannot forge or omit an authoritative field, and the server side no longer needs a `#[serde(default)]` compat shim.

All three hook-fetching SELECTs now pull `hook_index` and use `ORDER BY phase, hook_index`, so the response list mirrors `capsula.toml`'s array order.

## Tests

New integration test `response_exposes_hook_index_and_preserves_array_order`:

- Uploads a 3-element `pre_run` array: `[capture-command, capture-json, capture-command]`.
- Fetches `GET /api/v1/runs/{id}`.
- Asserts `hooks[i].__meta.hook_index == [0, 1, 2]` and that content-level ordering (stdout / content payload) matches the sent array.

Existing regression tests (`test_hook_outputs_storage`, `multiple_hooks_with_distinct_configs_coexist`, `multiple_hooks_with_identical_configs_coexist`) continue to pass.

## Follow-ups

- **Python client (#974)**: needs a small mirror to include `hook_index: int` in its `HookMeta`. Will land as a separate PR.
- **Query-side hook_index filter (Layer B)**: adding `hook_index: Option<i32>` to `ParameterMatch` so "the Nth capture" can be pinned in queries. Separate PR on top of this one.

## Verification

- [x] `cargo test -p capsula-server --test api_tests response_exposes_hook_index_and_preserves_array_order` — new test passes
- [x] `cargo test -p capsula-server --test api_tests multiple_hooks` — 2/2 existing regressions pass
- [x] `cargo test -p capsula-server --test api_tests test_hook_outputs_storage` — existing hook storage test passes
- [x] `cargo clippy -p capsula-server --all-targets -- -D warnings`
- [x] `cargo fmt --check -p capsula-server`
- [x] `.sqlx/` offline cache regenerated and committed