### PR TITLE
feat: add `capsula pull` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,6 +688,7 @@ name = "capsula-client"
 version = "0.14.0"
 dependencies = [
  "capsula-api-types",
+ "percent-encoding",
  "reqwest",
  "serde",
  "serde_json",
@@ -743,6 +744,7 @@ name = "capsula-orchestration"
 version = "0.14.0"
 dependencies = [
  "anyhow",
+ "capsula-api-types",
  "capsula-client",
  "capsula-config",
  "capsula-core",
@@ -753,9 +755,14 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
+ "shlex",
+ "tempfile",
+ "tokio",
  "tracing",
  "ulid",
  "walkdir",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/capsula-api-types/src/lib.rs
+++ b/crates/capsula-api-types/src/lib.rs
@@ -141,7 +141,7 @@ pub struct RunRecord {
     pub vault: String,
     pub project_root: String,
     pub exit_code: Option<i32>,
-    pub duration_ms: Option<i64>,
+    pub duration_ms: Option<i32>,
     pub stdout: Option<String>,
     pub stderr: Option<String>,
 }

--- a/crates/capsula-api-types/src/lib.rs
+++ b/crates/capsula-api-types/src/lib.rs
@@ -124,3 +124,55 @@ pub struct FileInfo {
     hash: Option<String>,
     url: String,
 }
+
+// =============================================================================
+// Run Detail API Types (GET /api/v1/runs/{id})
+// =============================================================================
+
+/// A run record as returned in the run detail response.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunRecord {
+    pub id: String,
+    pub name: String,
+    /// RFC 3339 timestamp of the run.
+    pub timestamp: String,
+    /// The executed command, serialized as a JSON array string.
+    pub command: String,
+    pub vault: String,
+    pub project_root: String,
+    pub exit_code: Option<i32>,
+    pub duration_ms: Option<i64>,
+    pub stdout: Option<String>,
+    pub stderr: Option<String>,
+}
+
+/// A captured file entry in the run detail response.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunDetailFile {
+    /// Path of the file relative to the run directory.
+    pub path: String,
+    pub size: i64,
+    /// Hex-encoded SHA-256 of the file content, when recorded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hash: Option<String>,
+}
+
+/// Response from the run detail endpoint (`GET /api/v1/runs/{id}`).
+///
+/// The server reports errors via the `status` field (`"ok"`,
+/// `"not_found"`, or `"error"`); the remaining fields are only populated
+/// on success.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunDetailResponse {
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run: Option<RunRecord>,
+    #[serde(default)]
+    pub pre_run_hooks: Vec<serde_json::Value>,
+    #[serde(default)]
+    pub post_run_hooks: Vec<serde_json::Value>,
+    #[serde(default)]
+    pub files: Vec<RunDetailFile>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}

--- a/crates/capsula-cli/src/main.rs
+++ b/crates/capsula-cli/src/main.rs
@@ -7,6 +7,7 @@
 use anyhow::{Context, Result};
 use capsula_core::hook::{PostRun, PreRun};
 use capsula_core::run::PreparedRun;
+use capsula_orchestration::pull::pull_single_run;
 use capsula_orchestration::push::push_single_run;
 use capsula_orchestration::resolve::resolve_server_url;
 use capsula_orchestration::run::{create_and_setup_run, run_post_hooks, run_pre_hooks};
@@ -94,6 +95,23 @@ enum Commands {
         /// Server URL (can also be set via `CAPSULA_SERVER_URL` env var after dotenv loading)
         #[arg(long)]
         server: Option<String>,
+    },
+    /// Download a run from a Capsula server into the local vault
+    Pull {
+        /// Run ID (ULID) to pull (e.g., 01HQXYZ...)
+        run_id: String,
+
+        /// Expected vault of the run (defaults to the vault in capsula.toml)
+        #[arg(long)]
+        vault: Option<String>,
+
+        /// Server URL (can also be set via `CAPSULA_SERVER_URL` env var after dotenv loading)
+        #[arg(long)]
+        server: Option<String>,
+
+        /// Replace the local run directory if it already exists
+        #[arg(long)]
+        force: bool,
     },
     /// Launch interactive terminal UI for starting and ending runs
     Tui,
@@ -484,6 +502,46 @@ path = \".\"
                 }
                 (false, None) => anyhow::bail!("Either provide a run ID/name or use --all flag"),
             }
+        }
+        Commands::Pull {
+            run_id,
+            vault,
+            server,
+            force,
+        } => {
+            let server_url =
+                resolve_server_url(server, config.server.as_deref()).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Server URL not specified. Use --server <URL>, set CAPSULA_SERVER_URL environment variable, or add 'server = \"URL\"' to capsula.toml"
+                    )
+                })?;
+
+            let client = capsula_client::CapsulaClient::new(&server_url);
+            let vault_name = vault.unwrap_or_else(|| config.vault.name.clone());
+
+            // The configured vault maps to vault_dir (which may be a custom
+            // path); runs pulled from other vaults are placed in a sibling
+            // directory named after their vault.
+            let target_vault_dir = if vault_name == config.vault.name {
+                vault_dir
+            } else {
+                vault_dir
+                    .parent()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Cannot determine a location for vault '{}': the configured vault directory {} has no parent",
+                            vault_name,
+                            vault_dir.display()
+                        )
+                    })?
+                    .join(&vault_name)
+            };
+
+            info!("Pulling run {} from server {}", run_id, server_url);
+
+            let run_dir = pull_single_run(&run_id, &vault_name, &target_vault_dir, &client, force)?;
+
+            info!("Pulled run into {}", run_dir.display());
         }
         Commands::Tui => unreachable!("Handled above"),
         Commands::Vaults { command } => match command {

--- a/crates/capsula-cli/src/main.rs
+++ b/crates/capsula-cli/src/main.rs
@@ -7,7 +7,7 @@
 use anyhow::{Context, Result};
 use capsula_core::hook::{PostRun, PreRun};
 use capsula_core::run::PreparedRun;
-use capsula_orchestration::pull::pull_single_run;
+use capsula_orchestration::pull::{ensure_single_path_component, pull_single_run};
 use capsula_orchestration::push::push_single_run;
 use capsula_orchestration::resolve::resolve_server_url;
 use capsula_orchestration::run::{create_and_setup_run, run_post_hooks, run_pre_hooks};
@@ -446,6 +446,7 @@ path = \".\"
 
                     let mut success_count = 0;
                     let mut skip_count = 0;
+                    let mut pulled_skip_count = 0;
                     let mut error_count = 0;
 
                     for entry in walkdir::WalkDir::new(&vault_dir)
@@ -470,6 +471,14 @@ path = \".\"
                             continue;
                         }
 
