### PR TITLE
feat: add client-side authentication via configurable server headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,6 +542,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "capsula-client",
+ "capsula-config",
  "capsula-core",
  "capsula-orchestration",
  "capsula-registry",
@@ -692,6 +693,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.19",
+ "tokio",
  "wiremock",
 ]
 
@@ -753,6 +755,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "shlex",
  "tracing",
  "ulid",
  "walkdir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,9 +756,12 @@ dependencies = [
  "serde",
  "serde_json",
  "shlex",
+ "tempfile",
+ "tokio",
  "tracing",
  "ulid",
  "walkdir",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/capsula-cli/Cargo.toml
+++ b/crates/capsula-cli/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 capsula-client = { workspace = true }
+capsula-config = { workspace = true }
 capsula-tui = { workspace = true }
 capsula-core = { workspace = true }
 capsula-orchestration = { workspace = true }

--- a/crates/capsula-cli/src/main.rs
+++ b/crates/capsula-cli/src/main.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result};
 use capsula_core::hook::{PostRun, PreRun};
 use capsula_core::run::PreparedRun;
 use capsula_orchestration::push::push_single_run;
-use capsula_orchestration::resolve::resolve_server_url;
+use capsula_orchestration::resolve::{resolve_server_headers, resolve_server_url};
 use capsula_orchestration::run::{create_and_setup_run, run_post_hooks, run_pre_hooks};
 use capsula_orchestration::setup::LoadedConfig;
 use capsula_orchestration::vault::{find_run_dir, find_run_dir_by_name, list_runs};
@@ -394,14 +394,7 @@ path = \".\"
             all,
             server,
         } => {
-            let server_url =
-                resolve_server_url(server, config.server.as_deref()).ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "Server URL not specified. Use --server <URL>, set CAPSULA_SERVER_URL environment variable, or add 'server = \"URL\"' to capsula.toml"
-                    )
-                })?;
-
-            let client = capsula_client::CapsulaClient::new(&server_url);
+            let (server_url, client) = build_server_client(server, config.server.as_ref())?;
             let vault_name = &config.vault.name;
 
             match client.vault_exists(vault_name) {
@@ -488,16 +481,10 @@ path = \".\"
         Commands::Tui => unreachable!("Handled above"),
         Commands::Vaults { command } => match command {
             VaultsCommands::List { server } => {
-                let server_url =
-                    resolve_server_url(server, config.server.as_deref()).ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "Server URL not specified. Use --server <URL>, set CAPSULA_SERVER_URL environment variable, or add 'server = \"URL\"' to capsula.toml"
-                        )
-                    })?;
+                let (server_url, client) = build_server_client(server, config.server.as_ref())?;
 
                 info!("Fetching vaults from server {}", server_url);
 
-                let client = capsula_client::CapsulaClient::new(&server_url);
                 let vaults = client.list_vaults().context("Failed to list vaults")?;
 
                 if vaults.is_empty() {
@@ -516,6 +503,30 @@ path = \".\"
         },
     }
     Ok(())
+}
+
+/// Resolve the server URL and configured headers, and build an HTTP client.
+fn build_server_client(
+    server_override: Option<String>,
+    config_server: Option<&capsula_config::ServerConfig>,
+) -> Result<(String, capsula_client::CapsulaClient)> {
+    let server_url = resolve_server_url(server_override, config_server.map(|s| s.url.as_str()))
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Server URL not specified. Use --server <URL>, set CAPSULA_SERVER_URL environment variable, or add 'server = \"URL\"' to capsula.toml"
+            )
+        })?;
+
+    let headers = config_server
+        .map(|s| resolve_server_headers(&s.headers))
+        .transpose()
+        .context("Failed to resolve server headers")?
+        .unwrap_or_default();
+
+    let client = capsula_client::CapsulaClient::with_headers(&server_url, &headers)
+        .context("Failed to build server client")?;
+
+    Ok((server_url, client))
 }
 
 fn read_json_if_exists(path: &std::path::Path) -> Result<Option<serde_json::Value>> {

--- a/crates/capsula-cli/src/main.rs
+++ b/crates/capsula-cli/src/main.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result};
 use capsula_core::hook::{PostRun, PreRun};
 use capsula_core::run::PreparedRun;
 use capsula_orchestration::push::push_single_run;
-use capsula_orchestration::resolve::{resolve_server_headers, resolve_server_url};
+use capsula_orchestration::resolve::{is_same_origin, resolve_server_headers, resolve_server_url};
 use capsula_orchestration::run::{create_and_setup_run, run_post_hooks, run_pre_hooks};
 use capsula_orchestration::setup::LoadedConfig;
 use capsula_orchestration::vault::{find_run_dir, find_run_dir_by_name, list_runs};
