### PR TITLE
`capture-file`: preserve artifact integrity

### DIFF
--- a/crates/capsula-capture-file/src/error.rs
+++ b/crates/capsula-capture-file/src/error.rs
@@ -59,6 +59,9 @@ pub enum FileHookError {
     #[error("Invalid run directory: {path}")]
     InvalidRunDir { path: PathBuf },
 
+    #[error("Artifact destination has no parent directory: {path}")]
+    InvalidArtifactDestination { path: PathBuf },
+
     #[error("capture-file hook requires an artifact directory but none was provided")]
     ArtifactDirMissing,
 

--- a/crates/capsula-capture-file/src/error.rs
+++ b/crates/capsula-capture-file/src/error.rs
@@ -62,6 +62,16 @@ pub enum FileHookError {
     #[error("Artifact destination has no parent directory: {path}")]
     InvalidArtifactDestination { path: PathBuf },
 
+    #[error("Refusing to overwrite existing artifact destination: {path}")]
+    ArtifactDestinationExists { path: PathBuf },
+
+    #[error("Failed to remove moved source {path}: {source}")]
+    RemoveMovedSource {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
     #[error("capture-file hook requires an artifact directory but none was provided")]
     ArtifactDirMissing,
 

--- a/crates/capsula-capture-file/src/lib.rs
+++ b/crates/capsula-capture-file/src/lib.rs
@@ -302,13 +302,19 @@ impl FileHook {
                     "FileHook: {:?} file to artifact directory",
                     self.config.mode
                 );
-                let file_name = path
-                    .file_name()
-                    .ok_or_else(|| FileHookError::InvalidRunDir {
-                        path: path.to_path_buf(),
-                    })?
-                    .to_os_string();
-                let dest_path = artifact_dir.join(file_name);
+                let relative_path =
+                    path.strip_prefix(self.project_root.as_path())
+                        .map_err(|_| FileHookError::WalkedPathOutsideProject {
+                            path: path.to_path_buf(),
+                            project_root: self.project_root.to_path_buf(),
+                        })?;
+                let dest_path = artifact_dir.join(relative_path);
+                let parent = dest_path.parent().ok_or_else(|| {
+                    FileHookError::InvalidArtifactDestination {
+                        path: dest_path.clone(),
+                    }
+                })?;
+                std::fs::create_dir_all(parent)?;
                 match self.config.mode {
                     CaptureMode::Copy => std::fs::copy(path, &dest_path).map(|_| ())?,
                     CaptureMode::Move => {

--- a/crates/capsula-capture-file/src/lib.rs
+++ b/crates/capsula-capture-file/src/lib.rs
@@ -10,9 +10,12 @@ use capsula_core::project_path::ResolvedProjectPath;
 use capsula_core::run::PreparedRun;
 use glob::{MatchOptions, Pattern};
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::ffi::OsStr;
+use std::fs::{File, OpenOptions};
+use std::io::ErrorKind;
 use std::path::{Component, Path, PathBuf};
-use tracing::debug;
+use tracing::{debug, warn};
 use walkdir::WalkDir;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -110,6 +113,12 @@ pub struct FileHook {
     glob: ProjectRelativeGlob,
 }
 
+#[derive(Debug)]
+struct PlannedFileCapture {
+    source: ResolvedProjectPath,
+    destination: Option<PathBuf>,
+}
+
 #[derive(Debug, Serialize)]
 pub struct FileCapturedPerFile {
     path: PathBuf,
@@ -191,11 +200,15 @@ impl FileHook {
         // Validate the complete match set before copy or move operations can
         // mutate the project or populate the artifact directory.
         let matching_files = self.matching_files()?;
-        let files = matching_files
+        let capture_plan = self.plan_captures(matching_files, artifact_dir)?;
+        let files = capture_plan
             .iter()
-            .map(|path| {
-                debug!("FileHook: Processing file: {}", path.as_path().display());
-                self.capture_file(path, artifact_dir)
+            .map(|planned| {
+                debug!(
+                    "FileHook: Processing file: {}",
+                    planned.source.as_path().display()
+                );
+                self.capture_file(planned)
             })
             .collect::<Result<Vec<_>, FileHookError>>()?;
 
@@ -254,6 +267,55 @@ impl FileHook {
             })
     }
 
+    fn plan_captures(
+        &self,
+        matching_files: Vec<ResolvedProjectPath>,
+        artifact_dir: &Path,
+    ) -> Result<Vec<PlannedFileCapture>, FileHookError> {
+        let mut destinations = HashSet::new();
+
+        matching_files
+            .into_iter()
+            .map(|source| {
+                let destination = match self.config.mode {
+                    CaptureMode::Copy | CaptureMode::Move => {
+                        let path = source.as_path();
+                        let relative_path = path
+                            .strip_prefix(self.project_root.as_path())
+                            .map_err(|_| FileHookError::WalkedPathOutsideProject {
+                                path: path.to_path_buf(),
+                                project_root: self.project_root.to_path_buf(),
+                            })?;
+                        let destination = artifact_dir.join(relative_path);
+                        if !destinations.insert(destination.clone()) {
+                            return Err(FileHookError::ArtifactDestinationExists {
+                                path: destination,
+                            });
+                        }
+                        Self::ensure_artifact_destination_available(&destination)?;
+                        Some(destination)
+                    }
+                    CaptureMode::None => None,
+                };
+
+                Ok(PlannedFileCapture {
+                    source,
+                    destination,
+                })
+            })
+            .collect()
+    }
+
+    fn ensure_artifact_destination_available(path: &Path) -> Result<(), FileHookError> {
+        match std::fs::symlink_metadata(path) {
+            Ok(_) => Err(FileHookError::ArtifactDestinationExists {
+                path: path.to_path_buf(),
+            }),
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        }
+    }
+
     fn revalidate_source(source: &ResolvedProjectPath) -> Result<&Path, FileHookError> {
         let path = source.as_path();
         let metadata = std::fs::symlink_metadata(path)?;
@@ -281,56 +343,102 @@ impl FileHook {
 
     fn capture_file(
         &self,
-        source: &ResolvedProjectPath,
-        artifact_dir: &Path,
+        planned: &PlannedFileCapture,
     ) -> Result<FileCapturedPerFile, FileHookError> {
-        let path = Self::revalidate_source(source)?;
-
-        // Compute hash if needed
-        let hash = match self.config.hash {
-            HashAlgorithm::Sha256 => {
-                debug!("FileHook: Computing SHA256 hash for: {}", path.display());
-                Some(format!("sha256:{}", file_digest_sha256(path)?))
-            }
-            HashAlgorithm::None => None,
-        };
-
-        // Copy or move file if needed
-        let copied_path = match self.config.mode {
-            CaptureMode::Copy | CaptureMode::Move => {
+        let path = Self::revalidate_source(&planned.source)?;
+        let copied_path = match planned.destination.as_deref() {
+            Some(destination) => {
                 debug!(
                     "FileHook: {:?} file to artifact directory",
                     self.config.mode
                 );
-                let relative_path =
-                    path.strip_prefix(self.project_root.as_path())
-                        .map_err(|_| FileHookError::WalkedPathOutsideProject {
-                            path: path.to_path_buf(),
-                            project_root: self.project_root.to_path_buf(),
-                        })?;
-                let dest_path = artifact_dir.join(relative_path);
-                let parent = dest_path.parent().ok_or_else(|| {
-                    FileHookError::InvalidArtifactDestination {
-                        path: dest_path.clone(),
-                    }
-                })?;
-                std::fs::create_dir_all(parent)?;
-                match self.config.mode {
-                    CaptureMode::Copy => std::fs::copy(path, &dest_path).map(|_| ())?,
-                    CaptureMode::Move => {
-                        std::fs::rename(path, &dest_path)?;
-                    }
-                    CaptureMode::None => unreachable!(),
-                }
-                Some(dest_path)
+                Self::copy_to_artifact(path, destination)?;
+                Some(destination.to_path_buf())
             }
-            CaptureMode::None => None,
+            None => None,
         };
+
+        let hash_target = copied_path.as_deref().unwrap_or(path);
+        let hash = match self.compute_hash(hash_target) {
+            Ok(hash) => hash,
+            Err(error) => {
+                if let Some(destination) = copied_path.as_deref() {
+                    Self::remove_partial_artifact(destination);
+                }
+                return Err(error);
+            }
+        };
+
+        if matches!(&self.config.mode, CaptureMode::Move) {
+            std::fs::remove_file(path).map_err(|source| FileHookError::RemoveMovedSource {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        }
 
         Ok(FileCapturedPerFile {
             path: path.to_path_buf(),
             copied_path,
             hash,
         })
+    }
+
+    fn copy_to_artifact(source: &Path, destination: &Path) -> Result<(), FileHookError> {
+        let parent =
+            destination
+                .parent()
+                .ok_or_else(|| FileHookError::InvalidArtifactDestination {
+                    path: destination.to_path_buf(),
+                })?;
+        std::fs::create_dir_all(parent)?;
+
+        let mut source_file = File::open(source)?;
+        let source_permissions = source_file.metadata()?.permissions();
+        let mut destination_file = match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(destination)
+        {
+            Ok(file) => file,
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+                return Err(FileHookError::ArtifactDestinationExists {
+                    path: destination.to_path_buf(),
+                });
+            }
+            Err(error) => return Err(error.into()),
+        };
+
+        let copy_result = std::io::copy(&mut source_file, &mut destination_file)
+            .and_then(|_| destination_file.set_permissions(source_permissions));
+        drop(destination_file);
+
+        match copy_result {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                Self::remove_partial_artifact(destination);
+                Err(error.into())
+            }
+        }
+    }
+
+    fn compute_hash(&self, path: &Path) -> Result<Option<String>, FileHookError> {
+        match self.config.hash {
+            HashAlgorithm::Sha256 => {
+                debug!("FileHook: Computing SHA256 hash for: {}", path.display());
+                Ok(Some(format!("sha256:{}", file_digest_sha256(path)?)))
+            }
+            HashAlgorithm::None => Ok(None),
+        }
+    }
+
+    fn remove_partial_artifact(path: &Path) {
+        match std::fs::remove_file(path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == ErrorKind::NotFound => {}
+            Err(error) => warn!(
+                "Failed to remove partial capture-file artifact {}: {error}",
+                path.display()
+            ),
+        }
     }
 }

--- a/crates/capsula-capture-file/tests/file_hook.rs
+++ b/crates/capsula-capture-file/tests/file_hook.rs
@@ -122,8 +122,8 @@ fn file_hook_captures_files_in_subdirectories() {
     );
     assert!(file_info.get("hash").is_some(), "Should have hash");
 
-    // Verify file was copied (by filename, flat)
-    let copied_path = artifact_dir.join("input.txt");
+    // Verify the project-relative path was preserved
+    let copied_path = artifact_dir.join("data").join("input.txt");
     assert!(
         copied_path.exists(),
         "File should be copied to artifact dir"
@@ -184,8 +184,12 @@ fn file_hook_captures_files_in_nested_subdirectories() {
         "Should capture the file in deeply nested subdirectory"
     );
 
-    // Verify file was copied (by filename, flat)
-    let copied_path = artifact_dir.join("config.json");
+    // Verify the project-relative path was preserved
+    let copied_path = artifact_dir
+        .join("data")
+        .join("deep")
+        .join("nested")
+        .join("config.json");
     assert!(
         copied_path.exists(),
         "File should be copied to artifact dir"
@@ -193,6 +197,58 @@ fn file_hook_captures_files_in_nested_subdirectories() {
 
     // Cleanup
     fs::remove_dir_all(&temp_dir).ok();
+}
+
+#[test]
+fn file_hook_preserves_paths_for_files_with_the_same_name() {
+    let temp_dir = std::env::temp_dir().join(format!("capsula_test_{}", Ulid::new()));
+    let run_dir = temp_dir.join("run");
+    let artifact_dir = run_dir.join("pre-0-capture-file");
+    let first_dir = temp_dir.join("a");
+    let second_dir = temp_dir.join("b");
+    fs::create_dir_all(&artifact_dir).unwrap();
+    fs::create_dir_all(&first_dir).unwrap();
+    fs::create_dir_all(&second_dir).unwrap();
+    fs::write(first_dir.join("config.json"), b"first").unwrap();
+    fs::write(second_dir.join("config.json"), b"second").unwrap();
+
+    let config = json!({
+        "glob": "**/config.json",
+        "mode": "copy",
+        "hash": "none"
+    });
+    let hook = <FileHook as Hook<PreRun>>::from_config(&config, &temp_dir).expect("from_config ok");
+    let run_metadata = PreparedRun {
+        id: Ulid::new(),
+        name: "test-run".to_string(),
+        command: vec![],
+        run_dir,
+        project_root: temp_dir.clone(),
+    };
+    let params = RuntimeParams::<PreRun>::with_artifact_dir(artifact_dir.clone());
+
+    let outcome = hook.run(&run_metadata, &params).expect("run ok");
+    let json = outcome
+        .output()
+        .serialize_json()
+        .expect("serialization should succeed");
+    let files = json
+        .get("files")
+        .and_then(|value| value.as_array())
+        .unwrap();
+
+    assert_eq!(files.len(), 2);
+    assert_eq!(
+        fs::read(artifact_dir.join("a/config.json")).unwrap(),
+        b"first"
+    );
+    assert_eq!(
+        fs::read(artifact_dir.join("b/config.json")).unwrap(),
+        b"second"
+    );
+    assert_ne!(files[0].get("copied_path"), files[1].get("copied_path"));
+
+    fs::remove_dir_all(temp_dir).ok();
 }
 
 #[test]

--- a/crates/capsula-capture-file/tests/file_hook.rs
+++ b/crates/capsula-capture-file/tests/file_hook.rs
@@ -5,9 +5,15 @@ use capsula_capture_file::FileHook;
 use capsula_core::captured::Captured;
 use capsula_core::hook::{Hook, PreRun, RuntimeParams};
 use capsula_core::run::PreparedRun;
+use capsula_core::util::hex_encode;
 use serde_json::json;
+use sha2::{Digest, Sha256};
 use std::fs;
 use ulid::Ulid;
+
+fn sha256(bytes: &[u8]) -> String {
+    format!("sha256:{}", hex_encode(Sha256::digest(bytes).as_ref()))
+}
 
 #[test]
 fn file_hook_captures_files_with_copy_mode() {
@@ -61,6 +67,13 @@ fn file_hook_captures_files_with_copy_mode() {
     assert!(
         copied_path.exists(),
         "File should be copied to artifact dir"
+    );
+    let copied_bytes = fs::read(&copied_path).unwrap();
+    let expected_hash = sha256(&copied_bytes);
+    assert_eq!(
+        file_info.get("hash").and_then(|value| value.as_str()),
+        Some(expected_hash.as_str()),
+        "Recorded hash should describe the archived bytes"
     );
 
     // Verify original file still exists
@@ -252,6 +265,47 @@ fn file_hook_preserves_paths_for_files_with_the_same_name() {
 }
 
 #[test]
+fn file_hook_rejects_existing_destinations_before_moving_files() {
+    let temp_dir = std::env::temp_dir().join(format!("capsula_test_{}", Ulid::new()));
+    let run_dir = temp_dir.join("run");
+    let artifact_dir = run_dir.join("pre-0-capture-file");
+    let first_source = temp_dir.join("a/config.json");
+    let second_source = temp_dir.join("b/config.json");
+    let existing_destination = artifact_dir.join("b/config.json");
+    fs::create_dir_all(first_source.parent().unwrap()).unwrap();
+    fs::create_dir_all(second_source.parent().unwrap()).unwrap();
+    fs::create_dir_all(existing_destination.parent().unwrap()).unwrap();
+    fs::write(&first_source, b"first").unwrap();
+    fs::write(&second_source, b"second").unwrap();
+    fs::write(&existing_destination, b"existing").unwrap();
+
+    let config = json!({
+        "glob": "*/config.json",
+        "mode": "move",
+        "hash": "none"
+    });
+    let hook = <FileHook as Hook<PreRun>>::from_config(&config, &temp_dir).expect("from_config ok");
+    let run_metadata = PreparedRun {
+        id: Ulid::new(),
+        name: "test-run".to_string(),
+        command: vec![],
+        run_dir,
+        project_root: temp_dir.clone(),
+    };
+    let params = RuntimeParams::<PreRun>::with_artifact_dir(artifact_dir.clone());
+
+    let result = hook.run(&run_metadata, &params);
+
+    assert!(result.is_err(), "existing destinations should be rejected");
+    assert!(first_source.exists(), "capture must be validated first");
+    assert!(second_source.exists(), "capture must be validated first");
+    assert!(!artifact_dir.join("a/config.json").exists());
+    assert_eq!(fs::read(existing_destination).unwrap(), b"existing");
+
+    fs::remove_dir_all(temp_dir).ok();
+}
+
+#[test]
 fn file_hook_wildcard_in_subdirectory() {
     // Arrange - create subdirectory with multiple files
     let temp_dir = std::env::temp_dir().join(format!("capsula_test_{}", Ulid::new()));
@@ -350,6 +404,58 @@ fn file_hook_captures_files_with_move_mode() {
 
     // Cleanup
     fs::remove_dir_all(&temp_dir).ok();
+}
+
+#[test]
+fn file_hook_move_creates_an_independent_hashed_artifact() {
+    let temp_dir = std::env::temp_dir().join(format!("capsula_test_{}", Ulid::new()));
+    let run_dir = temp_dir.join("run");
+    let artifact_dir = run_dir.join("pre-0-capture-file");
+    fs::create_dir_all(&artifact_dir).unwrap();
+
+    let source = temp_dir.join("moveme.txt");
+    let writer_link = temp_dir.join("writer.txt");
+    fs::write(&source, b"captured").unwrap();
+    fs::hard_link(&source, &writer_link).unwrap();
+
+    let config = json!({
+        "glob": "moveme.txt",
+        "mode": "move",
+        "hash": "sha256"
+    });
+    let hook = <FileHook as Hook<PreRun>>::from_config(&config, &temp_dir).expect("from_config ok");
+    let run_metadata = PreparedRun {
+        id: Ulid::new(),
+        name: "test-run".to_string(),
+        command: vec![],
+        run_dir,
+        project_root: temp_dir.clone(),
+    };
+    let params = RuntimeParams::<PreRun>::with_artifact_dir(artifact_dir.clone());
+
+    let outcome = hook.run(&run_metadata, &params).expect("run ok");
+    let json = outcome
+        .output()
+        .serialize_json()
+        .expect("serialization should succeed");
+    let file = &json
+        .get("files")
+        .and_then(|value| value.as_array())
+        .unwrap()[0];
+    let moved_path = artifact_dir.join("moveme.txt");
+
+    fs::write(writer_link, b"modified after capture").unwrap();
+
+    let moved_bytes = fs::read(moved_path).unwrap();
+    let expected_hash = sha256(&moved_bytes);
+    assert_eq!(moved_bytes, b"captured");
+    assert_eq!(
+        file.get("hash").and_then(|value| value.as_str()),
+        Some(expected_hash.as_str())
+    );
+    assert!(!source.exists());
+
+    fs::remove_dir_all(temp_dir).ok();
 }
 
 #[test]

--- a/docs/hooks/capture-file.md
+++ b/docs/hooks/capture-file.md
@@ -51,14 +51,22 @@ causes the hook to fail, and symbolic-link directories are not traversed.
 ### Mode Options
 
 - `"copy"` - Copies files to the hook's artifact directory, leaves originals
-- `"move"` - Moves files to the hook's artifact directory, removes originals
-- `"none"` - Only computes hash, doesn't copy or move
+- `"move"` - Copies files to the hook's artifact directory, then removes the originals
+- `"none"` - Only computes hashes, without copying or moving files
+
+When hashing is enabled for `"copy"` or `"move"`, each hash is computed from
+the completed artifact rather than reading the source again. In `"move"` mode,
+the source is removed only after the artifact has been successfully copied and
+any configured hash has been computed. In `"none"` mode, the source itself is
+hashed.
 
 !!! note "Per-hook artifact directory"
     When `mode` is `"copy"` or `"move"`, files are placed in a per-hook
     artifact directory named `{phase}-{index}-capture-file/` under the run
-    directory (e.g., `post-0-capture-file/`). This prevents filename
-    collisions between different `capture-file` hooks.
+    directory (e.g., `post-0-capture-file/`). Each file retains its path
+    relative to the project root: `results/a/data.csv` is stored as
+    `post-0-capture-file/results/a/data.csv`. Existing destinations are rejected
+    rather than overwritten.
 
 ### Example
 
@@ -85,16 +93,14 @@ hash = "sha256"
   },
   "files": [
     {
-      "src": "results/data.csv",
-      "dst": ".capsula/my-vault/2025-01-09/143022-happy-river/post-0-capture-file/data.csv",
-      "hash": "a1b2c3d4e5f6...",
-      "copied": true
+      "path": "/project/results/data.csv",
+      "copied_path": "/project/.capsula/my-vault/2025-01-09/143022-happy-river/post-0-capture-file/results/data.csv",
+      "hash": "sha256:a1b2c3d4e5f6..."
     },
     {
-      "src": "results/summary.csv",
-      "dst": ".capsula/my-vault/2025-01-09/143022-happy-river/post-0-capture-file/summary.csv",
-      "hash": "b2c3d4e5f6g7...",
-      "copied": true
+      "path": "/project/results/summary.csv",
+      "copied_path": "/project/.capsula/my-vault/2025-01-09/143022-happy-river/post-0-capture-file/results/summary.csv",
+      "hash": "sha256:b2c3d4e5f6g7..."
     }
   ]
 }


### PR DESCRIPTION
> [!WARNING]
> This content was written by an AI agent and must be verified by a human developer. After human verification, this alert may be removed.

## Summary

- Preserve each captured file's project-relative path under its hook artifact directory so same-basename files cannot overwrite each other.
- Plan and validate all destinations before mutation, and refuse to overwrite existing artifacts.
- Hash the completed archived bytes; implement move as copy, optional hash, then source removal so open writers cannot mutate the archived inode.
- Add regression coverage for path collisions, existing destinations, archived hashes, and independent moved artifacts.
- Update the `capture-file` documentation and output examples.

Closes #1081.

Validation:

- `just lint`
- `just test`

## AI assistance

- AI used: yes — an AI coding agent investigated the issue, implemented the changes, added tests, and drafted this description.
- Human review of AI-assisted code: pending

## Breaking changes

- [ ] No breaking changes
- [x] Breaking changes; the `breaking change` label is applied

<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #1147 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #1146
- <kbd>&nbsp;2&nbsp;</kbd> #1098
- <kbd>&nbsp;1&nbsp;</kbd> #1097
<!-- GitButler Footer Boundary Bottom -->