+                        // Pulled runs are lossy reconstructions; skip them
+                        // instead of degrading the server's copy.
+                        if capsula_dir.join("pulled.json").is_file() {
+                            debug!("Skipping pulled run at {}", run_dir.display());
+                            pulled_skip_count += 1;
+                            continue;
+                        }
+
                         match push_single_run(run_dir, vault_name, &server_url, &client) {
                             Ok(()) => success_count += 1,
                             Err(e) => {
@@ -484,8 +493,9 @@ path = \".\"
                     }
 
                     info!(
-                        "Push all completed: {} succeeded, {} skipped (already exist), {} failed",
-                        success_count, skip_count, error_count
+                        "Push all completed: {} succeeded, {} skipped (already exist), \
+                         {} skipped (pulled runs), {} failed",
+                        success_count, skip_count, pulled_skip_count, error_count
                     );
 
                     if error_count > 0 {
@@ -525,6 +535,9 @@ path = \".\"
             let target_vault_dir = if vault_name == config.vault.name {
                 vault_dir
             } else {
+                // The vault name becomes a directory name next to the
+                // configured vault; a separator or `..` would escape it.
+                ensure_single_path_component(&vault_name, "vault name")?;
                 vault_dir
                     .parent()
                     .ok_or_else(|| {

--- a/crates/capsula-client/Cargo.toml
+++ b/crates/capsula-client/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["api-bindings"]
 
 [dependencies]
 capsula-api-types = { workspace = true }
+percent-encoding = { workspace = true }
 reqwest = { workspace = true, features = ["blocking"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/capsula-client/src/lib.rs
+++ b/crates/capsula-client/src/lib.rs
@@ -1,24 +1,34 @@
 use capsula_api_types::{
     RunDetailResponse, UploadResponse, VaultExistsResponse, VaultInfo, VaultsResponse,
 };
-use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
 use reqwest::blocking::multipart;
 use serde_json::Value as JsonValue;
 use std::path::Path;
 use thiserror::Error;
 
+/// `NON_ALPHANUMERIC` minus the RFC 3986 unreserved characters (`-`,
+/// `.`, `_`, `~`), whose escaped and unescaped forms are defined to be
+/// equivalent (§2.3: such escapes "should not be created").
+const PATH_SEGMENT_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~');
+
 /// Percent-encode a run-relative file path for use as a URL path suffix.
 ///
-/// Each `/`-separated segment is encoded with `NON_ALPHANUMERIC`
-/// (allowlist polarity: everything except `[0-9A-Za-z]` is encoded), so
-/// any byte round-trips through the server's `/files/{*path}` wildcard
-/// route without a curated character list. This notably covers `\`,
-/// which the WHATWG URL parser would otherwise rewrite to `/` in an
-/// http(s) path, silently changing the requested file.
+/// Each `/`-separated segment is encoded with allowlist polarity
+/// (everything except `[0-9A-Za-z]` and the RFC 3986 unreserved set is
+/// encoded), so any byte round-trips through the server's
+/// `/files/{*path}` wildcard route without a curated character list.
+/// This notably covers `\`, which the WHATWG URL parser would otherwise
+/// rewrite to `/` in an http(s) path, silently changing the requested
+/// file.
 fn encode_file_path(file_path: &str) -> String {
     file_path
         .split('/')
-        .map(|segment| utf8_percent_encode(segment, NON_ALPHANUMERIC).to_string())
+        .map(|segment| utf8_percent_encode(segment, PATH_SEGMENT_ENCODE_SET).to_string())
         .collect::<Vec<_>>()
         .join("/")
 }
@@ -203,8 +213,9 @@ mod tests {
     }
 
     #[test]
-    fn encode_file_path_keeps_segment_separators() {
-        assert_eq!(encode_file_path("output/result.txt"), "output/result%2Etxt");
+    fn encode_file_path_keeps_separators_and_unreserved_chars() {
+        assert_eq!(encode_file_path("output/result.txt"), "output/result.txt");
+        assert_eq!(encode_file_path("a-b_c~d.e/f"), "a-b_c~d.e/f");
     }
 
     #[test]
@@ -212,7 +223,7 @@ mod tests {
         assert_eq!(encode_file_path("a b?c#d%e"), "a%20b%3Fc%23d%25e");
         assert_eq!(
             encode_file_path("日本語.txt"),
-            "%E6%97%A5%E6%9C%AC%E8%AA%9E%2Etxt"
+            "%E6%97%A5%E6%9C%AC%E8%AA%9E.txt"
         );
     }
 }

--- a/crates/capsula-client/src/lib.rs
+++ b/crates/capsula-client/src/lib.rs
@@ -1,8 +1,27 @@
-use capsula_api_types::{UploadResponse, VaultExistsResponse, VaultInfo, VaultsResponse};
+use capsula_api_types::{
+    RunDetailResponse, UploadResponse, VaultExistsResponse, VaultInfo, VaultsResponse,
+};
+use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
 use reqwest::blocking::multipart;
 use serde_json::Value as JsonValue;
 use std::path::Path;
 use thiserror::Error;
+
+/// Percent-encode a run-relative file path for use as a URL path suffix.
+///
+/// Each `/`-separated segment is encoded with `NON_ALPHANUMERIC`
+/// (allowlist polarity: everything except `[0-9A-Za-z]` is encoded), so
+/// any byte round-trips through the server's `/files/{*path}` wildcard
+/// route without a curated character list. This notably covers `\`,
+/// which the WHATWG URL parser would otherwise rewrite to `/` in an
+/// http(s) path, silently changing the requested file.
+fn encode_file_path(file_path: &str) -> String {
+    file_path
+        .split('/')
+        .map(|segment| utf8_percent_encode(segment, NON_ALPHANUMERIC).to_string())
+        .collect::<Vec<_>>()
+        .join("/")
+}
 
 #[derive(Debug, Error)]
 pub enum ClientError {
@@ -34,6 +53,51 @@ impl CapsulaClient {
             base_url: base_url.into(),
             client: reqwest::blocking::Client::new(),
         }
+    }
+
+    /// Base URL of the server this client talks to
+    #[must_use]
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// Fetch a run's detail (record, hook outputs, and captured file list)
+    pub fn get_run(&self, run_id: &str) -> Result<RunDetailResponse> {
+        let url = format!("{}/api/v1/runs/{}", self.base_url, run_id);
+        let response = self.client.get(&url).send()?;
+
+        if !response.status().is_success() {
+            return Err(ClientError::ServerError(format!(
+                "Failed to fetch run {}: {}",
+                run_id,
+                response.status()
+            )));
+        }
+
+        let detail: RunDetailResponse = response.json()?;
+        Ok(detail)
+    }
+
+    /// Download a captured file of a run, returning its raw bytes
+    pub fn download_file(&self, run_id: &str, file_path: &str) -> Result<Vec<u8>> {
+        let url = format!(
+            "{}/api/v1/runs/{}/files/{}",
+            self.base_url,
+            run_id,
+            encode_file_path(file_path)
+        );
+        let response = self.client.get(&url).send()?;
+
+        if !response.status().is_success() {
+            return Err(ClientError::ServerError(format!(
+                "Failed to download file '{}' of run {}: {}",
+                file_path,
+                run_id,
+                response.status()
+            )));
+        }
+
+        Ok(response.bytes()?.to_vec())
     }
 
     /// List all vaults on the server
@@ -136,5 +200,19 @@ mod tests {
     fn test_client_creation() {
         let client = CapsulaClient::new("http://localhost:8500");
         assert_eq!(client.base_url, "http://localhost:8500");
+    }
+
+    #[test]
+    fn encode_file_path_keeps_segment_separators() {
+        assert_eq!(encode_file_path("output/result.txt"), "output/result%2Etxt");
+    }
+
+    #[test]
+    fn encode_file_path_encodes_url_significant_and_non_ascii_chars() {
+        assert_eq!(encode_file_path("a b?c#d%e"), "a%20b%3Fc%23d%25e");
+        assert_eq!(
+            encode_file_path("日本語.txt"),
+            "%E6%97%A5%E6%9C%AC%E8%AA%9E%2Etxt"
+        );
     }
 }

--- a/crates/capsula-core/src/run.rs
+++ b/crates/capsula-core/src/run.rs
@@ -30,20 +30,33 @@ impl<Dir> Run<Dir> {
     }
 
     fn gen_run_dir(&self, vault_dir: impl AsRef<Path>) -> PathBuf {
-        let timestamp = self.timestamp();
-        let date_str = timestamp.format("%Y-%m-%d").to_string();
-        let time_str = timestamp.format("%H%M%S").to_string();
-
-        // Prefix the run directory with time because
-        // folders are sorted in natural order, not in lexicographical order,
-        // For example, on macOS Finder, the order is:
-        // 1. 01K5K478KNQ2ZXZG68MWM1Z9X6
-        // 2. 01K5K4571FGKBFTTRJCG1J3DCZ
-        // which is not the correct chronological order.
-        // By adding time prefix, it will be sorted correctly.
-        let run_dir_name = format!("{}-{}", time_str, self.name);
-        vault_dir.as_ref().join(date_str).join(&run_dir_name)
+        vault_dir
+            .as_ref()
+            .join(run_dir_relative_path(&self.id, &self.name))
     }
+}
+
+/// Relative path of a run directory within its vault:
+/// `{YYYY-MM-DD}/{HHMMSS}-{name}`.
+///
+/// Both components derive from the ULID's embedded timestamp (UTC), so the
+/// location is reproducible from `id` and `name` alone (e.g. when restoring
+/// a run pulled from a server).
+///
+/// The directory is prefixed with the time because folders are sorted in
+/// natural order, not in lexicographical order. For example, on macOS
+/// Finder, the order is:
+/// 1. `01K5K478KNQ2ZXZG68MWM1Z9X6`
+/// 2. `01K5K4571FGKBFTTRJCG1J3DCZ`
+///
+/// which is not the correct chronological order. By adding the time
+/// prefix, it will be sorted correctly.
+#[must_use]
+pub fn run_dir_relative_path(id: &Ulid, name: &str) -> PathBuf {
+    let timestamp: DateTime<Utc> = id.datetime().into();
+    let date_str = timestamp.format("%Y-%m-%d").to_string();
+    let time_str = timestamp.format("%H%M%S").to_string();
+    PathBuf::from(date_str).join(format!("{time_str}-{name}"))
 }
 
 impl UnpreparedRun {
@@ -273,7 +286,8 @@ impl PreparedRun {
     }
 }
 
-fn setup_vault(path: impl AsRef<std::path::Path>) -> io::Result<()> {
+/// Create the vault directory (and its `.gitignore`) if it does not exist.
+pub fn setup_vault(path: impl AsRef<std::path::Path>) -> io::Result<()> {
     let path = path.as_ref();
     if path.exists() {
         debug!("Vault directory already exists: {}", path.display());

--- a/crates/capsula-orchestration/Cargo.toml
+++ b/crates/capsula-orchestration/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["development-tools"]
 
 [dependencies]
 anyhow = { workspace = true }
+capsula-api-types = { workspace = true }
 capsula-client = { workspace = true }
 capsula-config = { workspace = true }
 capsula-core = { workspace = true }
@@ -22,9 +23,16 @@ names = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
+shlex = { workspace = true }
+tempfile = { workspace = true }
 tracing = { workspace = true }
 ulid = { workspace = true }
 walkdir = "2"
+
+[dev-dependencies]
+tokio = { workspace = true }
+wiremock = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/capsula-orchestration/src/lib.rs
+++ b/crates/capsula-orchestration/src/lib.rs
@@ -1,4 +1,5 @@
 pub(crate) mod hooks;
+pub mod pull;
 pub mod push;
 pub mod resolve;
 pub mod run;

--- a/crates/capsula-orchestration/src/pull.rs
+++ b/crates/capsula-orchestration/src/pull.rs
@@ -1,0 +1,280 @@
+use anyhow::{Context, Result};
+use capsula_api_types::{RunDetailResponse, RunRecord};
+use capsula_core::run::{run_dir_relative_path, setup_vault};
+use sha2::{Digest, Sha256};
+use std::path::{Component, Path, PathBuf};
+use tracing::{debug, info, warn};
+use ulid::Ulid;
+
+/// Pull a single run from the server and restore it under `target_vault_dir`.
+///
+/// The run directory is reconstructed at `{YYYY-MM-DD}/{HHMMSS}-{name}`
+/// (derived from the run's ULID and name, like locally created runs).
+/// Captured files are verified against the server-recorded SHA-256 hashes;
+/// the `_capsula` metadata files are reconstructed best-effort from the
+/// server's structured data and a `_capsula/pulled.json` marker records the
+/// origin. Everything is downloaded into a temporary directory and renamed
+/// into place, so an interrupted pull never leaves a half-restored run.
+///
+/// Returns the path of the restored run directory.
+pub fn pull_single_run(
+    run_id: &str,
+    expected_vault: &str,
+    target_vault_dir: &Path,
+    client: &capsula_client::CapsulaClient,
+    force: bool,
+) -> Result<PathBuf> {
+    let detail = client.get_run(run_id)?;
+    let run = match detail.status.as_str() {
+        "ok" => detail
+            .run
+            .as_ref()
+            .context("Server response is missing the run record")?,
+        "not_found" => anyhow::bail!("Run '{run_id}' not found on server"),
+        other => anyhow::bail!(
+            "Server returned status '{other}': {}",
+            detail.error.as_deref().unwrap_or("unknown error")
+        ),
+    };
+
+    if run.vault != expected_vault {
+        anyhow::bail!(
+            "Run '{run_id}' belongs to vault '{}', not '{expected_vault}'. \
+             Pass --vault {} to pull it.",
+            run.vault,
+            run.vault
+        );
+    }
+
+    let ulid = Ulid::from_string(&run.id)
+        .with_context(|| format!("Server returned a non-ULID run id: '{}'", run.id))?;
+    let target_dir = target_vault_dir.join(run_dir_relative_path(&ulid, &run.name));
+
+    if target_dir.exists() && !force {
+        anyhow::bail!(
+            "Run directory already exists: {}. Use --force to replace it.",
+            target_dir.display()
+        );
+    }
+
+    setup_vault(target_vault_dir)?;
+    let date_dir = target_dir
+        .parent()
+        .context("Run directory has no parent directory")?;
+    std::fs::create_dir_all(date_dir)
+        .with_context(|| format!("Failed to create {}", date_dir.display()))?;
+
+    // Download into a temporary sibling directory (same filesystem) first,
+    // then rename into place.
+    let temp = tempfile::Builder::new()
+        .prefix(".pull-tmp-")
+        .tempdir_in(date_dir)
+        .context("Failed to create temporary download directory")?;
+
+    download_captured_files(client, &detail, &run.id, temp.path())?;
+    write_capsula_dir(&detail, run, &target_dir, temp.path(), client.base_url())?;
+
+    if target_dir.exists() {
+        // Only reachable with --force (checked above).
+        std::fs::remove_dir_all(&target_dir)
+            .with_context(|| format!("Failed to remove {}", target_dir.display()))?;
+    }
+    std::fs::rename(temp.path(), &target_dir).with_context(|| {
+        format!(
+            "Failed to move pulled run into place at {}",
+            target_dir.display()
+        )
+    })?;
+    // `temp`'s cleanup-on-drop finds the directory already moved; harmless.
+
+    info!("Pulled run '{}' into {}", run.name, target_dir.display());
+    Ok(target_dir)
+}
+
+/// Download all captured files listed in the run detail into `dest`,
+/// verifying each against its server-recorded SHA-256 hash.
+fn download_captured_files(
+    client: &capsula_client::CapsulaClient,
+    detail: &RunDetailResponse,
+    run_id: &str,
+    dest: &Path,
+) -> Result<()> {
+    for file in &detail.files {
+        let relative_path = sanitize_relative_path(&file.path)?;
+        let bytes = client
+            .download_file(run_id, &file.path)
+            .with_context(|| format!("Failed to download '{}'", file.path))?;
+
+        if let Some(expected) = &file.hash {
+            let actual = hex_encode(Sha256::digest(&bytes).as_ref());
+            if !actual.eq_ignore_ascii_case(expected) {
+                anyhow::bail!(
+                    "Hash mismatch for '{}': server recorded {expected}, downloaded {actual}",
+                    file.path
+                );
+            }
+        } else {
+            warn!(
+                "No hash recorded for '{}'; restoring without verification",
+                file.path
+            );
+        }
+
+        let dest_path = dest.join(&relative_path);
+        if let Some(parent) = dest_path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create {}", parent.display()))?;
+        }
+        std::fs::write(&dest_path, &bytes)
+            .with_context(|| format!("Failed to write {}", dest_path.display()))?;
+        debug!("Restored {} ({} bytes)", file.path, bytes.len());
+    }
+    Ok(())
+}
+
+/// Minimal containment check for server-provided file paths: reject
+/// anything that is absolute or steps outside the run directory. (Broader
+/// hardening against malicious server responses is tracked separately.)
+fn sanitize_relative_path(path: &str) -> Result<PathBuf> {
+    let p = Path::new(path);
+    if p.as_os_str().is_empty()
+        || p.is_absolute()
+        || p.components().any(|c| !matches!(c, Component::Normal(_)))
+    {
+        anyhow::bail!("Refusing to restore file with unsafe path: '{path}'");
+    }
+    Ok(p.to_path_buf())
+}
+
+/// Reconstruct the `_capsula` directory from the server's structured data.
+///
+/// The result is a best-effort restoration: the server does not store the
+/// original JSON bytes, so formatting and precision (e.g. sub-millisecond
+/// duration) differ from a locally produced run.
+fn write_capsula_dir(
+    detail: &RunDetailResponse,
+    run: &RunRecord,
+    final_run_dir: &Path,
+    dest: &Path,
+    server_url: &str,
+) -> Result<()> {
+    let capsula_dir = dest.join("_capsula");
+    std::fs::create_dir_all(&capsula_dir)
+        .with_context(|| format!("Failed to create {}", capsula_dir.display()))?;
+
+    // metadata.json — same fields as a locally created run; `run_dir`
+    // points at the restored location.
+    let metadata = serde_json::json!({
+        "id": run.id,
+        "name": run.name,
+        "command": parse_command(&run.command),
+        "timestamp": run.timestamp,
+        "run_dir": final_run_dir.to_string_lossy(),
+        "project_root": run.project_root,
+    });
+    write_pretty_json(&capsula_dir.join("metadata.json"), &metadata)?;
+
+    if !detail.pre_run_hooks.is_empty() {
+        write_pretty_json(
+            &capsula_dir.join("pre-run.json"),
+            &serde_json::Value::Array(detail.pre_run_hooks.clone()),
+        )?;
+    }
+    if !detail.post_run_hooks.is_empty() {
+        write_pretty_json(
+            &capsula_dir.join("post-run.json"),
+            &serde_json::Value::Array(detail.post_run_hooks.clone()),
+        )?;
+    }
+
+    // command.json — only finalized runs have one; exit_code is the marker.
+    // The server stores the duration in milliseconds, so the restored
+    // duration loses sub-millisecond precision.
+    if let Some(exit_code) = run.exit_code {
+        let duration_ms = u64::try_from(run.duration_ms.unwrap_or(0)).unwrap_or(0);
+        let command_output = serde_json::json!({
+            "exit_code": exit_code,
+            "stdout": run.stdout.clone().unwrap_or_default(),
+            "stderr": run.stderr.clone().unwrap_or_default(),
+            "duration": {
+                "secs": duration_ms / 1000,
+                "nanos": (duration_ms % 1000) * 1_000_000,
+            },
+        });
+        write_pretty_json(&capsula_dir.join("command.json"), &command_output)?;
+    }
+
+    // Marker distinguishing pulled runs from locally produced ones.
+    let pulled = serde_json::json!({
+        "server_url": server_url,
+        "pulled_at": chrono::Utc::now().to_rfc3339(),
+    });
+    write_pretty_json(&capsula_dir.join("pulled.json"), &pulled)?;
+
+    Ok(())
+}
+
+/// The server stores the command as a JSON array string; fall back to
+/// shell-splitting for records that predate that format.
+fn parse_command(raw: &str) -> Vec<String> {
+    serde_json::from_str::<Vec<String>>(raw)
+        .ok()
+        .or_else(|| shlex::split(raw))
+        .unwrap_or_else(|| vec![raw.to_string()])
+}
+
+fn write_pretty_json(path: &Path, value: &serde_json::Value) -> Result<()> {
+    std::fs::write(path, serde_json::to_string_pretty(value)?)
+        .with_context(|| format!("Failed to write {}", path.display()))
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    bytes.iter().fold(String::new(), |mut out, b| {
+        let _ = write!(out, "{b:02x}");
+        out
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        reason = "Tests use unwrap/expect for brevity"
+    )]
+
+    use super::*;
+
+    #[test]
+    fn parse_command_reads_json_array_string() {
+        assert_eq!(
+            parse_command(r#"["echo","hello world"]"#),
+            vec!["echo".to_string(), "hello world".to_string()]
+        );
+    }
+
+    #[test]
+    fn parse_command_falls_back_to_shell_splitting() {
+        assert_eq!(
+            parse_command("echo 'hello world'"),
+            vec!["echo".to_string(), "hello world".to_string()]
+        );
+    }
+
+    #[test]
+    fn sanitize_rejects_escaping_paths() {
+        assert!(sanitize_relative_path("../evil.txt").is_err());
+        assert!(sanitize_relative_path("/etc/passwd").is_err());
+        assert!(sanitize_relative_path("a/../../evil.txt").is_err());
+        assert!(sanitize_relative_path("").is_err());
+    }
+
+    #[test]
+    fn sanitize_accepts_nested_relative_paths() {
+        assert_eq!(
+            sanitize_relative_path("output/result.txt").unwrap(),
+            PathBuf::from("output/result.txt")
+        );
+    }
+}

--- a/crates/capsula-orchestration/src/pull.rs
+++ b/crates/capsula-orchestration/src/pull.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use capsula_api_types::{RunDetailResponse, RunRecord};
 use capsula_core::run::{run_dir_relative_path, setup_vault};
+use capsula_core::util::hex_encode;
 use sha2::{Digest, Sha256};
 use std::path::{Component, Path, PathBuf};
 use tracing::{debug, info, warn};
@@ -10,11 +11,18 @@ use ulid::Ulid;
 ///
 /// The run directory is reconstructed at `{YYYY-MM-DD}/{HHMMSS}-{name}`
 /// (derived from the run's ULID and name, like locally created runs).
-/// Captured files are verified against the server-recorded SHA-256 hashes;
-/// the `_capsula` metadata files are reconstructed best-effort from the
-/// server's structured data and a `_capsula/pulled.json` marker records the
-/// origin. Everything is downloaded into a temporary directory and renamed
-/// into place, so an interrupted pull never leaves a half-restored run.
+/// Captured files are verified against the server-recorded sizes and
+/// SHA-256 hashes; the `_capsula` metadata files are reconstructed
+/// best-effort from the server's structured data and a
+/// `_capsula/pulled.json` marker records the origin. Everything is
+/// downloaded into a temporary directory directly under the vault root
+/// (outside the `vault/*/*` depth that the vault scanners walk) and
+/// renamed into place, so an interrupted pull never leaves a
+/// half-restored or phantom run.
+///
+/// A pulled run is a lossy reconstruction of the original, so `--force`
+/// only replaces run directories that carry the `pulled.json` marker;
+/// locally produced runs are never replaced.
 ///
 /// Returns the path of the restored run directory.
 pub fn pull_single_run(
@@ -24,6 +32,15 @@ pub fn pull_single_run(
     client: &capsula_client::CapsulaClient,
     force: bool,
 ) -> Result<PathBuf> {
+    // Fail fast on non-ULID arguments (e.g. a run *name*): the server
+    // would answer not_found, which misleadingly reads as "never pushed".
+    if Ulid::from_string(run_id).is_err() {
+        anyhow::bail!(
+            "'{run_id}' is not a run ID (ULID). `capsula pull` requires the run ID; \
+             run names cannot be resolved on the server. Find the ID with `capsula show <name>`."
+        );
+    }
+
     let detail = client.get_run(run_id)?;
     let run = match detail.status.as_str() {
         "ok" => detail
@@ -48,13 +65,37 @@ pub fn pull_single_run(
 
     let ulid = Ulid::from_string(&run.id)
         .with_context(|| format!("Server returned a non-ULID run id: '{}'", run.id))?;
+    // The name becomes part of the run directory name; a separator or
+    // `..` inside it would place the run outside the vault.
+    ensure_single_path_component(&run.name, "run name")?;
     let target_dir = target_vault_dir.join(run_dir_relative_path(&ulid, &run.name));
 
-    if target_dir.exists() && !force {
-        anyhow::bail!(
-            "Run directory already exists: {}. Use --force to replace it.",
-            target_dir.display()
-        );
+    if target_dir.exists() {
+        let is_pulled = is_pulled_run(&target_dir);
+        if !force {
+            if is_pulled {
+                anyhow::bail!(
+                    "A previously pulled copy of this run already exists: {}. \
+                     Use --force to replace it.",
+                    target_dir.display()
+                );
+            }
+            anyhow::bail!(
+                "Run directory already exists and appears locally produced \
+                 (no _capsula/pulled.json marker): {}. Refusing to replace it: \
+                 a pulled run is a lossy reconstruction of the original.",
+                target_dir.display()
+            );
+        }
+        if !is_pulled {
+            anyhow::bail!(
+                "--force only replaces previously pulled runs, but {} has no \
+                 _capsula/pulled.json marker and appears locally produced. \
+                 A pulled run is a lossy reconstruction of the original; \
+                 delete the directory manually if you really intend to replace it.",
+                target_dir.display()
+            );
+        }
     }
 
     setup_vault(target_vault_dir)?;
@@ -64,18 +105,30 @@ pub fn pull_single_run(
     std::fs::create_dir_all(date_dir)
         .with_context(|| format!("Failed to create {}", date_dir.display()))?;
 
-    // Download into a temporary sibling directory (same filesystem) first,
-    // then rename into place.
+    // Download into a temporary directory directly under the vault root:
+    // the same filesystem (so the rename below stays atomic), but one
+    // level above the `vault/*/*` depth that list_runs / find_run_dir /
+    // `push --all` walk — an interrupted pull leaves at worst an inert
+    // `.pull-tmp-*` directory that no scanner mistakes for a run.
     let temp = tempfile::Builder::new()
         .prefix(".pull-tmp-")
-        .tempdir_in(date_dir)
+        .tempdir_in(target_vault_dir)
         .context("Failed to create temporary download directory")?;
 
     download_captured_files(client, &detail, &run.id, temp.path())?;
     write_capsula_dir(&detail, run, &target_dir, temp.path(), client.base_url())?;
 
+    // Re-check at replacement time: the directory may have appeared (or
+    // changed) while we were downloading, e.g. through a concurrent pull
+    // or a local run landing in the same slot.
     if target_dir.exists() {
-        // Only reachable with --force (checked above).
+        if !force || !is_pulled_run(&target_dir) {
+            anyhow::bail!(
+                "Run directory {} appeared or changed during the download; \
+                 refusing to replace it",
+                target_dir.display()
+            );
+        }
         std::fs::remove_dir_all(&target_dir)
             .with_context(|| format!("Failed to remove {}", target_dir.display()))?;
     }
@@ -91,8 +144,28 @@ pub fn pull_single_run(
     Ok(target_dir)
 }
 
+/// A run directory restored by `pull` carries this marker (written by
+/// [`write_capsula_dir`]); locally produced runs do not.
+fn is_pulled_run(run_dir: &Path) -> bool {
+    run_dir.join("_capsula").join("pulled.json").is_file()
+}
+
+/// Assert that `value` is usable as a single, normal path component —
+/// no separators, no `..`, not absolute, not empty.
+pub fn ensure_single_path_component(value: &str, what: &str) -> Result<()> {
+    let mut components = Path::new(value).components();
+    let is_single = matches!(
+        (components.next(), components.next()),
+        (Some(Component::Normal(_)), None)
+    );
+    if !is_single {
+        anyhow::bail!("{what} '{value}' is not a single path component");
+    }
+    Ok(())
+}
+
 /// Download all captured files listed in the run detail into `dest`,
-/// verifying each against its server-recorded SHA-256 hash.
+/// verifying each against its server-recorded size and SHA-256 hash.
 fn download_captured_files(
     client: &capsula_client::CapsulaClient,
     detail: &RunDetailResponse,
@@ -100,10 +173,19 @@ fn download_captured_files(
     dest: &Path,
 ) -> Result<()> {
     for file in &detail.files {
-        let relative_path = sanitize_relative_path(&file.path)?;
+        let relative_path = checked_run_relative_path(&file.path)?;
         let bytes = client
             .download_file(run_id, &file.path)
             .with_context(|| format!("Failed to download '{}'", file.path))?;
+
+        if i64::try_from(bytes.len()).ok() != Some(file.size) {
+            anyhow::bail!(
+                "Size mismatch for '{}': server recorded {} bytes, downloaded {}",
+                file.path,
+                file.size,
+                bytes.len()
+            );
+        }
 
         if let Some(expected) = &file.hash {
             let actual = hex_encode(Sha256::digest(&bytes).as_ref());
@@ -133,9 +215,11 @@ fn download_captured_files(
 }
 
 /// Minimal containment check for server-provided file paths: reject
-/// anything that is absolute or steps outside the run directory. (Broader
-/// hardening against malicious server responses is tracked separately.)
-fn sanitize_relative_path(path: &str) -> Result<PathBuf> {
+/// anything that is absolute or steps outside the run directory.
+/// (Distinct from the server's upload-side `sanitize_relative_path`,
+/// which normalizes instead of rejecting; broader hardening is tracked
+/// separately.)
+fn checked_run_relative_path(path: &str) -> Result<PathBuf> {
     let p = Path::new(path);
     if p.as_os_str().is_empty()
         || p.is_absolute()
@@ -191,7 +275,18 @@ fn write_capsula_dir(
     // The server stores the duration in milliseconds, so the restored
     // duration loses sub-millisecond precision.
     if let Some(exit_code) = run.exit_code {
-        let duration_ms = u64::try_from(run.duration_ms.unwrap_or(0)).unwrap_or(0);
+        let duration_ms: u64 = match run.duration_ms {
+            Some(ms) if ms < 0 => {
+                warn!(
+                    "Server recorded a negative duration_ms ({ms}) for run '{}'; \
+                     restoring duration as 0",
+                    run.id
+                );
+                0
+            }
+            Some(ms) => u64::try_from(ms).unwrap_or(0),
+            None => 0,
+        };
         let command_output = serde_json::json!({
             "exit_code": exit_code,
             "stdout": run.stdout.clone().unwrap_or_default(),
@@ -204,7 +299,8 @@ fn write_capsula_dir(
         write_pretty_json(&capsula_dir.join("command.json"), &command_output)?;
     }
 
-    // Marker distinguishing pulled runs from locally produced ones.
+    // Marker distinguishing pulled runs from locally produced ones; read
+    // back by pull's --force guard and by push's re-upload guard.
     let pulled = serde_json::json!({
         "server_url": server_url,
         "pulled_at": chrono::Utc::now().to_rfc3339(),
@@ -226,14 +322,6 @@ fn parse_command(raw: &str) -> Vec<String> {
 fn write_pretty_json(path: &Path, value: &serde_json::Value) -> Result<()> {
     std::fs::write(path, serde_json::to_string_pretty(value)?)
         .with_context(|| format!("Failed to write {}", path.display()))
-}
-
-fn hex_encode(bytes: &[u8]) -> String {
-    use std::fmt::Write;
-    bytes.iter().fold(String::new(), |mut out, b| {
-        let _ = write!(out, "{b:02x}");
-        out
-    })
 }
 
 #[cfg(test)]
@@ -263,18 +351,33 @@ mod tests {
     }
 
     #[test]
-    fn sanitize_rejects_escaping_paths() {
-        assert!(sanitize_relative_path("../evil.txt").is_err());
-        assert!(sanitize_relative_path("/etc/passwd").is_err());
-        assert!(sanitize_relative_path("a/../../evil.txt").is_err());
-        assert!(sanitize_relative_path("").is_err());
+    fn checked_run_relative_path_rejects_escaping_paths() {
+        assert!(checked_run_relative_path("../evil.txt").is_err());
+        assert!(checked_run_relative_path("/etc/passwd").is_err());
+        assert!(checked_run_relative_path("a/../../evil.txt").is_err());
+        assert!(checked_run_relative_path("").is_err());
     }
 
     #[test]
-    fn sanitize_accepts_nested_relative_paths() {
+    fn checked_run_relative_path_accepts_nested_relative_paths() {
         assert_eq!(
-            sanitize_relative_path("output/result.txt").unwrap(),
+            checked_run_relative_path("output/result.txt").unwrap(),
             PathBuf::from("output/result.txt")
         );
+    }
+
+    #[test]
+    fn ensure_single_path_component_accepts_plain_names() {
+        assert!(ensure_single_path_component("e2e-vault", "vault name").is_ok());
+        assert!(ensure_single_path_component("happy-river", "run name").is_ok());
+    }
+
+    #[test]
+    fn ensure_single_path_component_rejects_separators_and_traversal() {
+        assert!(ensure_single_path_component("a/b", "vault name").is_err());
+        assert!(ensure_single_path_component("..", "run name").is_err());
+        assert!(ensure_single_path_component("../evil", "run name").is_err());
+        assert!(ensure_single_path_component("/abs", "vault name").is_err());
+        assert!(ensure_single_path_component("", "vault name").is_err());
     }
 }

--- a/crates/capsula-orchestration/src/push.rs
+++ b/crates/capsula-orchestration/src/push.rs
@@ -11,6 +11,16 @@ pub fn push_single_run(
 ) -> Result<()> {
     let capsula_dir = run_dir.join("_capsula");
 
+    // Runs restored by `pull` are lossy reconstructions (see pull.rs);
+    // re-uploading one would degrade the server's copy of the run.
+    if capsula_dir.join("pulled.json").is_file() {
+        anyhow::bail!(
+            "Run at {} was pulled from a server (found _capsula/pulled.json); \
+             refusing to push a lossy reconstruction",
+            run_dir.display()
+        );
+    }
+
     // Read metadata
     let metadata = crate::vault::read_run_metadata_json(run_dir)?;
 

--- a/crates/capsula-orchestration/tests/pull.rs
+++ b/crates/capsula-orchestration/tests/pull.rs
@@ -1,0 +1,268 @@
+//! Integration tests for `pull_single_run` against a mocked Capsula server.
+#![cfg(test)]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "Tests use unwrap/expect for brevity"
+)]
+
+use capsula_core::run::run_dir_relative_path;
+use capsula_orchestration::pull::pull_single_run;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+use ulid::Ulid;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const RUN_ID: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
+const RUN_NAME: &str = "pulled-run";
+const VAULT: &str = "test-vault";
+const FILE_CONTENT: &[u8] = b"hello from capsula";
+
+fn sha256_hex(data: &[u8]) -> String {
+    use std::fmt::Write;
+    Sha256::digest(data)
+        .iter()
+        .fold(String::new(), |mut out, b| {
+            let _ = write!(out, "{b:02x}");
+            out
+        })
+}
+
+fn run_record() -> serde_json::Value {
+    json!({
+        "id": RUN_ID,
+        "name": RUN_NAME,
+        "timestamp": "2026-08-01T10:20:00Z",
+        "command": "[\"echo\",\"hello\"]",
+        "vault": VAULT,
+        "project_root": "/origin/project",
+        "exit_code": 0,
+        "duration_ms": 1234,
+        "stdout": "hello\n",
+        "stderr": "",
+        "created_at": "2026-08-01T10:20:01Z",
+        "updated_at": "2026-08-01T10:20:01Z"
+    })
+}
+
+fn detail_response(files: &serde_json::Value) -> serde_json::Value {
+    json!({
+        "status": "ok",
+        "run": run_record(),
+        "pre_run_hooks": [
+            {
+                "__meta": {
+                    "id": "capture-cwd",
+                    "config": {},
+                    "success": true,
+                    "error": null,
+                    "hook_index": 0
+                },
+                "cwd": "/origin/project"
+            }
+        ],
+        "post_run_hooks": [],
+        "files": files
+    })
+}
+
+/// Start a mock server (kept alive by the returned runtime) serving the
+/// given run-detail response and one downloadable file.
+///
+/// `encoded_file_path` is the percent-encoded URL form of the file path
+/// (wiremock matches the encoded request path; the real server decodes it).
+fn start_server(
+    detail: serde_json::Value,
+    encoded_file_path: Option<&str>,
+) -> (tokio::runtime::Runtime, MockServer) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let server = rt.block_on(async {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/api/v1/runs/{RUN_ID}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(detail))
+            .mount(&server)
+            .await;
+        if let Some(fp) = encoded_file_path {
+            Mock::given(method("GET"))
+                .and(path(format!("/api/v1/runs/{RUN_ID}/files/{fp}")))
+                .respond_with(ResponseTemplate::new(200).set_body_bytes(FILE_CONTENT.to_vec()))
+                .mount(&server)
+                .await;
+        }
+        server
+    });
+    (rt, server)
+}
+
+fn expected_run_dir(vault_dir: &Path) -> PathBuf {
+    let ulid = Ulid::from_string(RUN_ID).unwrap();
+    vault_dir.join(run_dir_relative_path(&ulid, RUN_NAME))
+}
+
+fn read_json(path: &Path) -> serde_json::Value {
+    serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap()
+}
+
+#[test]
+fn pull_restores_run_with_files_and_metadata() {
+    let files = json!([
+        {"path": "output/result.txt", "size": FILE_CONTENT.len(), "hash": sha256_hex(FILE_CONTENT)}
+    ]);
+    let (_rt, server) = start_server(detail_response(&files), Some("output/result%2Etxt"));
+    let client = capsula_client::CapsulaClient::new(server.uri());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let vault_dir = tmp.path().join(VAULT);
+
+    let run_dir = pull_single_run(RUN_ID, VAULT, &vault_dir, &client, false).unwrap();
+
+    assert_eq!(run_dir, expected_run_dir(&vault_dir));
+
+    // Captured file restored byte-exact
+    assert_eq!(
+        std::fs::read(run_dir.join("output/result.txt")).unwrap(),
+        FILE_CONTENT
+    );
+
+    // metadata.json reconstructed with the original field layout
+    let metadata = read_json(&run_dir.join("_capsula/metadata.json"));
+    assert_eq!(metadata["id"], RUN_ID);
+    assert_eq!(metadata["name"], RUN_NAME);
+    assert_eq!(metadata["command"], json!(["echo", "hello"]));
+    assert_eq!(metadata["run_dir"], run_dir.to_string_lossy().as_ref());
+    assert_eq!(metadata["project_root"], "/origin/project");
+
+    // Hook outputs restored; empty post-run phase produces no file
+    let pre_run = read_json(&run_dir.join("_capsula/pre-run.json"));
+    assert_eq!(pre_run[0]["__meta"]["id"], "capture-cwd");
+    assert_eq!(pre_run[0]["cwd"], "/origin/project");
+    assert!(!run_dir.join("_capsula/post-run.json").exists());
+
+    // command.json reconstructed from exit_code / duration_ms / stdout
+    let command = read_json(&run_dir.join("_capsula/command.json"));
+    assert_eq!(command["exit_code"], 0);
+    assert_eq!(command["stdout"], "hello\n");
+    assert_eq!(command["duration"]["secs"], 1);
+    assert_eq!(command["duration"]["nanos"], 234_000_000);
+
+    // Marker records the origin
+    let pulled = read_json(&run_dir.join("_capsula/pulled.json"));
+    assert_eq!(pulled["server_url"], server.uri());
+    assert!(pulled["pulled_at"].is_string());
+}
+
+#[test]
+fn pull_fails_on_hash_mismatch_without_leaving_partial_run() {
+    let files = json!([
+        {"path": "output/result.txt", "size": FILE_CONTENT.len(), "hash": sha256_hex(b"different content")}
+    ]);
+    let (_rt, server) = start_server(detail_response(&files), Some("output/result%2Etxt"));
+    let client = capsula_client::CapsulaClient::new(server.uri());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let vault_dir = tmp.path().join(VAULT);
+
+    let err = pull_single_run(RUN_ID, VAULT, &vault_dir, &client, false).unwrap_err();
+
+    assert!(err.to_string().contains("Hash mismatch"), "got: {err}");
+    assert!(!expected_run_dir(&vault_dir).exists());
+}
+
+#[test]
+fn pull_rejects_vault_mismatch() {
+    let (_rt, server) = start_server(detail_response(&json!([])), None);
+    let client = capsula_client::CapsulaClient::new(server.uri());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let vault_dir = tmp.path().join("other-vault");
+
+    let err = pull_single_run(RUN_ID, "other-vault", &vault_dir, &client, false).unwrap_err();
+
+    assert!(err.to_string().contains("belongs to vault"), "got: {err}");
+    assert!(!expected_run_dir(&vault_dir).exists());
+}
+
+#[test]
+fn pull_rejects_unsafe_file_paths() {
+    let files = json!([
+        {"path": "../evil.txt", "size": FILE_CONTENT.len(), "hash": sha256_hex(FILE_CONTENT)}
+    ]);
+    let (_rt, server) = start_server(detail_response(&files), None);
+    let client = capsula_client::CapsulaClient::new(server.uri());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let vault_dir = tmp.path().join(VAULT);
+
+    let err = pull_single_run(RUN_ID, VAULT, &vault_dir, &client, false).unwrap_err();
+
+    assert!(err.to_string().contains("unsafe path"), "got: {err}");
+    assert!(!tmp.path().join("evil.txt").exists());
+}
+
+#[test]
+fn pull_requires_force_to_replace_existing_run_dir() {
+    let (_rt, server) = start_server(detail_response(&json!([])), None);
+    let client = capsula_client::CapsulaClient::new(server.uri());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let vault_dir = tmp.path().join(VAULT);
+
+    let run_dir = expected_run_dir(&vault_dir);
+    std::fs::create_dir_all(&run_dir).unwrap();
+    std::fs::write(run_dir.join("stale.txt"), "old").unwrap();
+
+    let err = pull_single_run(RUN_ID, VAULT, &vault_dir, &client, false).unwrap_err();
+    assert!(err.to_string().contains("already exists"), "got: {err}");
+    assert!(run_dir.join("stale.txt").exists(), "must not touch the dir");
+
+    let pulled_dir = pull_single_run(RUN_ID, VAULT, &vault_dir, &client, true).unwrap();
+    assert_eq!(pulled_dir, run_dir);
+    assert!(!run_dir.join("stale.txt").exists(), "--force replaces");
+    assert!(run_dir.join("_capsula/metadata.json").exists());
+}
+
+#[test]
+fn pull_restores_file_with_url_significant_characters_in_name() {
+    // Spaces (and other URL-significant characters) are legal in captured
+    // file paths. The mock below is mounted at the percent-encoded path
+    // only: if the client sent such a path unencoded, the request would
+    // miss the mock entirely.
+    let files = json!([
+        {"path": "nested dir/file with space.txt", "size": FILE_CONTENT.len(), "hash": sha256_hex(FILE_CONTENT)}
+    ]);
+    let (_rt, server) = start_server(
+        detail_response(&files),
+        Some("nested%20dir/file%20with%20space%2Etxt"),
+    );
+    let client = capsula_client::CapsulaClient::new(server.uri());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let vault_dir = tmp.path().join(VAULT);
+
+    let run_dir = pull_single_run(RUN_ID, VAULT, &vault_dir, &client, false).unwrap();
+
+    assert_eq!(
+        std::fs::read(run_dir.join("nested dir/file with space.txt")).unwrap(),
+        FILE_CONTENT
+    );
+}
+
+#[test]
+fn pull_reports_run_not_found() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let server = rt.block_on(async {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/api/v1/runs/{RUN_ID}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "status": "not_found",
+                "error": format!("Run with id {RUN_ID} not found")
+            })))
+            .mount(&server)
+            .await;
+        server
+    });
+    let client = capsula_client::CapsulaClient::new(server.uri());
+    let tmp = tempfile::TempDir::new().unwrap();
+
+    let err = pull_single_run(RUN_ID, VAULT, &tmp.path().join(VAULT), &client, false).unwrap_err();
+
+    assert!(err.to_string().contains("not found"), "got: {err}");
+}

--- a/crates/capsula-orchestration/tests/pull.rs
+++ b/crates/capsula-orchestration/tests/pull.rs
@@ -7,7 +7,10 @@
 )]
 
 use capsula_core::run::run_dir_relative_path;
+use capsula_core::util::hex_encode;
 use capsula_orchestration::pull::pull_single_run;
+use capsula_orchestration::push::push_single_run;
+use capsula_orchestration::vault::{find_run_dir, list_runs};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
@@ -21,13 +24,7 @@ const VAULT: &str = "test-vault";
 const FILE_CONTENT: &[u8] = b"hello from capsula";
 
 fn sha256_hex(data: &[u8]) -> String {
-    use std::fmt::Write;
-    Sha256::digest(data)
-        .iter()
-        .fold(String::new(), |mut out, b| {
-            let _ = write!(out, "{b:02x}");
-            out
-        })
+    hex_encode(Sha256::digest(data).as_ref())
 }
 
 fn run_record() -> serde_json::Value {
@@ -48,9 +45,16 @@ fn run_record() -> serde_json::Value {
 }
 
 fn detail_response(files: &serde_json::Value) -> serde_json::Value {
+    detail_response_with_run(&run_record(), files)
+}
+
+fn detail_response_with_run(
+    run: &serde_json::Value,
+    files: &serde_json::Value,
+) -> serde_json::Value {
     json!({
         "status": "ok",
-        "run": run_record(),
+        "run": run,
         "pre_run_hooks": [
             {
                 "__meta": {
@@ -111,7 +115,7 @@ fn pull_restores_run_with_files_and_metadata() {
     let files = json!([
         {"path": "output/result.txt", "size": FILE_CONTENT.len(), "hash": sha256_hex(FILE_CONTENT)}
     ]);
-    let (_rt, server) = start_server(detail_response(&files), Some("output/result%2Etxt"));
+    let (_rt, server) = start_server(detail_response(&files), Some("output/result.txt"));
     let client = capsula_client::CapsulaClient::new(server.uri());
     let tmp = tempfile::TempDir::new().unwrap();
     let vault_dir = tmp.path().join(VAULT);
@@ -158,7 +162,7 @@ fn pull_fails_on_hash_mismatch_without_leaving_partial_run() {
     let files = json!([
         {"path": "output/result.txt", "size": FILE_CONTENT.len(), "hash": sha256_hex(b"different content")}
     ]);
-    let (_rt, server) = start_server(detail_response(&files), Some("output/result%2Etxt"));
+    let (_rt, server) = start_server(detail_response(&files), Some("output/result.txt"));
     let client = capsula_client::CapsulaClient::new(server.uri());
     let tmp = tempfile::TempDir::new().unwrap();
     let vault_dir = tmp.path().join(VAULT);
@@ -167,6 +171,42 @@ fn pull_fails_on_hash_mismatch_without_leaving_partial_run() {
 
     assert!(err.to_string().contains("Hash mismatch"), "got: {err}");
     assert!(!expected_run_dir(&vault_dir).exists());
+}
+
+#[test]
+fn pull_fails_on_size_mismatch() {
+    let files = json!([
+        {"path": "output/result.txt", "size": FILE_CONTENT.len() + 1, "hash": sha256_hex(FILE_CONTENT)}
+    ]);
+    let (_rt, server) = start_server(detail_response(&files), Some("output/result.txt"));
+    let client = capsula_client::CapsulaClient::new(server.uri());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let vault_dir = tmp.path().join(VAULT);
+
+    let err = pull_single_run(RUN_ID, VAULT, &vault_dir, &client, false).unwrap_err();
+
+    assert!(err.to_string().contains("Size mismatch"), "got: {err}");
+    assert!(!expected_run_dir(&vault_dir).exists());
+}
+
+#[test]
+fn pull_restores_file_without_recorded_hash() {
+    // Files without a stored hash are restored (with a warning) rather
+    // than rejected.
+    let files = json!([
+        {"path": "nohash.txt", "size": FILE_CONTENT.len(), "hash": null}
+    ]);
+    let (_rt, server) = start_server(detail_response(&files), Some("nohash.txt"));
+    let client = capsula_client::CapsulaClient::new(server.uri());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let vault_dir = tmp.path().join(VAULT);
+
+    let run_dir = pull_single_run(RUN_ID, VAULT, &vault_dir, &client, false).unwrap();
+
+    assert_eq!(
+        std::fs::read(run_dir.join("nohash.txt")).unwrap(),
+        FILE_CONTENT
+    );
 }
 
 #[test]
@@ -199,23 +239,177 @@ fn pull_rejects_unsafe_file_paths() {
 }
 
 #[test]
-fn pull_requires_force_to_replace_existing_run_dir() {
+fn pull_rejects_run_name_that_is_not_a_single_path_component() {
+    let mut run = run_record();
+    run["name"] = json!("../evil");
+    let (_rt, server) = start_server(detail_response_with_run(&run, &json!([])), None);
+    let client = capsula_client::CapsulaClient::new(server.uri());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let vault_dir = tmp.path().join(VAULT);
+
+    let err = pull_single_run(RUN_ID, VAULT, &vault_dir, &client, false).unwrap_err();
+
+    assert!(
+        err.to_string().contains("single path component"),
+        "got: {err}"
+    );
+    assert!(!tmp.path().join("evil").exists());
+}
+
+#[test]
+fn pull_rejects_run_names_as_argument() {
+    // A run *name* must fail fast with a specific message instead of a
+    // misleading server-side not_found.
+    let (_rt, server) = start_server(detail_response(&json!([])), None);
+    let client = capsula_client::CapsulaClient::new(server.uri());
+    let tmp = tempfile::TempDir::new().unwrap();
+
+    let err = pull_single_run(
+        "happy-river",
+        VAULT,
+        &tmp.path().join(VAULT),
+        &client,
+        false,
+    )
+    .unwrap_err();
+
+    assert!(err.to_string().contains("not a run ID"), "got: {err}");
+}
+
+#[test]
+fn pull_refuses_to_replace_locally_produced_run() {
+    let (_rt, server) = start_server(detail_response(&json!([])), None);
+    let client = capsula_client::CapsulaClient::new(server.uri());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let vault_dir = tmp.path().join(VAULT);
+
+    // A locally produced run: has _capsula but no pulled.json marker.
+    let run_dir = expected_run_dir(&vault_dir);
+    std::fs::create_dir_all(run_dir.join("_capsula")).unwrap();
+    std::fs::write(run_dir.join("_capsula/metadata.json"), "{}").unwrap();
+    std::fs::write(run_dir.join("stale.txt"), "authoritative").unwrap();
+
+    let err = pull_single_run(RUN_ID, VAULT, &vault_dir, &client, false).unwrap_err();
+    assert!(err.to_string().contains("locally produced"), "got: {err}");
+
+    // Even --force must not replace a locally produced run.
+    let err = pull_single_run(RUN_ID, VAULT, &vault_dir, &client, true).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("--force only replaces previously pulled runs"),
+        "got: {err}"
+    );
+    assert!(
+        run_dir.join("stale.txt").exists(),
+        "local run must be untouched"
+    );
+}
+
+#[test]
+fn pull_force_replaces_previously_pulled_run() {
+    let (_rt, server) = start_server(detail_response(&json!([])), None);
+    let client = capsula_client::CapsulaClient::new(server.uri());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let vault_dir = tmp.path().join(VAULT);
+
+    let run_dir = pull_single_run(RUN_ID, VAULT, &vault_dir, &client, false).unwrap();
+    std::fs::write(run_dir.join("extra.txt"), "local modification").unwrap();
+
+    let err = pull_single_run(RUN_ID, VAULT, &vault_dir, &client, false).unwrap_err();
+    assert!(err.to_string().contains("Use --force"), "got: {err}");
+    assert!(run_dir.join("extra.txt").exists());
+
+    let pulled_dir = pull_single_run(RUN_ID, VAULT, &vault_dir, &client, true).unwrap();
+    assert_eq!(pulled_dir, run_dir);
+    assert!(!run_dir.join("extra.txt").exists(), "--force replaces");
+    assert!(run_dir.join("_capsula/pulled.json").exists());
+}
+
+#[test]
+fn pull_force_refuses_when_target_is_a_file() {
     let (_rt, server) = start_server(detail_response(&json!([])), None);
     let client = capsula_client::CapsulaClient::new(server.uri());
     let tmp = tempfile::TempDir::new().unwrap();
     let vault_dir = tmp.path().join(VAULT);
 
     let run_dir = expected_run_dir(&vault_dir);
-    std::fs::create_dir_all(&run_dir).unwrap();
-    std::fs::write(run_dir.join("stale.txt"), "old").unwrap();
+    std::fs::create_dir_all(run_dir.parent().unwrap()).unwrap();
+    std::fs::write(&run_dir, "not a directory").unwrap();
 
-    let err = pull_single_run(RUN_ID, VAULT, &vault_dir, &client, false).unwrap_err();
-    assert!(err.to_string().contains("already exists"), "got: {err}");
-    assert!(run_dir.join("stale.txt").exists(), "must not touch the dir");
+    let err = pull_single_run(RUN_ID, VAULT, &vault_dir, &client, true).unwrap_err();
 
-    let pulled_dir = pull_single_run(RUN_ID, VAULT, &vault_dir, &client, true).unwrap();
-    assert_eq!(pulled_dir, run_dir);
-    assert!(!run_dir.join("stale.txt").exists(), "--force replaces");
+    assert!(
+        err.to_string()
+            .contains("--force only replaces previously pulled runs"),
+        "got: {err}"
+    );
+    assert!(run_dir.is_file(), "existing file must be untouched");
+}
+
+#[test]
+fn push_refuses_pulled_runs() {
+    let (_rt, server) = start_server(detail_response(&json!([])), None);
+    let client = capsula_client::CapsulaClient::new(server.uri());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let vault_dir = tmp.path().join(VAULT);
+
+    let run_dir = pull_single_run(RUN_ID, VAULT, &vault_dir, &client, false).unwrap();
+
+    // The guard fires before any network access, so an unreachable
+    // server URL proves it.
+    let offline = capsula_client::CapsulaClient::new("http://127.0.0.1:9");
+    let err = push_single_run(&run_dir, VAULT, "http://127.0.0.1:9", &offline).unwrap_err();
+
+    assert!(err.to_string().contains("refusing to push"), "got: {err}");
+}
+
+#[test]
+fn abandoned_temp_dir_is_invisible_to_vault_scanners() {
+    // Simulates a pull interrupted after the _capsula reconstruction:
+    // the temp directory lives directly under the vault root, one level
+    // above the `vault/*/*` depth the scanners walk.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let vault_dir = tmp.path().join(VAULT);
+    let stale = vault_dir.join(".pull-tmp-abandoned");
+    std::fs::create_dir_all(stale.join("_capsula")).unwrap();
+    std::fs::write(
+        stale.join("_capsula/metadata.json"),
+        json!({
+            "id": RUN_ID,
+            "name": "ghost",
+            "command": [],
+            "timestamp": "2026-08-01T10:20:00Z"
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    assert!(
+        list_runs(&vault_dir).unwrap().is_empty(),
+        "abandoned temp dir must not be listed as a run"
+    );
+    assert!(
+        find_run_dir(&vault_dir, RUN_ID).is_err(),
+        "abandoned temp dir must not resolve as a run"
+    );
+}
+
+#[test]
+fn run_without_exit_code_produces_no_command_json() {
+    // A run created by `run-start` and never finalized has no command
+    // result on the server; the restored run must not invent one.
+    let mut run = run_record();
+    run["exit_code"] = json!(null);
+    run["duration_ms"] = json!(null);
+    run["stdout"] = json!(null);
+    run["stderr"] = json!(null);
+    let (_rt, server) = start_server(detail_response_with_run(&run, &json!([])), None);
+    let client = capsula_client::CapsulaClient::new(server.uri());
+    let tmp = tempfile::TempDir::new().unwrap();
+
+    let run_dir = pull_single_run(RUN_ID, VAULT, &tmp.path().join(VAULT), &client, false).unwrap();
+
+    assert!(!run_dir.join("_capsula/command.json").exists());
     assert!(run_dir.join("_capsula/metadata.json").exists());
 }
 
@@ -230,7 +424,7 @@ fn pull_restores_file_with_url_significant_characters_in_name() {
     ]);
     let (_rt, server) = start_server(
         detail_response(&files),
-        Some("nested%20dir/file%20with%20space%2Etxt"),
+        Some("nested%20dir/file%20with%20space.txt"),
     );
     let client = capsula_client::CapsulaClient::new(server.uri());
     let tmp = tempfile::TempDir::new().unwrap();

--- a/crates/capsula-server/src/lib.rs
+++ b/crates/capsula-server/src/lib.rs
@@ -421,20 +421,7 @@ async fn run_detail_page(
     };
 
     // Fetch captured files
-    let files_result = sqlx::query_as!(
-        models::CapturedFile,
-        r#"
-        SELECT path, size, hash, storage_path, content_type
-        FROM captured_files
-        WHERE run_id = $1
-        ORDER BY path
-        "#,
-        id
-    )
-    .fetch_all(&state.pool)
-    .await;
-
-    let files = match files_result {
+    let files = match fetch_run_files(&state.pool, &id).await {
         Ok(files) => files,
         Err(e) => {
             error!("Failed to fetch captured files: {}", e);
@@ -823,10 +810,13 @@ async fn create_run(
     }
 }
 
-/// Fetch a run's captured files as JSON objects exposing only
-/// client-relevant fields (`storage_path` is a server-internal location).
-async fn fetch_run_files_json(pool: &PgPool, id: &str) -> Vec<serde_json::Value> {
-    let files_result = sqlx::query_as!(
+/// Fetch a run's captured files, ordered by path. Shared by the HTML
+/// run-detail page and the JSON run-detail endpoint.
+async fn fetch_run_files(
+    pool: &PgPool,
+    id: &str,
+) -> Result<Vec<models::CapturedFile>, sqlx::Error> {
+    sqlx::query_as!(
         models::CapturedFile,
         r#"
         SELECT path, size, hash, storage_path, content_type
@@ -837,24 +827,7 @@ async fn fetch_run_files_json(pool: &PgPool, id: &str) -> Vec<serde_json::Value>
         id
     )
     .fetch_all(pool)
-    .await;
-
-    match files_result {
-        Ok(files) => files
-            .into_iter()
-            .map(|f| {
-                json!({
-                    "path": f.path,
-                    "size": f.size,
-                    "hash": f.hash,
-                })
-            })
-            .collect(),
-        Err(e) => {
-            error!("Failed to fetch captured files: {}", e);
-            Vec::new()
-        }
-    }
+    .await
 }
 
 async fn get_run(State(state): State<AppState>, Path(id): Path<String>) -> impl IntoResponse {
@@ -919,7 +892,24 @@ async fn get_run(State(state): State<AppState>, Path(id): Path<String>) -> impl 
                 }
             };
 
-            let files = fetch_run_files_json(&state.pool, &id).await;
+            // Expose only client-relevant fields (storage_path is a
+            // server-internal location).
+            let files: Vec<serde_json::Value> = match fetch_run_files(&state.pool, &id).await {
+                Ok(files) => files
+                    .into_iter()
+                    .map(|f| {
+                        json!({
+                            "path": f.path,
+                            "size": f.size,
+                            "hash": f.hash,
+                        })
+                    })
+                    .collect(),
+                Err(e) => {
+                    error!("Failed to fetch captured files: {}", e);
+                    Vec::new()
+                }
+            };
 
             Json(json!({
                 "status": "ok",

--- a/crates/capsula-server/src/lib.rs
+++ b/crates/capsula-server/src/lib.rs
@@ -823,6 +823,40 @@ async fn create_run(
     }
 }
 
+/// Fetch a run's captured files as JSON objects exposing only
+/// client-relevant fields (`storage_path` is a server-internal location).
+async fn fetch_run_files_json(pool: &PgPool, id: &str) -> Vec<serde_json::Value> {
+    let files_result = sqlx::query_as!(
+        models::CapturedFile,
+        r#"
+        SELECT path, size, hash, storage_path, content_type
+        FROM captured_files
+        WHERE run_id = $1
+        ORDER BY path
+        "#,
+        id
+    )
+    .fetch_all(pool)
+    .await;
+
+    match files_result {
+        Ok(files) => files
+            .into_iter()
+            .map(|f| {
+                json!({
+                    "path": f.path,
+                    "size": f.size,
+                    "hash": f.hash,
+                })
+            })
+            .collect(),
+        Err(e) => {
+            error!("Failed to fetch captured files: {}", e);
+            Vec::new()
+        }
+    }
+}
+
 async fn get_run(State(state): State<AppState>, Path(id): Path<String>) -> impl IntoResponse {
     info!("Getting run: {}", id);
 
@@ -885,11 +919,14 @@ async fn get_run(State(state): State<AppState>, Path(id): Path<String>) -> impl 
                 }
             };
 
+            let files = fetch_run_files_json(&state.pool, &id).await;
+
             Json(json!({
                 "status": "ok",
                 "run": run,
                 "pre_run_hooks": pre_run_hooks,
-                "post_run_hooks": post_run_hooks
+                "post_run_hooks": post_run_hooks,
+                "files": files
             }))
         }
         Ok(None) => {

--- a/crates/capsula-server/tests/api_tests.rs
+++ b/crates/capsula-server/tests/api_tests.rs
@@ -398,6 +398,88 @@ async fn test_multiple_file_upload_with_storage() {
 }
 
 #[tokio::test]
+async fn get_run_response_includes_captured_files() {
+    let ctx = TestContext::new().await;
+    let client = reqwest::Client::new();
+
+    let run_id = "01RUNFILES1234567890ABCDE";
+    let run_data = json!({
+        "id": run_id,
+        "name": "test-run-files",
+        "timestamp": "2026-08-01T10:00:00Z",
+        "command": "echo files",
+        "vault": "test-vault",
+        "project_root": "/tmp/test",
+        "exit_code": 0,
+        "duration_ms": 100,
+        "stdout": null,
+        "stderr": null
+    });
+    let response = client
+        .post(format!("{}/api/v1/runs", ctx.base_url()))
+        .json(&run_data)
+        .send()
+        .await
+        .expect("Failed to create run");
+    assert_eq!(response.status(), 201);
+
+    let nested_content = b"nested file content";
+    let root_content = b"root file";
+    let form = reqwest::multipart::Form::new()
+        .text("run_id", run_id)
+        .text("path", "output/result.txt")
+        .part(
+            "file",
+            reqwest::multipart::Part::bytes(nested_content.to_vec())
+                .file_name("result.txt")
+                .mime_str("text/plain")
+                .expect("Failed to set MIME type"),
+        )
+        .text("path", "readme.md")
+        .part(
+            "file",
+            reqwest::multipart::Part::bytes(root_content.to_vec())
+                .file_name("readme.md")
+                .mime_str("text/markdown")
+                .expect("Failed to set MIME type"),
+        );
+    let response = client
+        .post(format!("{}/api/v1/upload", ctx.base_url()))
+        .multipart(form)
+        .send()
+        .await
+        .expect("Failed to upload files");
+    assert_eq!(response.status(), 200);
+
+    let response = client
+        .get(format!("{}/api/v1/runs/{run_id}", ctx.base_url()))
+        .send()
+        .await
+        .expect("Failed to get run");
+    assert_eq!(response.status(), 200);
+    let body: serde_json::Value = response.json().await.expect("Failed to parse JSON");
+
+    assert_eq!(body["status"], "ok");
+    let files = body["files"].as_array().expect("files should be an array");
+    assert_eq!(files.len(), 2, "files: {files:?}");
+
+    // Ordered by path; each entry exposes path/size/hash but not the
+    // server-internal storage location.
+    assert_eq!(files[0]["path"], "output/result.txt");
+    assert_eq!(files[0]["size"], nested_content.len() as u64);
+    assert_eq!(files[1]["path"], "readme.md");
+    assert_eq!(files[1]["size"], root_content.len() as u64);
+    for file in files {
+        let hash = file["hash"].as_str().expect("hash should be present");
+        assert_eq!(hash.len(), 64, "hash should be hex sha-256: {hash}");
+        assert!(
+            file.get("storage_path").is_none(),
+            "storage_path must not leak: {file:?}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn test_file_download() {
     let ctx = TestContext::new().await;
     let client = reqwest::Client::new();

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -203,6 +203,10 @@ capsula run-dir happy-river
 
 Push run data to a capsula server.
 
+Runs restored by [`capsula pull`](#capsula-pull) (marked with
+`_capsula/pulled.json`) are lossy reconstructions: a direct push of one is
+refused, and `push --all` skips them.
+
 ### Usage
 
 ```bash
@@ -235,17 +239,13 @@ capsula push happy-river --server https://capsula.example.com
 
 ## `capsula pull`
 
-Download a run from a capsula server and restore it under the local vault.
+Download a run from a capsula server and restore it to the local vault.
 
-The run directory is restored at `{YYYY-MM-DD}/{HHMMSS}-{name}` (derived
-from the run's ID and name, like locally created runs). Captured files are
-verified against the server-recorded SHA-256 hashes, and only files with
-relative paths that stay inside the run directory are restored — absolute
-paths and paths containing `..` are rejected as errors. The `_capsula`
-metadata files are reconstructed from the server's structured data —
-best-effort, not byte-identical to the originals — and a
-`_capsula/pulled.json` marker records the origin server and pull time so
-pulled runs can be told apart from locally produced ones.
+The run is restored at {YYYY-MM-DD}/{HHMMSS}-{name}, using the same layout as a locally created run. Downloaded files are verified against their recorded sizes and SHA-256 hashes. Absolute paths and paths containing .. are rejected.
+
+The _capsula metadata is reconstructed from the server's structured data. A _capsula/pulled.json marker records the source server and pull time.
+
+--force only replaces runs previously created by capsula pull, as identified by _capsula/pulled.json. Locally produced runs are never overwritten. Pulled runs cannot be uploaded again with capsula push.
 
 ### Usage
 
@@ -259,7 +259,7 @@ capsula pull <RUN_ID>
 | -------- | ------------- |
 | `--vault <NAME>` | Expected vault of the run (defaults to the vault in `capsula.toml`). The pull fails if the run belongs to a different vault. |
 | `--server <URL>` | Server URL (can also be set via `CAPSULA_SERVER_URL` env var or `server` field in `capsula.toml`) |
-| `--force` | Replace the local run directory if it already exists |
+| `--force` | Replace a previously pulled copy of the run if it already exists. Locally produced runs are never replaced. |
 
 ### Examples
 
@@ -273,6 +273,18 @@ capsula pull 01K8WSYC91YAE21R7CWHQ4KYN2 --vault other-vault
 # Pull from a specific server, replacing a previously pulled copy
 capsula pull 01K8WSYC91YAE21R7CWHQ4KYN2 --server https://capsula.example.com --force
 ```
+
+### Limitations
+
+A pulled run is a subset of the original local run. Data that was not uploaded by capsula push cannot be restored, including:
+
+- symlinks
+- empty directories
+- files added after the push
+- the original _capsula/*.json file contents
+- sub-millisecond command duration
+
+The reconstructed metadata may therefore differ from the original files. Phases with no hook outputs do not produce pre-run.json or post-run.json. Command strings stored by older server versions are normalized to JSON arrays.
 
 ## `capsula tui`
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -233,6 +233,47 @@ capsula push --all
 capsula push happy-river --server https://capsula.example.com
 ```
 
+## `capsula pull`
+
+Download a run from a capsula server and restore it under the local vault.
+
+The run directory is restored at `{YYYY-MM-DD}/{HHMMSS}-{name}` (derived
+from the run's ID and name, like locally created runs). Captured files are
+verified against the server-recorded SHA-256 hashes, and only files with
+relative paths that stay inside the run directory are restored — absolute
+paths and paths containing `..` are rejected as errors. The `_capsula`
+metadata files are reconstructed from the server's structured data —
+best-effort, not byte-identical to the originals — and a
+`_capsula/pulled.json` marker records the origin server and pull time so
+pulled runs can be told apart from locally produced ones.
+
+### Usage
+
+```bash
+capsula pull <RUN_ID>
+```
+
+### Options
+
+| Option | Description |
+| -------- | ------------- |
+| `--vault <NAME>` | Expected vault of the run (defaults to the vault in `capsula.toml`). The pull fails if the run belongs to a different vault. |
+| `--server <URL>` | Server URL (can also be set via `CAPSULA_SERVER_URL` env var or `server` field in `capsula.toml`) |
+| `--force` | Replace the local run directory if it already exists |
+
+### Examples
+
+```bash
+# Pull a run by ID
+capsula pull 01K8WSYC91YAE21R7CWHQ4KYN2
+
+# Pull a run that belongs to another vault
+capsula pull 01K8WSYC91YAE21R7CWHQ4KYN2 --vault other-vault
+
+# Pull from a specific server, replacing a previously pulled copy
+capsula pull 01K8WSYC91YAE21R7CWHQ4KYN2 --server https://capsula.example.com --force
+```
+
 ## `capsula tui`
 
 Launch an interactive terminal UI for starting and ending runs.


### PR DESCRIPTION
## Summary

Adds a `capsula pull` command that downloads a run from a Capsula server and restores it under the local `.capsula` directory, as the counterpart of `capsula push`. Implements the design decided in #1177.

Closes #1177.

```
capsula pull <RUN_ID> [--vault <NAME>] [--server <URL>] [--force]
```

### How it works

1. `GET /api/v1/runs/{id}` — extended in this PR to include a `files` array (`path`, `size`, `hash`; the server-internal `storage_path` is not exposed). The run's recorded vault is verified against `--vault` (default: the vault in `capsula.toml`).
2. The run directory is reconstructed deterministically at `{YYYY-MM-DD}/{HHMMSS}-{name}` from the run's ULID (UTC timestamp) and name — the naming logic is extracted from `Run::gen_run_dir` into the public `capsula_core::run::run_dir_relative_path`, so it cannot drift.
3. Captured files are downloaded one by one through the existing `GET /api/v1/runs/{id}/files/{*path}` endpoint and verified against the server-recorded SHA-256 hash; a mismatch fails the pull. Files without a stored hash are restored with a warning.
4. `_capsula/{metadata,pre-run,post-run,command}.json` are reconstructed from the server's structured data (best-effort as decided in #1177 — not byte-identical: JSON formatting differs and `duration` is restored at millisecond precision). A `_capsula/pulled.json` marker records the origin server URL and pull time, so pulled runs can be told apart from locally produced ones (e.g. by a future push-side guard).
5. Everything is downloaded into a temporary sibling directory and atomically renamed into place, so an interrupted pull never leaves a half-restored run. An existing run directory fails the pull unless `--force` is given, in which case it is replaced.

### Path containment scope

Restoring writes server-provided file paths to the local disk, so this PR includes a **minimal, syntactic containment check** (`sanitize_relative_path`): only relative paths that stay inside the run directory are restored — absolute paths and paths containing `..` (or any non-normal component) are rejected as errors. Within a pull, only regular files and directories are ever created, so symlink-based escapes cannot be introduced by the restore itself.

This intentionally stops short of full path-safety hardening. #1177 deferred sanitization entirely; this PR ships the cheap syntactic subset because writing unchecked server paths to disk is an obvious footgun. The full treatment should follow the approach of the in-flight path-safety PR stack (#1097 → #1098 → #1146 → #1147): once `ResolvedProjectPath` (#1098) and the containment semantics established for `capture-file` (#1146) land, the pull-side check should be migrated to that shared mechanism instead of growing its own.

### Other notes

- New client methods `CapsulaClient::{get_run, download_file, base_url}`. File paths are URL-encoded segment by segment with `NON_ALPHANUMERIC` (allowlist polarity — everything except `[0-9A-Za-z]` is percent-encoded, keeping `/` for the wildcard route), so no curated character list needs to be exhaustive. Spaces, URL-significant characters, and non-ASCII filenames all round-trip; server-side path normalization at upload time (e.g. `\` → `/`) is untouched, and pull restores exactly what the server recorded.
- Shared response types `RunRecord` / `RunDetailFile` / `RunDetailResponse` added to `capsula-api-types`, following the existing client/server type-sharing convention.
- The `files` addition to `GET /api/v1/runs/{id}` is additive and reuses the exact query already used by the run detail page (no new SQLx offline metadata needed).
- Runs pulled from a vault other than the configured one are placed in a sibling directory of the configured vault directory, named after their vault.
- Docs: `capsula pull` section added to the CLI reference, including the restore semantics and the path/hash verification behavior.

## Testing

- 7 wiremock-based integration tests for `pull_single_run`: successful restore (files, metadata, hooks, marker), hash mismatch leaves no partial run, vault mismatch, unsafe path rejection, existing directory / `--force` replacement, not-found handling, and a regression test for URL-significant characters in file paths (spaces) that pins the percent-encoded wire format; plus unit tests for command parsing, path sanitization, and URL path encoding.
- Server API test asserting `GET /api/v1/runs/{id}` returns `files` with `path`/`size`/`hash` and does not leak `storage_path`.
- `cargo test --workspace`, `cargo clippy --workspace --all-targets --all-features` / `--no-default-features`, `cargo fmt --check --all`, `cargo doc --workspace --no-deps` all clean.
- End-to-end against a real server + PostgreSQL: `capsula run` → `push` → delete local run → `pull` restored the captured files byte-identically at the exact original directory path, and the restored run works with `capsula list` / `show`; `--force` semantics verified live.

## AI assistance

- AI used: yes — implementation, tests, documentation, and this PR description were prepared with an AI coding agent (Claude Code) following the design decided in #1177
- Human review of AI-assisted code: complete

## Breaking changes

- [x] No breaking changes
- [ ] Breaking changes; the `breaking change` label is applied
