### PR TITLE
Restore full workspace publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,13 +54,7 @@ jobs:
         run: rustup toolchain install --no-self-update
       - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: auth
-      # These crates were published manually to bootstrap trusted publishing for this release.
-      # Remove the exclusions after this release so future versions publish with the workspace.
-      - run: >-
-          cargo publish --workspace --locked
-          --exclude capsula-core
-          --exclude capsula-capture-json
-          --exclude capsula-capture-toml
+      - run: cargo publish --workspace
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 


### PR DESCRIPTION
> [!NOTE]
> This reverts the temporary release-only changes from #1132 now that all v0.13.0 workspace crates have been published and trusted publishing is configured.

## Summary

- restore `cargo publish --workspace` for future releases
- remove the temporary exclusions for the manually bootstrapped crates
- remove `--locked`; adding it will be handled in a separate pull request

## Verification

- `just lint`
- `just test`