### PR TITLE
chore: add rust-analyzer to Rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.97.1"
 profile = "default"
+components = ["rust-analyzer"]


### PR DESCRIPTION
## Summary

- Add `rust-analyzer` to the components installed for the repository-pinned Rust toolchain because it is not included in the `default` profile.
- Ensure editors can start the language server without requiring a separate per-toolchain installation.

## AI assistance

- AI used: yes — investigated the Helix LSP startup failure and made the toolchain configuration change.
- Human review of AI-assisted code: complete

## Breaking changes

- [x] No breaking changes
- [ ] Breaking changes; the `breaking change` label is applied

## Testing

- `just lint`
- `just test`