### PR TITLE
Exclude bootstrapped crates from v0.13.0 release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,7 +54,13 @@ jobs:
         run: rustup toolchain install --no-self-update
       - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: auth
-      - run: cargo publish --workspace
+      # These crates were published manually to bootstrap trusted publishing for this release.
+      # Remove the exclusions after this release so future versions publish with the workspace.
+      - run: >-
+          cargo publish --workspace --locked
+          --exclude capsula-core
+          --exclude capsula-capture-json
+          --exclude capsula-capture-toml
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 


### PR DESCRIPTION
> [!WARNING]
> This change is temporary and will be reverted after the v0.13.0 release.

## Summary
- exclude `capsula-core`, `capsula-capture-json`, and `capsula-capture-toml` because their v0.13.0 releases were published manually to bootstrap trusted publishing
- publish the remaining workspace crates with the lockfile enforced
- document that the exclusions should be removed after this release

## Verification
- `just lint`
- `just test`