@@ -83,6 +83,11 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
+    #[command(group(
+        clap::ArgGroup::new("push_target")
+            .required(true)
+            .args(["run_id", "all"])
+    ))]
     Push {
         /// Run ID or name to push (e.g., 01HQXYZ... or chubby-back)
         run_id: Option<String>,
@@ -394,7 +399,8 @@ path = \".\"
             all,
             server,
         } => {
-            let (server_url, client) = build_server_client(server, config.server.as_ref())?;
+            let (server_url, client) =
+                build_server_client(server, config.server.as_ref(), &project_root)?;
             let vault_name = &config.vault.name;
 
             match client.vault_exists(vault_name) {
@@ -445,7 +451,7 @@ path = \".\"
                             continue;
                         }
 
-                        match push_single_run(run_dir, vault_name, &server_url, &client) {
+                        match push_single_run(run_dir, vault_name, &client) {
                             Ok(()) => success_count += 1,
                             Err(e) => {
                                 if e.to_string().contains("already exists") {
@@ -471,17 +477,20 @@ path = \".\"
                     info!("Pushing run {} to server {}", run_id, server_url);
 
                     let run_dir = find_run_dir(&vault_dir, &run_id)?;
-                    push_single_run(&run_dir, vault_name, &server_url, &client)?;
+                    push_single_run(&run_dir, vault_name, &client)?;
 
                     info!("Push completed successfully");
                 }
-                (false, None) => anyhow::bail!("Either provide a run ID/name or use --all flag"),
+                (false, None) => {
+                    unreachable!("clap's push_target group requires a run ID or --all")
+                }
             }
         }
         Commands::Tui => unreachable!("Handled above"),
         Commands::Vaults { command } => match command {
             VaultsCommands::List { server } => {
-                let (server_url, client) = build_server_client(server, config.server.as_ref())?;
+                let (server_url, client) =
+                    build_server_client(server, config.server.as_ref(), &project_root)?;
 
                 info!("Fetching vaults from server {}", server_url);
 
@@ -506,9 +515,14 @@ path = \".\"
 }
 
 /// Resolve the server URL and configured headers, and build an HTTP client.
+///
+/// Configured `[server.headers]` credentials are bound to the configured
+/// server origin: a `--server` / `CAPSULA_SERVER_URL` override pointing at a
+/// different origin is rejected rather than silently receiving them.
 fn build_server_client(
     server_override: Option<String>,
     config_server: Option<&capsula_config::ServerConfig>,
+    project_root: &std::path::Path,
 ) -> Result<(String, capsula_client::CapsulaClient)> {
     let server_url = resolve_server_url(server_override, config_server.map(|s| s.url.as_str()))
         .ok_or_else(|| {
@@ -517,11 +531,21 @@ fn build_server_client(
             )
         })?;
 
-    let headers = config_server
-        .map(|s| resolve_server_headers(&s.headers))
-        .transpose()
-        .context("Failed to resolve server headers")?
-        .unwrap_or_default();
+    let headers = match config_server {
+        Some(config) if !config.headers.is_empty() => {
+            if !is_same_origin(&server_url, &config.url)? {
+                anyhow::bail!(
+                    "Server URL '{server_url}' has a different origin than the configured server '{}'. \
+                     [server.headers] credentials are only sent to the configured origin; \
+                     use the configured URL, or remove the override or the headers.",
+                    config.url
+                );
+            }
+            resolve_server_headers(&config.headers, project_root)
+                .context("Failed to resolve server headers")?
+        }
+        _ => Vec::new(),
+    };
 
     let client = capsula_client::CapsulaClient::with_headers(&server_url, &headers)
         .context("Failed to build server client")?;

--- a/crates/capsula-client/Cargo.toml
+++ b/crates/capsula-client/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+tokio = { workspace = true }
 wiremock = { workspace = true }
 
 [lints]

--- a/crates/capsula-client/src/lib.rs
+++ b/crates/capsula-client/src/lib.rs
@@ -1,5 +1,7 @@
 use capsula_api_types::{UploadResponse, VaultExistsResponse, VaultInfo, VaultsResponse};
+use reqwest::StatusCode;
 use reqwest::blocking::multipart;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde_json::Value as JsonValue;
 use std::path::Path;
 use thiserror::Error;
@@ -17,6 +19,9 @@ pub enum ClientError {
 
     #[error("Server returned error: {0}")]
     ServerError(String),
+
+    #[error("Invalid header '{name}': {message}")]
+    InvalidHeader { name: String, message: String },
 }
 
 pub type Result<T> = std::result::Result<T, ClientError>;
@@ -36,16 +41,55 @@ impl CapsulaClient {
         }
     }
 
+    /// Create a client that attaches the given headers to every request.
+    pub fn with_headers(base_url: impl Into<String>, headers: &[(String, String)]) -> Result<Self> {
+        let mut header_map = HeaderMap::new();
+        for (name, value) in headers {
+            let header_name = HeaderName::from_bytes(name.as_bytes()).map_err(|e| {
+                ClientError::InvalidHeader {
+                    name: name.clone(),
+                    message: e.to_string(),
+                }
+            })?;
+            let mut header_value =
+                HeaderValue::from_str(value).map_err(|e| ClientError::InvalidHeader {
+                    name: name.clone(),
+                    message: e.to_string(),
+                })?;
+            // Keep credential values out of debug logs
+            header_value.set_sensitive(true);
+            header_map.insert(header_name, header_value);
+        }
+
+        let client = reqwest::blocking::Client::builder()
+            .default_headers(header_map)
+            .build()?;
+
+        Ok(Self {
+            base_url: base_url.into(),
+            client,
+        })
+    }
+
+    fn server_error(action: &str, status: StatusCode) -> ClientError {
+        let auth_hint = if matches!(status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN) {
+            " (authentication may be missing or expired; check [server.headers] in capsula.toml)"
+        } else {
+            ""
+        };
+        ClientError::ServerError(format!("{action}: {status}{auth_hint}"))
+    }
+
     /// List all vaults on the server
     pub fn list_vaults(&self) -> Result<Vec<VaultInfo>> {
         let url = format!("{}/api/v1/vaults", self.base_url);
         let response = self.client.get(&url).send()?;
 
         if !response.status().is_success() {
-            return Err(ClientError::ServerError(format!(
-                "Failed to list vaults: {}",
-                response.status()
-            )));
+            return Err(Self::server_error(
+                "Failed to list vaults",
+                response.status(),
+            ));
         }
 
         let vaults_response: VaultsResponse = response.json()?;
@@ -58,10 +102,10 @@ impl CapsulaClient {
         let response = self.client.get(&url).send()?;
 
         if !response.status().is_success() {
-            return Err(ClientError::ServerError(format!(
-                "Failed to check vault: {}",
-                response.status()
-            )));
+            return Err(Self::server_error(
+                "Failed to check vault",
+                response.status(),
+            ));
         }
 
         let vault_response: VaultExistsResponse = response.json()?;
@@ -117,10 +161,7 @@ impl CapsulaClient {
         let response = self.client.post(&url).multipart(form).send()?;
 
         if !response.status().is_success() {
-            return Err(ClientError::ServerError(format!(
-                "Upload failed: {}",
-                response.status()
-            )));
+            return Err(Self::server_error("Upload failed", response.status()));
         }
 
         let upload_response: UploadResponse = response.json()?;
@@ -136,5 +177,77 @@ mod tests {
     fn test_client_creation() {
         let client = CapsulaClient::new("http://localhost:8500");
         assert_eq!(client.base_url, "http://localhost:8500");
+    }
+
+    #[test]
+    fn rejects_invalid_header_name() {
+        let result = CapsulaClient::with_headers(
+            "http://localhost:8500",
+            &[("bad header".to_string(), "value".to_string())],
+        );
+
+        assert!(matches!(result, Err(ClientError::InvalidHeader { .. })));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn sends_configured_headers_with_requests() {
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/vaults"))
+            .and(header("cf-access-token", "test-jwt"))
+            .and(header("authorization", "Bearer abc123"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "status": "ok", "vaults": [] })),
+            )
+            .mount(&server)
+            .await;
+
+        let uri = server.uri();
+        // The blocking client must be created and dropped outside the async runtime
+        let vaults = tokio::task::spawn_blocking(move || {
+            let client = CapsulaClient::with_headers(
+                uri,
+                &[
+                    ("cf-access-token".to_string(), "test-jwt".to_string()),
+                    ("Authorization".to_string(), "Bearer abc123".to_string()),
+                ],
+            )
+            .unwrap();
+            client.list_vaults()
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert!(vaults.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn hints_at_authentication_on_forbidden_response() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/vaults"))
+            .respond_with(ResponseTemplate::new(403))
+            .mount(&server)
+            .await;
+
+        let uri = server.uri();
+        let error = tokio::task::spawn_blocking(move || CapsulaClient::new(uri).list_vaults())
+            .await
+            .unwrap()
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("authentication may be missing or expired")
+        );
     }
 }

--- a/crates/capsula-client/src/lib.rs
+++ b/crates/capsula-client/src/lib.rs
@@ -2,6 +2,7 @@ use capsula_api_types::{UploadResponse, VaultExistsResponse, VaultInfo, VaultsRe
 use reqwest::StatusCode;
 use reqwest::blocking::multipart;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use reqwest::redirect::Policy;
 use serde_json::Value as JsonValue;
 use std::path::Path;
 use thiserror::Error;
@@ -26,6 +27,15 @@ pub enum ClientError {
 
 pub type Result<T> = std::result::Result<T, ClientError>;
 
+/// Outcome of registering a run on the server.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CreateRunOutcome {
+    /// The run was newly created.
+    Created,
+    /// A run with the same ID already exists on the server.
+    AlreadyExists,
+}
+
 #[derive(Debug, Clone)]
 pub struct CapsulaClient {
     base_url: String,
@@ -35,9 +45,17 @@ pub struct CapsulaClient {
 impl CapsulaClient {
     /// Create a new Capsula client
     pub fn new(base_url: impl Into<String>) -> Self {
+        #[expect(
+            clippy::expect_used,
+            reason = "mirrors reqwest::blocking::Client::new(), which panics if the client cannot be initialized"
+        )]
+        let client = reqwest::blocking::Client::builder()
+            .redirect(Policy::none())
+            .build()
+            .expect("failed to initialize HTTP client");
         Self {
             base_url: base_url.into(),
-            client: reqwest::blocking::Client::new(),
+            client,
         }
     }
 
@@ -61,8 +79,11 @@ impl CapsulaClient {
             header_map.insert(header_name, header_value);
         }
 
+        // Never follow redirects: a cross-origin redirect would forward the
+        // configured credential headers to the redirect target
         let client = reqwest::blocking::Client::builder()
             .default_headers(header_map)
+            .redirect(Policy::none())
             .build()?;
 
         Ok(Self {
@@ -72,12 +93,14 @@ impl CapsulaClient {
     }
 
     fn server_error(action: &str, status: StatusCode) -> ClientError {
-        let auth_hint = if matches!(status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN) {
+        let hint = if matches!(status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN) {
             " (authentication may be missing or expired; check [server.headers] in capsula.toml)"
+        } else if status.is_redirection() {
+            " (the server redirected the request, possibly to a login page; redirects are not followed — check the server URL and authentication configuration)"
         } else {
             ""
         };
-        ClientError::ServerError(format!("{action}: {status}{auth_hint}"))
+        ClientError::ServerError(format!("{action}: {status}{hint}"))
     }
 
     /// List all vaults on the server
@@ -110,6 +133,18 @@ impl CapsulaClient {
 
         let vault_response: VaultExistsResponse = response.json()?;
         Ok(vault_response.vault)
+    }
+
+    /// Register a run's metadata on the server.
+    pub fn create_run(&self, run: &JsonValue) -> Result<CreateRunOutcome> {
+        let url = format!("{}/api/v1/runs", self.base_url);
+        let response = self.client.post(&url).json(run).send()?;
+
+        match response.status() {
+            StatusCode::CONFLICT => Ok(CreateRunOutcome::AlreadyExists),
+            status if status.is_success() => Ok(CreateRunOutcome::Created),
+            status => Err(Self::server_error("Failed to create run on server", status)),
+        }
     }
 
     /// Upload a run's data and files to the server
@@ -224,6 +259,112 @@ mod tests {
         .unwrap();
 
         assert!(vaults.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn create_run_sends_headers_and_maps_conflict_to_already_exists() {
+        use wiremock::matchers::{body_json, header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let created = MockServer::start().await;
+        let payload = serde_json::json!({ "id": "01RUN", "vault": "v" });
+        Mock::given(method("POST"))
+            .and(path("/api/v1/runs"))
+            .and(header("x-auth", "secret"))
+            .and(body_json(payload.clone()))
+            .respond_with(ResponseTemplate::new(201))
+            .mount(&created)
+            .await;
+
+        let conflicting = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/v1/runs"))
+            .respond_with(ResponseTemplate::new(409))
+            .mount(&conflicting)
+            .await;
+
+        let created_uri = created.uri();
+        let conflicting_uri = conflicting.uri();
+        let (first, second) = tokio::task::spawn_blocking(move || {
+            let auth = [("x-auth".to_string(), "secret".to_string())];
+            let first = CapsulaClient::with_headers(created_uri, &auth)
+                .unwrap()
+                .create_run(&payload);
+            let second = CapsulaClient::with_headers(conflicting_uri, &auth)
+                .unwrap()
+                .create_run(&payload);
+            (first, second)
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(first.unwrap(), CreateRunOutcome::Created);
+        assert_eq!(second.unwrap(), CreateRunOutcome::AlreadyExists);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn vault_exists_sends_configured_headers() {
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/vaults/my-vault"))
+            .and(header("x-auth", "secret"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({ "status": "ok", "exists": false, "vault": null }),
+            ))
+            .mount(&server)
+            .await;
+
+        let uri = server.uri();
+        let vault = tokio::task::spawn_blocking(move || {
+            CapsulaClient::with_headers(uri, &[("x-auth".to_string(), "secret".to_string())])
+                .unwrap()
+                .vault_exists("my-vault")
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert!(vault.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn does_not_follow_redirects_and_reports_them() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let target = MockServer::start().await;
+        let origin = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/vaults"))
+            .respond_with(
+                ResponseTemplate::new(302)
+                    .insert_header("location", format!("{}/api/v1/vaults", target.uri())),
+            )
+            .mount(&origin)
+            .await;
+
+        let uri = origin.uri();
+        let error = tokio::task::spawn_blocking(move || {
+            CapsulaClient::with_headers(
+                uri,
+                &[(
+                    "cf-access-client-secret".to_string(),
+                    "top-secret".to_string(),
+                )],
+            )
+            .unwrap()
+            .list_vaults()
+        })
+        .await
+        .unwrap()
+        .unwrap_err();
+
+        assert!(error.to_string().contains("redirects are not followed"));
+        // The credential header must never reach the redirect target
+        assert!(target.received_requests().await.unwrap().is_empty());
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/capsula-config/src/lib.rs
+++ b/crates/capsula-config/src/lib.rs
@@ -3,6 +3,7 @@ use capsula_core::{
     hook::PhaseMarker,
 };
 use serde::{Deserialize, Deserializer};
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 use tracing::debug;
@@ -50,11 +51,84 @@ pub struct CapsulaConfig {
     #[serde(default)]
     pub dotenv: Option<PathBuf>,
     #[serde(default)]
-    pub server: Option<String>,
+    pub server: Option<ServerConfig>,
     #[serde(default)]
     pub pre_run: HookPhaseConfig,
     #[serde(default)]
     pub post_run: HookPhaseConfig,
+}
+
+/// Server connection settings.
+///
+/// Accepts either a plain URL string (`server = "https://..."`) or a table
+/// with a `url` and optional `headers` attached to every request:
+///
+/// ```toml
+/// [server]
+/// url = "https://capsula.example.com"
+///
+/// [server.headers]
+/// Authorization = { env = "CAPSULA_TOKEN", prefix = "Bearer " }
+/// ```
+#[derive(Debug, Clone)]
+pub struct ServerConfig {
+    pub url: String,
+    pub headers: BTreeMap<String, HeaderValueSource>,
+}
+
+impl<'de> Deserialize<'de> for ServerConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum ServerConfigHelper {
+            Url(String),
+            Detailed {
+                url: String,
+                #[serde(default)]
+                headers: BTreeMap<String, HeaderValueSource>,
+            },
+        }
+
+        Ok(match ServerConfigHelper::deserialize(deserializer)? {
+            ServerConfigHelper::Url(url) => Self {
+                url,
+                headers: BTreeMap::new(),
+            },
+            ServerConfigHelper::Detailed { url, headers } => Self { url, headers },
+        })
+    }
+}
+
+/// Source of an HTTP header value sent with server requests.
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum HeaderValueSource {
+    /// The string is used as the header value verbatim.
+    Literal(String),
+    /// The value is read from an environment variable.
+    Env(EnvHeaderSource),
+    /// The value is the trimmed stdout of a command.
+    Command(CommandHeaderSource),
+}
+
+/// Header value read from an environment variable.
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct EnvHeaderSource {
+    pub env: String,
+    /// Prepended to the variable's value (e.g. `"Bearer "`).
+    #[serde(default)]
+    pub prefix: Option<String>,
+}
+
+/// Header value produced by running a command and capturing its stdout.
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct CommandHeaderSource {
+    pub command: String,
 }
 
 #[derive(Debug, Clone)]
@@ -209,6 +283,109 @@ id = "capture-cwd"
 
         assert_eq!(config.vault.name, "my_vault");
         assert_eq!(config.vault.path, PathBuf::from("/custom/path/to/vault"));
+    }
+
+    #[test]
+    fn parses_server_as_plain_url_string() {
+        let config_str = r#"
+server = "https://capsula.example.com"
+
+[vault]
+name = "v"
+"#;
+
+        let config = CapsulaConfig::from_toml_str(config_str).unwrap();
+
+        let server = config.server.unwrap();
+        assert_eq!(server.url, "https://capsula.example.com");
+        assert!(server.headers.is_empty());
+    }
+
+    #[test]
+    fn server_defaults_to_none_when_absent() {
+        let config_str = r#"
+[vault]
+name = "v"
+"#;
+
+        let config = CapsulaConfig::from_toml_str(config_str).unwrap();
+
+        assert!(config.server.is_none());
+    }
+
+    #[test]
+    fn parses_server_table_with_all_header_source_kinds() {
+        let config_str = r#"
+[vault]
+name = "v"
+
+[server]
+url = "https://capsula.example.com"
+
+[server.headers]
+x-literal = "fixed-value"
+Authorization = { env = "CAPSULA_TOKEN", prefix = "Bearer " }
+cf-access-token = { command = "cloudflared access token --app=https://capsula.example.com" }
+CF-Access-Client-Id = { env = "CF_ACCESS_CLIENT_ID" }
+"#;
+
+        let config = CapsulaConfig::from_toml_str(config_str).unwrap();
+
+        let server = config.server.unwrap();
+        assert_eq!(server.url, "https://capsula.example.com");
+        assert_eq!(
+            server.headers["x-literal"],
+            HeaderValueSource::Literal("fixed-value".to_string())
+        );
+        assert_eq!(
+            server.headers["Authorization"],
+            HeaderValueSource::Env(EnvHeaderSource {
+                env: "CAPSULA_TOKEN".to_string(),
+                prefix: Some("Bearer ".to_string()),
+            })
+        );
+        assert_eq!(
+            server.headers["cf-access-token"],
+            HeaderValueSource::Command(CommandHeaderSource {
+                command: "cloudflared access token --app=https://capsula.example.com".to_string(),
+            })
+        );
+        assert_eq!(
+            server.headers["CF-Access-Client-Id"],
+            HeaderValueSource::Env(EnvHeaderSource {
+                env: "CF_ACCESS_CLIENT_ID".to_string(),
+                prefix: None,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_header_source_mixing_env_and_command() {
+        let config_str = r#"
+[vault]
+name = "v"
+
+[server]
+url = "https://capsula.example.com"
+
+[server.headers]
+Authorization = { env = "CAPSULA_TOKEN", command = "echo x" }
+"#;
+
+        assert!(CapsulaConfig::from_toml_str(config_str).is_err());
+    }
+
+    #[test]
+    fn rejects_server_table_without_url() {
+        let config_str = r#"
+[vault]
+name = "v"
+
+[server]
+headers = {}
+"#;
+
+        assert!(CapsulaConfig::from_toml_str(config_str).is_err());
     }
 
     #[test]

--- a/crates/capsula-config/src/lib.rs
+++ b/crates/capsula-config/src/lib.rs
@@ -82,14 +82,18 @@ impl<'de> Deserialize<'de> for ServerConfig {
         D: Deserializer<'de>,
     {
         #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct DetailedServerConfigHelper {
+            url: String,
+            #[serde(default)]
+            headers: BTreeMap<String, HeaderValueSource>,
+        }
+
+        #[derive(Deserialize)]
         #[serde(untagged)]
         enum ServerConfigHelper {
             Url(String),
-            Detailed {
-                url: String,
-                #[serde(default)]
-                headers: BTreeMap<String, HeaderValueSource>,
-            },
+            Detailed(DetailedServerConfigHelper),
         }
 
         Ok(match ServerConfigHelper::deserialize(deserializer)? {
@@ -97,7 +101,10 @@ impl<'de> Deserialize<'de> for ServerConfig {
                 url,
                 headers: BTreeMap::new(),
             },
-            ServerConfigHelper::Detailed { url, headers } => Self { url, headers },
+            ServerConfigHelper::Detailed(detailed) => Self {
+                url: detailed.url,
+                headers: detailed.headers,
+            },
         })
     }
 }
@@ -370,6 +377,22 @@ url = "https://capsula.example.com"
 
 [server.headers]
 Authorization = { env = "CAPSULA_TOKEN", command = "echo x" }
+"#;
+
+        assert!(CapsulaConfig::from_toml_str(config_str).is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_field_in_server_table() {
+        let config_str = r#"
+[vault]
+name = "v"
+
+[server]
+url = "https://capsula.example.com"
+
+[server.header]
+Authorization = "typo-should-fail"
 "#;
 
         assert!(CapsulaConfig::from_toml_str(config_str).is_err());

--- a/crates/capsula-orchestration/Cargo.toml
+++ b/crates/capsula-orchestration/Cargo.toml
@@ -27,5 +27,10 @@ tracing = { workspace = true }
 ulid = { workspace = true }
 walkdir = "2"
 
+[dev-dependencies]
+tempfile = { workspace = true }
+tokio = { workspace = true }
+wiremock = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/capsula-orchestration/Cargo.toml
+++ b/crates/capsula-orchestration/Cargo.toml
@@ -22,6 +22,7 @@ names = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+shlex = { workspace = true }
 tracing = { workspace = true }
 ulid = { workspace = true }
 walkdir = "2"

--- a/crates/capsula-orchestration/src/push.rs
+++ b/crates/capsula-orchestration/src/push.rs
@@ -6,7 +6,6 @@ use tracing::{debug, info};
 pub fn push_single_run(
     run_dir: &Path,
     vault_name: &str,
-    server_url: &str,
     client: &capsula_client::CapsulaClient,
 ) -> Result<()> {
     let capsula_dir = run_dir.join("_capsula");
@@ -63,17 +62,12 @@ pub fn push_single_run(
         "stderr": command_output.get("stderr"),
     });
 
-    // Post the run metadata
-    let url = format!("{server_url}/api/v1/runs");
-    let http_client = reqwest::blocking::Client::new();
-    let response = http_client.post(&url).json(&create_run_payload).send()?;
-
-    if !response.status().is_success() {
-        if response.status().as_u16() == 409 {
+    // Post the run metadata through the authenticated client
+    match client.create_run(&create_run_payload)? {
+        capsula_client::CreateRunOutcome::AlreadyExists => {
             info!("Run already registered on server, re-uploading files: {run_name}");
-        } else {
-            anyhow::bail!("Failed to create run on server: {}", response.status());
         }
+        capsula_client::CreateRunOutcome::Created => {}
     }
 
     // Collect files to upload

--- a/crates/capsula-orchestration/src/resolve.rs
+++ b/crates/capsula-orchestration/src/resolve.rs
@@ -1,3 +1,6 @@
+use anyhow::Context;
+use capsula_config::HeaderValueSource;
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use tracing::debug;
 
@@ -70,4 +73,165 @@ pub fn resolve_server_url(
     }
 
     None
+}
+
+/// Resolve configured server headers into concrete `(name, value)` pairs.
+///
+/// Environment variables and commands are evaluated at call time, so dotenv
+/// should be loaded before calling.
+pub fn resolve_server_headers(
+    headers: &BTreeMap<String, HeaderValueSource>,
+) -> anyhow::Result<Vec<(String, String)>> {
+    headers
+        .iter()
+        .map(|(name, source)| {
+            let value = resolve_header_value(name, source)?;
+            debug!("Resolved server header: {}", name);
+            Ok((name.clone(), value))
+        })
+        .collect()
+}
+
+fn resolve_header_value(name: &str, source: &HeaderValueSource) -> anyhow::Result<String> {
+    match source {
+        HeaderValueSource::Literal(value) => Ok(value.clone()),
+        HeaderValueSource::Env(env_source) => {
+            let value = std::env::var(&env_source.env).with_context(|| {
+                format!(
+                    "Header '{name}': environment variable '{}' is not set",
+                    env_source.env
+                )
+            })?;
+            Ok(match &env_source.prefix {
+                Some(prefix) => format!("{prefix}{value}"),
+                None => value,
+            })
+        }
+        HeaderValueSource::Command(command_source) => {
+            run_header_command(name, &command_source.command)
+        }
+    }
+}
+
+fn run_header_command(name: &str, command: &str) -> anyhow::Result<String> {
+    let tokens = shlex::split(command)
+        .ok_or_else(|| anyhow::anyhow!("Header '{name}': failed to parse command: {command}"))?;
+    let [program, args @ ..] = tokens.as_slice() else {
+        anyhow::bail!("Header '{name}': command is empty");
+    };
+
+    let output = std::process::Command::new(program)
+        .args(args)
+        .output()
+        .with_context(|| format!("Header '{name}': failed to execute command '{command}'"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "Header '{name}': command '{command}' failed with {}: {}",
+            output.status,
+            stderr.trim_end()
+        );
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(stdout.trim_end_matches(['\r', '\n']).to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use capsula_config::{CommandHeaderSource, EnvHeaderSource};
+
+    fn env_source(env: &str, prefix: Option<&str>) -> HeaderValueSource {
+        HeaderValueSource::Env(EnvHeaderSource {
+            env: env.to_string(),
+            prefix: prefix.map(str::to_string),
+        })
+    }
+
+    fn command_source(command: &str) -> HeaderValueSource {
+        HeaderValueSource::Command(CommandHeaderSource {
+            command: command.to_string(),
+        })
+    }
+
+    #[test]
+    fn resolves_literal_value_verbatim() {
+        let headers = BTreeMap::from([(
+            "x-static".to_string(),
+            HeaderValueSource::Literal("fixed".to_string()),
+        )]);
+
+        let resolved = resolve_server_headers(&headers).unwrap();
+
+        assert_eq!(
+            resolved,
+            vec![("x-static".to_string(), "fixed".to_string())]
+        );
+    }
+
+    #[test]
+    fn resolves_env_value_with_prefix() {
+        // PATH is guaranteed to be set in test environments
+        let path_value = std::env::var("PATH").unwrap();
+        let headers = BTreeMap::from([(
+            "authorization".to_string(),
+            env_source("PATH", Some("Bearer ")),
+        )]);
+
+        let resolved = resolve_server_headers(&headers).unwrap();
+
+        assert_eq!(resolved[0].1, format!("Bearer {path_value}"));
+    }
+
+    #[test]
+    fn fails_when_env_var_is_missing() {
+        let headers = BTreeMap::from([(
+            "authorization".to_string(),
+            env_source("CAPSULA_TEST_UNSET_VAR_1153", None),
+        )]);
+
+        let error = resolve_server_headers(&headers).unwrap_err();
+
+        assert!(error.to_string().contains("CAPSULA_TEST_UNSET_VAR_1153"));
+    }
+
+    #[test]
+    fn resolves_command_stdout_with_trailing_newline_trimmed() {
+        let headers = BTreeMap::from([("x-token".to_string(), command_source("echo token-value"))]);
+
+        let resolved = resolve_server_headers(&headers).unwrap();
+
+        assert_eq!(
+            resolved,
+            vec![("x-token".to_string(), "token-value".to_string())]
+        );
+    }
+
+    #[test]
+    fn fails_with_stderr_when_command_exits_nonzero() {
+        let headers = BTreeMap::from([(
+            "x-token".to_string(),
+            command_source("sh -c 'echo session-expired >&2; exit 1'"),
+        )]);
+
+        let error = resolve_server_headers(&headers).unwrap_err();
+
+        let message = error.to_string();
+        assert!(message.contains("x-token"));
+        assert!(message.contains("session-expired"));
+    }
+
+    #[test]
+    fn fails_when_command_is_not_found() {
+        let headers = BTreeMap::from([(
+            "x-token".to_string(),
+            command_source("capsula-test-nonexistent-binary-1153"),
+        )]);
+
+        let error = resolve_server_headers(&headers).unwrap_err();
+
+        assert!(error.to_string().contains("failed to execute"));
+    }
 }

--- a/crates/capsula-orchestration/src/resolve.rs
+++ b/crates/capsula-orchestration/src/resolve.rs
@@ -75,24 +75,38 @@ pub fn resolve_server_url(
     None
 }
 
+/// Check whether two URLs share the same origin (scheme, host, and effective port).
+pub fn is_same_origin(a: &str, b: &str) -> anyhow::Result<bool> {
+    let parse = |input: &str| {
+        reqwest::Url::parse(input).with_context(|| format!("Invalid server URL: {input}"))
+    };
+    Ok(parse(a)?.origin() == parse(b)?.origin())
+}
+
 /// Resolve configured server headers into concrete `(name, value)` pairs.
 ///
 /// Environment variables and commands are evaluated at call time, so dotenv
-/// should be loaded before calling.
+/// should be loaded before calling. Commands run with `project_root` as their
+/// working directory, matching the `capture-command` hook.
 pub fn resolve_server_headers(
     headers: &BTreeMap<String, HeaderValueSource>,
+    project_root: &Path,
 ) -> anyhow::Result<Vec<(String, String)>> {
     headers
         .iter()
         .map(|(name, source)| {
-            let value = resolve_header_value(name, source)?;
+            let value = resolve_header_value(name, source, project_root)?;
             debug!("Resolved server header: {}", name);
             Ok((name.clone(), value))
         })
         .collect()
 }
 
-fn resolve_header_value(name: &str, source: &HeaderValueSource) -> anyhow::Result<String> {
+fn resolve_header_value(
+    name: &str,
+    source: &HeaderValueSource,
+    project_root: &Path,
+) -> anyhow::Result<String> {
     match source {
         HeaderValueSource::Literal(value) => Ok(value.clone()),
         HeaderValueSource::Env(env_source) => {
@@ -108,12 +122,12 @@ fn resolve_header_value(name: &str, source: &HeaderValueSource) -> anyhow::Resul
             })
         }
         HeaderValueSource::Command(command_source) => {
-            run_header_command(name, &command_source.command)
+            run_header_command(name, &command_source.command, project_root)
         }
     }
 }
 
-fn run_header_command(name: &str, command: &str) -> anyhow::Result<String> {
+fn run_header_command(name: &str, command: &str, project_root: &Path) -> anyhow::Result<String> {
     let tokens = shlex::split(command)
         .ok_or_else(|| anyhow::anyhow!("Header '{name}': failed to parse command: {command}"))?;
     let [program, args @ ..] = tokens.as_slice() else {
@@ -122,6 +136,7 @@ fn run_header_command(name: &str, command: &str) -> anyhow::Result<String> {
 
     let output = std::process::Command::new(program)
         .args(args)
+        .current_dir(project_root)
         .output()
         .with_context(|| format!("Header '{name}': failed to execute command '{command}'"))?;
 
@@ -163,7 +178,7 @@ mod tests {
             HeaderValueSource::Literal("fixed".to_string()),
         )]);
 
-        let resolved = resolve_server_headers(&headers).unwrap();
+        let resolved = resolve_server_headers(&headers, Path::new(".")).unwrap();
 
         assert_eq!(
             resolved,
@@ -180,7 +195,7 @@ mod tests {
             env_source("PATH", Some("Bearer ")),
         )]);
 
-        let resolved = resolve_server_headers(&headers).unwrap();
+        let resolved = resolve_server_headers(&headers, Path::new(".")).unwrap();
 
         assert_eq!(resolved[0].1, format!("Bearer {path_value}"));
     }
@@ -192,7 +207,7 @@ mod tests {
             env_source("CAPSULA_TEST_UNSET_VAR_1153", None),
         )]);
 
-        let error = resolve_server_headers(&headers).unwrap_err();
+        let error = resolve_server_headers(&headers, Path::new(".")).unwrap_err();
 
         assert!(error.to_string().contains("CAPSULA_TEST_UNSET_VAR_1153"));
     }
@@ -201,7 +216,7 @@ mod tests {
     fn resolves_command_stdout_with_trailing_newline_trimmed() {
         let headers = BTreeMap::from([("x-token".to_string(), command_source("echo token-value"))]);
 
-        let resolved = resolve_server_headers(&headers).unwrap();
+        let resolved = resolve_server_headers(&headers, Path::new(".")).unwrap();
 
         assert_eq!(
             resolved,
@@ -216,11 +231,44 @@ mod tests {
             command_source("sh -c 'echo session-expired >&2; exit 1'"),
         )]);
 
-        let error = resolve_server_headers(&headers).unwrap_err();
+        let error = resolve_server_headers(&headers, Path::new(".")).unwrap_err();
 
         let message = error.to_string();
         assert!(message.contains("x-token"));
         assert!(message.contains("session-expired"));
+    }
+
+    #[test]
+    fn runs_command_from_project_root() {
+        let project_root = tempfile::tempdir().unwrap();
+        std::fs::write(project_root.path().join("marker.txt"), "from-root\n").unwrap();
+        let headers = BTreeMap::from([("x-token".to_string(), command_source("cat marker.txt"))]);
+
+        let resolved = resolve_server_headers(&headers, project_root.path()).unwrap();
+
+        assert_eq!(resolved[0].1, "from-root");
+    }
+
+    #[test]
+    fn same_origin_ignores_paths_and_default_ports() {
+        assert!(is_same_origin("http://capsula.example", "http://capsula.example:80/api").unwrap());
+        assert!(
+            is_same_origin("https://capsula.example:443/x", "https://capsula.example").unwrap()
+        );
+    }
+
+    #[test]
+    fn different_scheme_host_or_port_is_cross_origin() {
+        assert!(!is_same_origin("http://capsula.example", "https://capsula.example").unwrap());
+        assert!(!is_same_origin("https://a.example", "https://b.example").unwrap());
+        assert!(
+            !is_same_origin("https://capsula.example", "https://capsula.example:8443").unwrap()
+        );
+    }
+
+    #[test]
+    fn invalid_url_is_an_error_not_a_match() {
+        assert!(is_same_origin("not a url", "https://capsula.example").is_err());
     }
 
     #[test]
@@ -230,7 +278,7 @@ mod tests {
             command_source("capsula-test-nonexistent-binary-1153"),
         )]);
 
-        let error = resolve_server_headers(&headers).unwrap_err();
+        let error = resolve_server_headers(&headers, Path::new(".")).unwrap_err();
 
         assert!(error.to_string().contains("failed to execute"));
     }

--- a/crates/capsula-orchestration/tests/push_flow.rs
+++ b/crates/capsula-orchestration/tests/push_flow.rs
@@ -1,0 +1,103 @@
+//! End-to-end push flow tests against a mock server.
+//!
+//! Every request of the push sequence must carry the configured headers;
+//! the header matchers make the mock reject unauthenticated requests.
+#![cfg(test)]
+
+use capsula_client::CapsulaClient;
+use capsula_orchestration::push::push_single_run;
+use std::path::PathBuf;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn write_run_fixture(run_dir: &std::path::Path) {
+    let capsula_dir = run_dir.join("_capsula");
+    std::fs::create_dir_all(&capsula_dir).unwrap();
+    std::fs::write(
+        capsula_dir.join("metadata.json"),
+        serde_json::json!({
+            "id": "01TESTPUSHFLOWRUN",
+            "name": "test-run",
+            "timestamp": "2026-08-03T00:00:00Z",
+            "command": ["echo", "hello"],
+            "project_root": "/tmp/project",
+        })
+        .to_string(),
+    )
+    .unwrap();
+    std::fs::write(run_dir.join("output.txt"), "data").unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn push_sends_configured_headers_on_every_request() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/runs"))
+        .and(header("x-auth", "secret"))
+        .respond_with(ResponseTemplate::new(201))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/upload"))
+        .and(header("x-auth", "secret"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": "ok",
+            "files_processed": 1,
+            "total_bytes": 4,
+            "pre_run_hooks": 0,
+            "post_run_hooks": 0,
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let run_dir = tempfile::tempdir().unwrap();
+    write_run_fixture(run_dir.path());
+
+    let uri = server.uri();
+    let run_path: PathBuf = run_dir.path().to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        let client =
+            CapsulaClient::with_headers(uri, &[("x-auth".to_string(), "secret".to_string())])
+                .unwrap();
+        push_single_run(&run_path, "test-vault", &client)
+    })
+    .await
+    .unwrap()
+    .unwrap();
+    // .expect(1) on each mock verifies both endpoints were hit (with headers)
+    // when the MockServer is dropped
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn push_fails_with_auth_hint_when_run_creation_is_rejected() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/runs"))
+        .respond_with(ResponseTemplate::new(403))
+        .mount(&server)
+        .await;
+
+    let run_dir = tempfile::tempdir().unwrap();
+    write_run_fixture(run_dir.path());
+
+    let uri = server.uri();
+    let run_path: PathBuf = run_dir.path().to_path_buf();
+    let error = tokio::task::spawn_blocking(move || {
+        let client = CapsulaClient::new(uri);
+        push_single_run(&run_path, "test-vault", &client)
+    })
+    .await
+    .unwrap()
+    .unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("authentication may be missing or expired")
+    );
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,7 +52,7 @@ The Capsula server used by `capsula push` and `capsula vaults`. The simplest for
 server = "https://capsula.example.com"
 ```
 
-The URL can also be set with the `--server` flag or the `CAPSULA_SERVER_URL` environment variable, which take priority over the config file (in that order).
+The URL can also be set with the `--server` flag or the `CAPSULA_SERVER_URL` environment variable, which take priority over the config file (in that order). When `[server.headers]` is configured, an override must point at the same origin (scheme, host, and port) as the configured `url` — credentials are never sent to a different origin, and a cross-origin override is rejected with an error.
 
 #### `server.headers` (optional)
 
@@ -91,7 +91,9 @@ CF-Access-Client-Id = { env = "CF_ACCESS_CLIENT_ID" }
 CF-Access-Client-Secret = { env = "CF_ACCESS_CLIENT_SECRET" }
 ```
 
-Commands are split with shell-like word splitting and executed directly (no shell), and their stdout is trimmed of trailing newlines. If a command fails (e.g. an expired login session), the push aborts with the command's stderr.
+Commands are split with shell-like word splitting and executed directly (no shell) from the project root (the directory containing `capsula.toml`), and their stdout is trimmed of trailing newlines. If a command fails (e.g. an expired login session), the push aborts with the command's stderr.
+
+HTTP redirects are never followed: a redirect (e.g. to a login page) is reported as an error instead of forwarding credentials to the redirect target.
 
 !!! warning "Trust model"
     `command` entries execute arbitrary commands when you run `capsula push` or `capsula vaults`. Only use them with a trusted `capsula.toml` — the same caution that already applies to the `capture-command` hook.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,61 @@ dotenv = ".env"
 
 Relative paths are resolved from the directory containing `capsula.toml`.
 
+### `server` (optional)
+
+The Capsula server used by `capsula push` and `capsula vaults`. The simplest form is a plain URL:
+
+```toml
+server = "https://capsula.example.com"
+```
+
+The URL can also be set with the `--server` flag or the `CAPSULA_SERVER_URL` environment variable, which take priority over the config file (in that order).
+
+#### `server.headers` (optional)
+
+When the server sits behind an authenticating reverse proxy (Cloudflare Access, oauth2-proxy, etc.), use the table form to attach HTTP headers to every request:
+
+```toml
+[server]
+url = "https://capsula.example.com"
+
+[server.headers]
+Authorization = { env = "CAPSULA_TOKEN", prefix = "Bearer " }
+```
+
+Each entry becomes one HTTP header line. With `CAPSULA_TOKEN=abc123` in the environment, the example above sends `Authorization: Bearer abc123`.
+
+Each header value is one of three sources:
+
+| Form | Meaning |
+|------|---------|
+| `"literal string"` | Used as-is |
+| `{ env = "VAR", prefix = "Bearer " }` | Read from environment variable; optional `prefix` prepended |
+| `{ command = "..." }` | Run the command, use trimmed stdout as the value |
+
+Common setups:
+
+```toml
+[server.headers]
+# Plain bearer token against any authenticating reverse proxy
+Authorization = { env = "CAPSULA_TOKEN", prefix = "Bearer " }
+
+# Cloudflare Access, interactive user (JWT from cloudflared login session)
+cf-access-token = { command = "cloudflared access token --app=https://capsula.example.com" }
+
+# Cloudflare Access service token (CI)
+CF-Access-Client-Id = { env = "CF_ACCESS_CLIENT_ID" }
+CF-Access-Client-Secret = { env = "CF_ACCESS_CLIENT_SECRET" }
+```
+
+Commands are split with shell-like word splitting and executed directly (no shell), and their stdout is trimmed of trailing newlines. If a command fails (e.g. an expired login session), the push aborts with the command's stderr.
+
+!!! warning "Trust model"
+    `command` entries execute arbitrary commands when you run `capsula push` or `capsula vaults`. Only use them with a trusted `capsula.toml` — the same caution that already applies to the `capture-command` hook.
+
+!!! tip "Secrets"
+    Never write secret values directly in `capsula.toml`. Reference them with `env` (combined with the top-level `dotenv` option if convenient), or use `command` sources whose credentials live with the external tool (e.g. `~/.cloudflared/`).
+
 ## Vault Configuration
 
 The `[vault]` section defines where Capsula stores captured data.


### PR DESCRIPTION
## Summary

Closes #1153

Adds client-side authentication for server access (`capsula push`, `capsula vaults`): the CLI attaches configured HTTP headers to every request it sends to the server, making the API reachable through authenticating reverse proxies (Cloudflare Access, oauth2-proxy, etc.) with no vendor-specific code in capsula.

```toml
[server]
url = "https://capsula.example.com"

[server.headers]
Authorization = { env = "CAPSULA_TOKEN", prefix = "Bearer " }
cf-access-token = { command = "cloudflared access token --app=https://capsula.example.com" }
```

- **capsula-config**: `server` accepts either the existing plain URL string (backward compatible) or a table with `url` and `headers`. Header values come from a literal string, `{ env = "VAR", prefix = "..." }`, or `{ command = "..." }`; sources mixing `env` and `command` are rejected at parse time.
- **capsula-orchestration**: new `resolve_server_headers` resolves sources at call time. Commands are split with shell-like word splitting and executed directly (no shell); failures surface the command's stderr, missing env vars name the variable.
- **capsula-client**: new `CapsulaClient::with_headers` constructor (header values marked sensitive to keep them out of debug logs); 401/403 responses get a hint that credentials may be missing or expired.
- **capsula-cli**: shared `build_server_client` helper replaces the duplicated URL-resolution/client-construction in `push` and `vaults list`. URL resolution priority is unchanged (`--server` > `CAPSULA_SERVER_URL` > config).
- **docs**: `server` / `server.headers` reference in `configuration.md` with common setups and a trust-model note (`command` entries execute arbitrary commands — same caution as the existing `capture-command` hook).

Verified with `cargo test --workspace` (159 passed, 0 failed; 15 new tests), the individual lint steps from `just lint` (clippy all-features / no-default-features, fmt, doc, check — 0 warnings), and an end-to-end smoke test against a local HTTP server confirming `Authorization: Bearer ...` (env source) and a command-sourced header arrive on the wire.

## AI assistance

- AI used: yes — implemented by Claude Code based on the design settled in #1153; a human directed the design discussion and reviewed each decision
- Human review of AI-assisted code: complete

## Breaking changes

- [x] No breaking changes
- [ ] Breaking changes; the `breaking change` label is applied

Note: the `capsula.toml` format and CLI behavior are fully backward compatible. The Rust API of `capsula-config` changes shape (`CapsulaConfig.server` is now `Option<ServerConfig>` instead of `Option<String>`) for library consumers.
