### PR TITLE
Refactor internal APIs with Hawk

### DIFF
--- a/crates/capsula-api-types/src/lib.rs
+++ b/crates/capsula-api-types/src/lib.rs
@@ -52,12 +52,12 @@ pub struct ErrorResponse {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct HookFilter {
     /// The hook ID (e.g., "capture-git-repo", "capture-env")
-    pub hook_id: String,
+    hook_id: String,
     /// `JSONPath` expression to match against hook's config (optional)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub config_filter: Option<String>,
+    config_filter: Option<String>,
     /// `JSONPath` expression to match against hook's output
-    pub output_filter: String,
+    output_filter: String,
 }
 
 /// Fields that can be included in search response
@@ -85,42 +85,42 @@ pub enum SortOrder {
 pub struct SearchRunsRequest {
     /// Filter by vault name
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub vault: Option<String>,
+    vault: Option<String>,
     /// Filter runs from this timestamp (ISO 8601)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub from: Option<String>,
+    from: Option<String>,
     /// Filter runs until this timestamp (ISO 8601)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub to: Option<String>,
+    to: Option<String>,
     /// Filter by exact exit code
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub exit_code: Option<i32>,
+    exit_code: Option<i32>,
     /// Filter by success (`exit_code` = 0) or failure (`exit_code` != 0)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub success: Option<bool>,
+    success: Option<bool>,
     /// Hook output filters (AND logic)
     #[serde(default)]
-    pub hook_filters: Vec<HookFilter>,
+    hook_filters: Vec<HookFilter>,
     /// What to include in response
     #[serde(default)]
-    pub include: Vec<IncludeField>,
+    include: Vec<IncludeField>,
     /// Sort order
     #[serde(default)]
-    pub order: SortOrder,
+    order: SortOrder,
     /// Maximum number of results (default: 100)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub limit: Option<i64>,
+    limit: Option<i64>,
     /// Offset for pagination
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub offset: Option<i64>,
+    offset: Option<i64>,
 }
 
 /// File information in search results
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FileInfo {
-    pub path: String,
-    pub size: i64,
+    path: String,
+    size: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub hash: Option<String>,
-    pub url: String,
+    hash: Option<String>,
+    url: String,
 }

--- a/crates/capsula-capture-json/src/lib.rs
+++ b/crates/capsula-capture-json/src/lib.rs
@@ -93,7 +93,7 @@ mod tests {
 
     use super::*;
     use capsula_core::hook::PreRun;
-    use capsula_core::run::Run;
+    use capsula_core::run::PreparedRun;
     use std::fs;
     use tempfile::TempDir;
     use ulid::Ulid;
@@ -104,7 +104,7 @@ mod tests {
     }
 
     fn make_run(project_root: &Path) -> PreparedRun {
-        Run {
+        PreparedRun {
             id: Ulid::new(),
             name: "test-run".into(),
             command: vec![],

--- a/crates/capsula-capture-toml/src/lib.rs
+++ b/crates/capsula-capture-toml/src/lib.rs
@@ -119,7 +119,7 @@ mod tests {
 
     use super::*;
     use capsula_core::hook::PreRun;
-    use capsula_core::run::Run;
+    use capsula_core::run::PreparedRun;
     use std::fs;
     use tempfile::TempDir;
     use ulid::Ulid;
@@ -130,7 +130,7 @@ mod tests {
     }
 
     fn make_run(project_root: &Path) -> PreparedRun {
-        Run {
+        PreparedRun {
             id: Ulid::new(),
             name: "test-run".into(),
             command: vec![],

--- a/crates/capsula-cli/src/main.rs
+++ b/crates/capsula-cli/src/main.rs
@@ -6,7 +6,7 @@
 
 use anyhow::{Context, Result};
 use capsula_core::hook::{PostRun, PreRun};
-use capsula_core::run::Run;
+use capsula_core::run::PreparedRun;
 use capsula_orchestration::push::push_single_run;
 use capsula_orchestration::resolve::resolve_server_url;
 use capsula_orchestration::run::{create_and_setup_run, run_post_hooks, run_pre_hooks};
@@ -369,7 +369,7 @@ path = \".\"
 
             let metadata = capsula_orchestration::vault::read_run_metadata(&run_dir)?;
 
-            let run = Run {
+            let run = PreparedRun {
                 id: metadata.id,
                 name: metadata.name,
                 command: metadata.command,

--- a/crates/capsula-config/src/lib.rs
+++ b/crates/capsula-config/src/lib.rs
@@ -97,11 +97,11 @@ pub struct HookPhaseConfig {
 pub struct HookEnvelope {
     pub id: String,
     #[serde(flatten)]
-    pub rest: serde_json::Value,
+    rest: serde_json::Value,
 }
 
 impl CapsulaConfig {
-    pub fn from_toml_str(content: &str) -> ConfigResult<Self> {
+    fn from_toml_str(content: &str) -> ConfigResult<Self> {
         debug!("Parsing TOML configuration ({} bytes)", content.len());
         let config = toml::from_str(content)?;
         debug!("TOML configuration parsed successfully");

--- a/crates/capsula-core/src/hook.rs
+++ b/crates/capsula-core/src/hook.rs
@@ -35,7 +35,7 @@ pub struct RuntimeParams<P: PhaseMarker> {
 impl<P: PhaseMarker> RuntimeParams<P> {
     /// Create `RuntimeParams` with no artifact directory.
     #[must_use]
-    pub const fn new() -> Self {
+    const fn new() -> Self {
         Self {
             phase_marker: PhantomData,
             artifact_dir: None,

--- a/crates/capsula-core/src/run.rs
+++ b/crates/capsula-core/src/run.rs
@@ -46,12 +46,12 @@ impl<Dir> Run<Dir> {
     }
 }
 
-impl Run<()> {
+impl UnpreparedRun {
     pub fn setup_run_dir(
         &self,
         vault_dir: impl AsRef<std::path::Path>,
         max_retries: usize,
-    ) -> io::Result<Run<PathBuf>> {
+    ) -> io::Result<PreparedRun> {
         debug!(
             "Setting up vault directory: {}",
             vault_dir.as_ref().display()
@@ -90,7 +90,7 @@ impl Run<()> {
         std::fs::create_dir_all(&run_dir)?;
         debug!("Run directory created successfully");
 
-        Ok(Run {
+        Ok(PreparedRun {
             id: self.id,
             name: self.name.clone(),
             command: self.command.clone(),
@@ -100,7 +100,7 @@ impl Run<()> {
     }
 }
 
-impl Serialize for Run<()> {
+impl Serialize for UnpreparedRun {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -115,7 +115,7 @@ impl Serialize for Run<()> {
     }
 }
 
-impl Serialize for Run<PathBuf> {
+impl Serialize for PreparedRun {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -154,7 +154,7 @@ fn exit_code_from_status(status: ExitStatus) -> i32 {
     })
 }
 
-impl Run<PathBuf> {
+impl PreparedRun {
     pub fn exec(&self) -> std::io::Result<RunOutput> {
         if self.command.is_empty() {
             return Err(io::Error::new(io::ErrorKind::InvalidInput, "empty command"));

--- a/crates/capsula-core/src/run.rs
+++ b/crates/capsula-core/src/run.rs
@@ -29,7 +29,7 @@ impl<Dir> Run<Dir> {
         dt
     }
 
-    pub fn gen_run_dir(&self, vault_dir: impl AsRef<Path>) -> PathBuf {
+    fn gen_run_dir(&self, vault_dir: impl AsRef<Path>) -> PathBuf {
         let timestamp = self.timestamp();
         let date_str = timestamp.format("%Y-%m-%d").to_string();
         let time_str = timestamp.format("%H%M%S").to_string();
@@ -134,9 +134,9 @@ impl Serialize for Run<PathBuf> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RunOutput {
     pub exit_code: i32,
-    pub stdout: String,
-    pub stderr: String,
-    pub duration: Duration,
+    stdout: String,
+    stderr: String,
+    duration: Duration,
 }
 
 fn exit_code_from_status(status: ExitStatus) -> i32 {

--- a/crates/capsula-orchestration/src/lib.rs
+++ b/crates/capsula-orchestration/src/lib.rs
@@ -1,4 +1,4 @@
-pub mod hooks;
+pub(crate) mod hooks;
 pub mod push;
 pub mod resolve;
 pub mod run;

--- a/crates/capsula-orchestration/src/resolve.rs
+++ b/crates/capsula-orchestration/src/resolve.rs
@@ -5,7 +5,7 @@ use tracing::debug;
 ///
 /// The `override_path` parameter corresponds to CLI arguments or other explicit overrides.
 /// Environment variables are read at call time, so dotenv should be loaded before calling.
-pub fn resolve_vault_path(
+pub(crate) fn resolve_vault_path(
     override_path: Option<PathBuf>,
     config_vault_path: &Path,
     project_root: &Path,

--- a/crates/capsula-orchestration/src/run.rs
+++ b/crates/capsula-orchestration/src/run.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use capsula_config::HookPhaseConfig;
 use capsula_core::hook::{PostRun, PreRun};
-use capsula_core::run::{PreparedRun, Run};
+use capsula_core::run::{PreparedRun, UnpreparedRun};
 use names::Generator;
 use std::path::{Path, PathBuf};
 use tracing::{debug, info};
@@ -18,7 +18,7 @@ pub fn create_and_setup_run(
     vault_dir: &Path,
 ) -> Result<(PreparedRun, PathBuf)> {
     debug!("Creating run metadata");
-    let run = Run::<()> {
+    let run = UnpreparedRun {
         id: Ulid::new(),
         name: Generator::default()
             .next()

--- a/crates/capsula-registry/src/lib.rs
+++ b/crates/capsula-registry/src/lib.rs
@@ -47,7 +47,7 @@ pub struct HookRegistry<P: PhaseMarker> {
 impl<P: PhaseMarker> HookRegistry<P> {
     /// Create a new empty registry
     #[must_use]
-    pub fn new() -> Self {
+    fn new() -> Self {
         Self {
             creators: HashMap::new(),
         }
@@ -63,7 +63,7 @@ impl<P: PhaseMarker> HookRegistry<P> {
     /// let mut registry = HookRegistry::<PreRun>::new();
     /// registry.register::<CwdHook>()?;
     /// ```
-    pub fn register<H>(&mut self) -> Result<(), RegistryError>
+    fn register<H>(&mut self) -> Result<(), RegistryError>
     where
         H: capsula_core::hook::Hook<P> + 'static,
     {
@@ -114,7 +114,7 @@ impl<P: PhaseMarker> HookRegistry<P> {
 
     /// Get list of registered hook types
     #[must_use]
-    pub fn registered_types(&self) -> Vec<&'static str> {
+    fn registered_types(&self) -> Vec<&'static str> {
         self.creators.keys().copied().collect()
     }
 }
@@ -135,7 +135,7 @@ pub struct RegistryBuilder<P: PhaseMarker> {
 
 impl<P: PhaseMarker> RegistryBuilder<P> {
     #[must_use]
-    pub fn new() -> Self {
+    fn new() -> Self {
         Self {
             registry: HookRegistry::new(),
         }
@@ -149,7 +149,7 @@ impl<P: PhaseMarker> RegistryBuilder<P> {
     ///     .with_hook::<CwdHook>()?
     ///     .build()
     /// ```
-    pub fn with_hook<H>(mut self) -> Result<Self, RegistryError>
+    fn with_hook<H>(mut self) -> Result<Self, RegistryError>
     where
         H: capsula_core::hook::Hook<P> + 'static,
     {
@@ -158,7 +158,7 @@ impl<P: PhaseMarker> RegistryBuilder<P> {
     }
 
     #[must_use]
-    pub fn build(self) -> HookRegistry<P> {
+    fn build(self) -> HookRegistry<P> {
         self.registry
     }
 }

--- a/crates/capsula-server/src/lib.rs
+++ b/crates/capsula-server/src/lib.rs
@@ -75,8 +75,8 @@ const RFC5987_ATTR_CHAR: &AsciiSet = &NON_ALPHANUMERIC
 
 #[derive(Clone)]
 pub struct AppState {
-    pub pool: PgPool,
-    pub storage_path: PathBuf,
+    pool: PgPool,
+    storage_path: PathBuf,
 }
 
 mod models;

--- a/crates/capsula-tui/src/app.rs
+++ b/crates/capsula-tui/src/app.rs
@@ -2,7 +2,7 @@ use std::time::Instant;
 
 use anyhow::Result;
 use capsula_core::hook::{PostRun, PreRun};
-use capsula_core::run::Run;
+use capsula_core::run::PreparedRun;
 use capsula_orchestration::run::{create_and_setup_run, run_post_hooks, run_pre_hooks};
 use capsula_orchestration::setup::LoadedConfig;
 use capsula_orchestration::vault::find_run_dir_by_name;
@@ -202,7 +202,7 @@ impl App {
 
         let metadata = capsula_orchestration::vault::read_run_metadata(&run_dir)?;
 
-        let run = Run {
+        let run = PreparedRun {
             id: metadata.id,
             name: metadata.name,
             command: metadata.command,

--- a/hawk.toml
+++ b/hawk.toml
@@ -1,0 +1,9 @@
+[[production]]
+package = "capsula"
+bin = "capsula"
+reason = "shipped application binary"
+
+[[production]]
+package = "capsula-server"
+bin = "capsula-server"
+reason = "shipped server binary"


### PR DESCRIPTION
## Summary

- add [Hawk](https://github.com/astral-sh/hawk) production-target configuration (`hawk.toml`) for the shipped CLI and server binaries
- reduce visibility for implementation-only APIs and fields based on the production targets
- use `PreparedRun` and `UnpreparedRun` aliases consistently for run type states

## AI assistance

- AI used: yes — Codex implemented the run type-alias refactor, resolved the lint cleanup, ran verification, and prepared this pull request
- Human review of AI-assisted code: complete

## Breaking changes

- [x] No breaking changes
- [ ] Breaking changes; the breaking change label is applied

## Verification

- RUSTFLAGS=-Dwarnings just lint
- just test
- pre-commit checks for the final cleanup