### PR TITLE
Bump version to v0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,7 +537,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "capsula"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-api-types"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-capture-command"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "capsula-core",
  "serde",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-capture-cwd"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "capsula-core",
  "serde",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-capture-env"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "capsula-core",
  "serde",
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-capture-file"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "capsula-core",
  "glob",
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-capture-git-repo"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "capsula-core",
  "git2",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-capture-json"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "capsula-core",
  "serde",
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-capture-machine"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "capsula-core",
  "serde",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-capture-toml"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "capsula-core",
  "serde",
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-client"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "capsula-api-types",
  "reqwest",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-config"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "capsula-core",
  "capsula-registry",
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-core"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "clap",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-notify-slack"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "capsula-core",
  "glob",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-orchestration"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "capsula-client",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-registry"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "capsula-capture-command",
  "capsula-capture-cwd",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-server"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "askama",
  "askama_web",
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "capsula-tui"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "capsula-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,12 @@
+#:tombi toml-version = "v1.0.0"
+
 [workspace]
 resolver = "3"
 members = ["crates/*"]
 default-members = ["crates/capsula-cli"]
 
 [workspace.package]
-version = "0.12.1"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.95"
 readme = "README.md"
@@ -16,22 +18,22 @@ anyhow = "1"
 askama = "0.16"
 askama_web = { version = "0.16", features = ["axum-0.8"] }
 axum = { version = "0.8", features = ["multipart"] }
-capsula-api-types = { path = "crates/capsula-api-types", version = "0.12.1" }
-capsula-capture-command = { path = "crates/capsula-capture-command", version = "0.12.1" }
-capsula-capture-cwd = { path = "crates/capsula-capture-cwd", version = "0.12.1" }
-capsula-capture-env = { path = "crates/capsula-capture-env", version = "0.12.1" }
-capsula-capture-file = { path = "crates/capsula-capture-file", version = "0.12.1" }
-capsula-capture-git-repo = { path = "crates/capsula-capture-git-repo", version = "0.12.1" }
-capsula-capture-json = { path = "crates/capsula-capture-json", version = "0.12.1" }
-capsula-capture-machine = { path = "crates/capsula-capture-machine", version = "0.12.1" }
-capsula-capture-toml = { path = "crates/capsula-capture-toml", version = "0.12.1" }
-capsula-client = { path = "crates/capsula-client", version = "0.12.1" }
-capsula-config = { path = "crates/capsula-config", version = "0.12.1" }
-capsula-core = { path = "crates/capsula-core", version = "0.12.1" }
-capsula-notify-slack = { path = "crates/capsula-notify-slack", version = "0.12.1" }
-capsula-orchestration = { path = "crates/capsula-orchestration", version = "0.12.1" }
-capsula-registry = { path = "crates/capsula-registry", version = "0.12.1" }
-capsula-tui = { path = "crates/capsula-tui", version = "0.12.1" }
+capsula-api-types = { path = "crates/capsula-api-types", version = "0.13.0" }
+capsula-capture-command = { path = "crates/capsula-capture-command", version = "0.13.0" }
+capsula-capture-cwd = { path = "crates/capsula-capture-cwd", version = "0.13.0" }
+capsula-capture-env = { path = "crates/capsula-capture-env", version = "0.13.0" }
+capsula-capture-file = { path = "crates/capsula-capture-file", version = "0.13.0" }
+capsula-capture-git-repo = { path = "crates/capsula-capture-git-repo", version = "0.13.0" }
+capsula-capture-json = { path = "crates/capsula-capture-json", version = "0.13.0" }
+capsula-capture-machine = { path = "crates/capsula-capture-machine", version = "0.13.0" }
+capsula-capture-toml = { path = "crates/capsula-capture-toml", version = "0.13.0" }
+capsula-client = { path = "crates/capsula-client", version = "0.13.0" }
+capsula-config = { path = "crates/capsula-config", version = "0.13.0" }
+capsula-core = { path = "crates/capsula-core", version = "0.13.0" }
+capsula-notify-slack = { path = "crates/capsula-notify-slack", version = "0.13.0" }
+capsula-orchestration = { path = "crates/capsula-orchestration", version = "0.13.0" }
+capsula-registry = { path = "crates/capsula-registry", version = "0.13.0" }
+capsula-tui = { path = "crates/capsula-tui", version = "0.13.0" }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive", "env"] }
 crossterm = "0.29"


### PR DESCRIPTION
This PR bumps the version from v0.12.1 to v0.13.0.

## PRs since the previous release (excluding Renovate PRs)

### Breaking changes

- #964
- #1094

### New hooks

- #1018
- #1016

### Bug fix

- #1036
- #1092
- #1095

### Improvements

- #1096
- #1099
- #1102

### Internal changes

- #965
- #968
- #1009
- #1012
- #1025
- #1031
- #1032
- #1043
- #1060
- #1101
- #1108
- #1129