### PR TITLE
`capture-file`: constrain globs to the project root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,6 +614,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tracing",
  "ulid",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ toml = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ulid = { version = "1", features = ["serde"] }
+walkdir = "2"
 wiremock = "0.6"
 
 [workspace.lints.clippy]

--- a/crates/capsula-capture-file/Cargo.toml
+++ b/crates/capsula-capture-file/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+walkdir = "2"
 
 [dev-dependencies]
 ulid = { workspace = true }

--- a/crates/capsula-capture-file/Cargo.toml
+++ b/crates/capsula-capture-file/Cargo.toml
@@ -18,7 +18,7 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-walkdir = "2"
+walkdir = { workspace = true }
 
 [dev-dependencies]
 ulid = { workspace = true }

--- a/crates/capsula-capture-file/src/error.rs
+++ b/crates/capsula-capture-file/src/error.rs
@@ -1,4 +1,5 @@
 use capsula_core::error::CapsulaError;
+use capsula_core::project_path::ProjectPathError;
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -17,9 +18,40 @@ pub enum FileHookError {
     #[error("Invalid glob pattern: {0}")]
     InvalidPattern(#[from] glob::PatternError),
 
-    /// Glob traversal error
-    #[error("Glob traversal error: {0}")]
-    GlobError(#[from] glob::GlobError),
+    /// The glob is absolute or has a platform path prefix.
+    #[error("Glob pattern must be relative to the project root: {pattern}")]
+    NonRelativePattern { pattern: String },
+
+    /// The glob contains an explicit parent-directory traversal.
+    #[error("Glob pattern cannot contain parent traversal ('..'): {pattern}")]
+    ParentTraversalPattern { pattern: String },
+
+    /// Walking the project unexpectedly produced an out-of-project path.
+    #[error("Walked path '{path}' is outside project root '{project_root}'")]
+    WalkedPathOutsideProject {
+        path: PathBuf,
+        project_root: PathBuf,
+    },
+
+    /// A path matched the glob but is a symbolic link.
+    #[error("Refusing to capture symbolic link: {path}")]
+    SymlinkNotAllowed { path: PathBuf },
+
+    /// A matched source stopped being a regular file before capture.
+    #[error("Capture source is no longer a regular file: {path}")]
+    SourceNotRegularFile { path: PathBuf },
+
+    /// A matched source resolved differently when it was revalidated.
+    #[error("Capture source '{path}' changed to resolve as '{resolved}'")]
+    SourcePathChanged { path: PathBuf, resolved: PathBuf },
+
+    /// Project-root-aware path validation failed.
+    #[error(transparent)]
+    ProjectPath(#[from] ProjectPathError),
+
+    /// Project traversal failed.
+    #[error("Failed to walk project files: {0}")]
+    Walk(#[from] walkdir::Error),
 
     #[error("Run directory is not set")]
     RunDirNotSet,

--- a/crates/capsula-capture-file/src/lib.rs
+++ b/crates/capsula-capture-file/src/lib.rs
@@ -6,10 +6,14 @@ use crate::hash::file_digest_sha256;
 use capsula_core::captured::Captured;
 use capsula_core::error::{CapsulaError, CapsulaResult};
 use capsula_core::hook::{Hook, HookOutcome, PhaseMarker, RuntimeParams};
+use capsula_core::project_path::ResolvedProjectPath;
 use capsula_core::run::PreparedRun;
+use glob::{MatchOptions, Pattern};
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
+use std::ffi::OsStr;
+use std::path::{Component, Path, PathBuf};
 use tracing::debug;
+use walkdir::WalkDir;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -40,8 +44,70 @@ pub enum HashAlgorithm {
 }
 
 #[derive(Debug)]
+struct ProjectRelativeGlob {
+    pattern: Pattern,
+    max_depth: Option<usize>,
+}
+
+impl ProjectRelativeGlob {
+    const MATCH_OPTIONS: MatchOptions = MatchOptions {
+        case_sensitive: true,
+        require_literal_separator: true,
+        require_literal_leading_dot: false,
+    };
+
+    fn parse(configured: &str) -> Result<Self, FileHookError> {
+        let (normalized, component_count, is_recursive) =
+            Path::new(configured).components().try_fold(
+                (PathBuf::new(), 0, false),
+                |(mut normalized, component_count, is_recursive), component| match component {
+                    Component::Normal(component) => {
+                        normalized.push(component);
+                        Ok((
+                            normalized,
+                            component_count + 1,
+                            is_recursive || component == OsStr::new("**"),
+                        ))
+                    }
+                    Component::CurDir => Ok((normalized, component_count, is_recursive)),
+                    Component::ParentDir => Err(FileHookError::ParentTraversalPattern {
+                        pattern: configured.to_string(),
+                    }),
+                    Component::Prefix(_) | Component::RootDir => {
+                        Err(FileHookError::NonRelativePattern {
+                            pattern: configured.to_string(),
+                        })
+                    }
+                },
+            )?;
+
+        let mut normalized = normalized.to_string_lossy().into_owned();
+        #[cfg(windows)]
+        {
+            normalized = normalized.replace('\\', "/");
+        }
+        let has_trailing_separator =
+            configured.ends_with('/') || (cfg!(windows) && configured.ends_with('\\'));
+        if has_trailing_separator && !normalized.is_empty() {
+            normalized.push('/');
+        }
+
+        Ok(Self {
+            pattern: Pattern::new(&normalized)?,
+            max_depth: (!is_recursive).then_some(component_count),
+        })
+    }
+
+    fn matches(&self, path: &Path) -> bool {
+        self.pattern.matches_path_with(path, Self::MATCH_OPTIONS)
+    }
+}
+
+#[derive(Debug)]
 pub struct FileHook {
     config: FileHookConfig,
+    project_root: ResolvedProjectPath,
+    glob: ProjectRelativeGlob,
 }
 
 #[derive(Debug, Serialize)]
@@ -73,10 +139,18 @@ where
 
     fn from_config(
         config: &serde_json::Value,
-        _project_root: &std::path::Path,
+        project_root: &std::path::Path,
     ) -> CapsulaResult<Self> {
         let config: FileHookConfig = serde_json::from_value(config.clone())?;
-        Ok(Self { config })
+        let glob = ProjectRelativeGlob::parse(&config.glob)?;
+        let project_root = ResolvedProjectPath::resolve_existing(project_root, project_root)
+            .map_err(FileHookError::from)?;
+
+        Ok(Self {
+            config,
+            project_root,
+            glob,
+        })
     }
 
     fn config(&self) -> &Self::Config {
@@ -103,30 +177,25 @@ where
 }
 
 impl FileHook {
-    /// Builds a complete glob pattern from base path and user pattern.
-    /// Users must use forward slashes (/) in patterns.
-    /// On Windows, this normalizes path separators from backslashes to forward slashes.
-    fn build_glob_pattern(base: &Path, pattern: &str) -> String {
-        base.join(pattern).to_string_lossy().replace('\\', "/")
-    }
-
     fn run(
         &self,
-        metadata: &PreparedRun,
+        _metadata: &PreparedRun,
         artifact_dir: &Path,
     ) -> Result<FileCaptured, FileHookError> {
-        let pattern = Self::build_glob_pattern(&metadata.project_root, &self.config.glob);
         debug!(
-            "FileHook: Searching for files matching pattern: {}",
-            pattern
+            "FileHook: Searching under {} for files matching pattern: {}",
+            self.project_root.as_path().display(),
+            self.config.glob
         );
 
-        let files: Vec<_> = glob::glob(&pattern)?
-            .filter_map(Result::ok) // Filter out GlobErrors
-            .filter(|path| path.is_file()) // Only files, not directories
+        // Validate the complete match set before copy or move operations can
+        // mutate the project or populate the artifact directory.
+        let matching_files = self.matching_files()?;
+        let files = matching_files
+            .iter()
             .map(|path| {
-                debug!("FileHook: Processing file: {}", path.display());
-                self.capture_file(&path, artifact_dir)
+                debug!("FileHook: Processing file: {}", path.as_path().display());
+                self.capture_file(path, artifact_dir)
             })
             .collect::<Result<Vec<_>, FileHookError>>()?;
 
@@ -134,11 +203,89 @@ impl FileHook {
         Ok(FileCaptured { files })
     }
 
+    fn matching_files(&self) -> Result<Vec<ResolvedProjectPath>, FileHookError> {
+        let Some(max_depth) = self.glob.max_depth else {
+            return self.walk_matching_files(WalkDir::new(self.project_root.as_path()));
+        };
+        if max_depth == 0 {
+            return Ok(Vec::new());
+        }
+
+        self.walk_matching_files(WalkDir::new(self.project_root.as_path()).max_depth(max_depth))
+    }
+
+    fn walk_matching_files(
+        &self,
+        walker: WalkDir,
+    ) -> Result<Vec<ResolvedProjectPath>, FileHookError> {
+        let project_root = self.project_root.as_path();
+
+        walker
+            .follow_links(false)
+            .follow_root_links(false)
+            .min_depth(1)
+            .sort_by_file_name()
+            .into_iter()
+            .try_fold(Vec::new(), |mut files, entry| {
+                let entry = entry?;
+                let path = entry.path();
+                let relative_path = path.strip_prefix(project_root).map_err(|_| {
+                    FileHookError::WalkedPathOutsideProject {
+                        path: path.to_path_buf(),
+                        project_root: project_root.to_path_buf(),
+                    }
+                })?;
+
+                if !self.glob.matches(relative_path) {
+                    return Ok(files);
+                }
+
+                let file_type = entry.file_type();
+                if file_type.is_symlink() {
+                    return Err(FileHookError::SymlinkNotAllowed {
+                        path: path.to_path_buf(),
+                    });
+                }
+                if file_type.is_file() {
+                    files.push(ResolvedProjectPath::resolve_existing(path, project_root)?);
+                }
+
+                Ok(files)
+            })
+    }
+
+    fn revalidate_source(source: &ResolvedProjectPath) -> Result<&Path, FileHookError> {
+        let path = source.as_path();
+        let metadata = std::fs::symlink_metadata(path)?;
+        if metadata.file_type().is_symlink() {
+            return Err(FileHookError::SymlinkNotAllowed {
+                path: path.to_path_buf(),
+            });
+        }
+        if !metadata.file_type().is_file() {
+            return Err(FileHookError::SourceNotRegularFile {
+                path: path.to_path_buf(),
+            });
+        }
+
+        let current = ResolvedProjectPath::resolve_existing(path, source.project_root())?;
+        if &current != source {
+            return Err(FileHookError::SourcePathChanged {
+                path: path.to_path_buf(),
+                resolved: current.into_path_buf(),
+            });
+        }
+
+        Ok(path)
+    }
+
     fn capture_file(
         &self,
-        path: &Path,
+        source: &ResolvedProjectPath,
         artifact_dir: &Path,
     ) -> Result<FileCapturedPerFile, FileHookError> {
+        let path = Self::revalidate_source(source)?;
+
         // Compute hash if needed
         let hash = match self.config.hash {
             HashAlgorithm::Sha256 => {

--- a/crates/capsula-capture-file/tests/file_hook.rs
+++ b/crates/capsula-capture-file/tests/file_hook.rs
@@ -413,3 +413,224 @@ fn file_hook_rejects_unknown_config_fields() {
 
     assert!(result.is_err(), "unknown config fields should be rejected");
 }
+
+#[test]
+fn file_hook_rejects_absolute_glob() {
+    let temp_dir = std::env::temp_dir().join(format!("capsula_test_{}", Ulid::new()));
+    fs::create_dir_all(&temp_dir).unwrap();
+    let absolute_glob = temp_dir.join("*.txt").to_string_lossy().into_owned();
+    let config = json!({
+        "glob": absolute_glob,
+        "mode": "move",
+        "hash": "none"
+    });
+
+    let result = <FileHook as Hook<PreRun>>::from_config(&config, &temp_dir);
+
+    assert!(result.is_err(), "absolute globs should be rejected");
+    fs::remove_dir_all(temp_dir).ok();
+}
+
+#[test]
+fn file_hook_rejects_parent_traversal_glob() {
+    let temp_dir = std::env::temp_dir().join(format!("capsula_test_{}", Ulid::new()));
+    fs::create_dir_all(&temp_dir).unwrap();
+    let config = json!({
+        "glob": "../outside/*.txt",
+        "mode": "move",
+        "hash": "none"
+    });
+
+    let result = <FileHook as Hook<PreRun>>::from_config(&config, &temp_dir);
+
+    assert!(result.is_err(), "parent traversal should be rejected");
+    fs::remove_dir_all(temp_dir).ok();
+}
+
+#[test]
+fn file_hook_recursive_glob_preserves_double_star_semantics() {
+    let temp_dir = std::env::temp_dir().join(format!("capsula_test_{}", Ulid::new()));
+    let run_dir = temp_dir.join("run");
+    let artifact_dir = run_dir.join("pre-0-capture-file");
+    let nested_dir = temp_dir.join("nested").join("deep");
+    fs::create_dir_all(&artifact_dir).unwrap();
+    fs::create_dir_all(&nested_dir).unwrap();
+    fs::write(temp_dir.join("root.txt"), b"root").unwrap();
+    fs::write(nested_dir.join("nested.txt"), b"nested").unwrap();
+
+    let config = json!({
+        "glob": "**/*.txt",
+        "mode": "none",
+        "hash": "none"
+    });
+    let hook = <FileHook as Hook<PreRun>>::from_config(&config, &temp_dir).expect("from_config ok");
+    let run_metadata = PreparedRun {
+        id: Ulid::new(),
+        name: "test-run".to_string(),
+        command: vec![],
+        run_dir,
+        project_root: temp_dir.clone(),
+    };
+    let params = RuntimeParams::<PreRun>::with_artifact_dir(artifact_dir);
+
+    let outcome = hook.run(&run_metadata, &params).expect("run ok");
+    let json = outcome
+        .output()
+        .serialize_json()
+        .expect("serialization should succeed");
+    let files = json
+        .get("files")
+        .and_then(|value| value.as_array())
+        .unwrap();
+
+    assert_eq!(files.len(), 2, "double-star glob should match recursively");
+    fs::remove_dir_all(temp_dir).ok();
+}
+
+#[cfg(unix)]
+#[test]
+fn file_hook_rejects_symlink_before_moving_any_matches() {
+    use std::os::unix::fs::symlink;
+
+    let parent = std::env::temp_dir().join(format!("capsula_test_{}", Ulid::new()));
+    let project_root = parent.join("project");
+    let run_dir = project_root.join("run");
+    let artifact_dir = run_dir.join("pre-0-capture-file");
+    let safe_file = project_root.join("a-safe.txt");
+    let outside_file = parent.join("outside-secret.txt");
+    let symlink_path = project_root.join("z-secret.txt");
+    fs::create_dir_all(&artifact_dir).unwrap();
+    fs::write(&safe_file, b"safe").unwrap();
+    fs::write(&outside_file, b"secret").unwrap();
+    symlink(&outside_file, &symlink_path).unwrap();
+
+    let config = json!({
+        "glob": "*.txt",
+        "mode": "move",
+        "hash": "sha256"
+    });
+    let hook =
+        <FileHook as Hook<PreRun>>::from_config(&config, &project_root).expect("from_config ok");
+    let run_metadata = PreparedRun {
+        id: Ulid::new(),
+        name: "test-run".to_string(),
+        command: vec![],
+        run_dir,
+        project_root,
+    };
+    let params = RuntimeParams::<PreRun>::with_artifact_dir(artifact_dir.clone());
+
+    let result = hook.run(&run_metadata, &params);
+
+    assert!(result.is_err(), "a matching symlink should fail the hook");
+    assert!(safe_file.exists(), "safe files must not be partially moved");
+    assert!(
+        outside_file.exists(),
+        "the symlink target must remain untouched"
+    );
+    assert!(symlink_path.exists(), "the symlink must remain untouched");
+    assert!(
+        fs::read_dir(&artifact_dir).unwrap().next().is_none(),
+        "the artifact directory must remain empty"
+    );
+    fs::remove_dir_all(parent).ok();
+}
+
+#[cfg(unix)]
+#[test]
+fn file_hook_does_not_descend_into_symlinked_directory() {
+    use std::os::unix::fs::symlink;
+
+    let parent = std::env::temp_dir().join(format!("capsula_test_{}", Ulid::new()));
+    let project_root = parent.join("project");
+    let outside_dir = parent.join("outside");
+    let outside_file = outside_dir.join("secret.txt");
+    let symlink_path = project_root.join("external");
+    let run_dir = project_root.join("run");
+    let artifact_dir = run_dir.join("pre-0-capture-file");
+    fs::create_dir_all(&artifact_dir).unwrap();
+    fs::create_dir_all(&outside_dir).unwrap();
+    fs::write(&outside_file, b"secret").unwrap();
+    symlink(&outside_dir, &symlink_path).unwrap();
+
+    let config = json!({
+        "glob": "external/*.txt",
+        "mode": "move",
+        "hash": "sha256"
+    });
+    let hook =
+        <FileHook as Hook<PreRun>>::from_config(&config, &project_root).expect("from_config ok");
+    let run_metadata = PreparedRun {
+        id: Ulid::new(),
+        name: "test-run".to_string(),
+        command: vec![],
+        run_dir,
+        project_root,
+    };
+    let params = RuntimeParams::<PreRun>::with_artifact_dir(artifact_dir.clone());
+
+    let outcome = hook.run(&run_metadata, &params).expect("run ok");
+    let json = outcome
+        .output()
+        .serialize_json()
+        .expect("serialization should succeed");
+    let files = json
+        .get("files")
+        .and_then(|value| value.as_array())
+        .unwrap();
+
+    assert!(files.is_empty(), "files behind symlinks must not match");
+    assert!(
+        outside_file.exists(),
+        "the outside file must remain untouched"
+    );
+    assert!(symlink_path.exists(), "the symlink must remain untouched");
+    assert!(
+        fs::read_dir(&artifact_dir).unwrap().next().is_none(),
+        "the artifact directory must remain empty"
+    );
+    fs::remove_dir_all(parent).ok();
+}
+
+#[cfg(unix)]
+#[test]
+fn file_hook_preserves_backslashes_in_unix_globs() {
+    let temp_dir = std::env::temp_dir().join(format!("capsula_test_{}", Ulid::new()));
+    let run_dir = temp_dir.join("run");
+    let artifact_dir = run_dir.join("pre-0-capture-file");
+    let file_name = r"report\2026.txt";
+    fs::create_dir_all(&artifact_dir).unwrap();
+    fs::write(temp_dir.join(file_name), b"report").unwrap();
+
+    let config = json!({
+        "glob": file_name,
+        "mode": "copy",
+        "hash": "none"
+    });
+    let hook = <FileHook as Hook<PreRun>>::from_config(&config, &temp_dir).expect("from_config ok");
+    let run_metadata = PreparedRun {
+        id: Ulid::new(),
+        name: "test-run".to_string(),
+        command: vec![],
+        run_dir,
+        project_root: temp_dir.clone(),
+    };
+    let params = RuntimeParams::<PreRun>::with_artifact_dir(artifact_dir.clone());
+
+    let outcome = hook.run(&run_metadata, &params).expect("run ok");
+    let json = outcome
+        .output()
+        .serialize_json()
+        .expect("serialization should succeed");
+    let files = json
+        .get("files")
+        .and_then(|value| value.as_array())
+        .unwrap();
+
+    assert_eq!(files.len(), 1, "the backslash should remain literal");
+    assert!(
+        artifact_dir.join(file_name).exists(),
+        "the backslash-named file should be copied"
+    );
+    fs::remove_dir_all(temp_dir).ok();
+}

--- a/crates/capsula-cli/Cargo.toml
+++ b/crates/capsula-cli/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = { workspace = true }
 shlex = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-walkdir = "2"
+walkdir = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = "=2.2.2"

--- a/crates/capsula-orchestration/Cargo.toml
+++ b/crates/capsula-orchestration/Cargo.toml
@@ -24,7 +24,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 ulid = { workspace = true }
-walkdir = "2"
+walkdir = { workspace = true }
 
 [lints]
 workspace = true

--- a/docs/hooks/capture-file.md
+++ b/docs/hooks/capture-file.md
@@ -28,6 +28,26 @@ Captures files by copying them, moving them, or computing their hash.
 | `mode` | string | `"copy"` | How to handle files: `"copy"`, `"move"`, or `"none"` |
 | `hash` | string | `"sha256"` | Hash algorithm: `"sha256"` or `"none"` |
 
+### Glob Path Rules
+
+Glob patterns are always relative to the project root (the directory containing
+`capsula.toml`). Absolute patterns and patterns containing a `..` path component
+are rejected.
+
+- `*.txt` matches files at the project root.
+- `results/*.csv` matches files directly under `results/`.
+- `**/*.txt` matches files recursively.
+- Use `/` as the portable path separator. On Unix, `\` remains a legal,
+  literal filename character.
+
+Symbolic links are not followed. A symbolic link that directly matches the glob
+causes the hook to fail, and symbolic-link directories are not traversed.
+
+!!! warning "Project containment"
+    A `capture-file` hook cannot read, hash, copy, or move files outside the
+    project root. Use an explicit project-local path instead of an absolute or
+    parent-relative path.
+
 ### Mode Options
 
 - `"copy"` - Copies files to the hook's artifact directory, leaves originals


### PR DESCRIPTION
## Summary

- reject absolute and parent-traversing `capture-file` glob patterns
- enumerate matches beneath the canonical project root without following symbolic links
- validate the full match set before hashing, copying, or moving files
- preserve existing `*` and `**` semantics and literal Unix backslashes
- document the new path restrictions and add security regression coverage

Closes #1067.

This PR is stacked on #1098, which provides `ResolvedProjectPath`.

## Testing

- `just lint`
- `just test`

## AI assistance

- AI used: yes — implementation, tests, documentation, and PR description were prepared with an AI coding agent
- Human review of AI-assisted code: pending

## Breaking changes

- [ ] No breaking changes
- [x] Breaking changes; the `breaking change` label is applied

Absolute, parent-relative, and symlink-based capture patterns that previously worked are now rejected or not traversed.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #1147
- <kbd>&nbsp;3&nbsp;</kbd> #1146 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #1098
- <kbd>&nbsp;1&nbsp;</kbd> #1097
<!-- GitButler Footer Boundary Bottom -->