### PR TITLE
Add `--locked` flag to `cargo publish` in the release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,7 +54,7 @@ jobs:
         run: rustup toolchain install --no-self-update
       - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: auth
-      - run: cargo publish --workspace
+      - run: cargo publish --workspace --locked
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 


### PR DESCRIPTION
This PR adds `--locked` flag to `cargo publish` in the `release` GitHub Action workflow so that a stale `Cargo.lock` will be detected as an error.