### PR TITLE
Pin Rust toolchain for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,9 +22,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
-        with:
-          components: clippy, rustfmt
+      - name: Install Rust toolchain
+        run: rustup toolchain install --no-self-update
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo clippy --workspace --all-targets --all-features
       - run: cargo clippy --workspace --all-targets --no-default-features
@@ -57,9 +56,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
-        with:
-          components: llvm-tools-preview
+      - name: Install Rust toolchain
+        run: rustup toolchain install --no-self-update
+
+      - name: Install llvm-tools-preview
+        run: rustup component add llvm-tools-preview
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
@@ -110,7 +111,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+      - name: Install Rust toolchain
+        run: rustup toolchain install --no-self-update
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Install sqlx-cli
         run: cargo install sqlx-cli --no-default-features --features postgres
@@ -131,6 +133,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install --no-self-update
 
       - uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,9 @@ jobs:
         with:
           persist-credentials: true
 
+      - name: Install Rust toolchain
+        run: rustup toolchain install --no-self-update
+
       - name: Get the version
         id: get-version
         run: |
@@ -47,6 +50,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+      - name: Install Rust toolchain
+        run: rustup toolchain install --no-self-update
       - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: auth
       - run: cargo publish --workspace

--- a/renovate.json5
+++ b/renovate.json5
@@ -7,6 +7,11 @@
   },
   packageRules: [
     {
+      matchManagers: ["rust-toolchain"],
+      matchDepTypes: ["toolchain"],
+      addLabels: ["rust", "ci"],
+    },
+    {
       // Docker Hub provides a tag timestamp, but Renovate cannot reliably know
       // the true per-digest publish time. Wait until the minimumReleaseAge
       // stability check is no longer pending before opening Docker Hub digest PRs.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.96.1"
+profile = "default"


### PR DESCRIPTION
## Summary
- Pin Rust via rust-toolchain.toml with the default profile
- Install the pinned toolchain from rust-toolchain.toml in CI and release workflows
- Add a Renovate rule for Rust toolchain updates

## Tests
- just lint
- just test